### PR TITLE
feat(US-3.2): Add properties dialog with color customization

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,3 +148,4 @@ tests/
 | Status | US | Description |
 |--------|-----|-------------|
 | ✅ | 3.1 | Add property objects (house, fence, path, etc.) |
+| ✅ | 3.2 | Set fill color for objects |

--- a/prd.md
+++ b/prd.md
@@ -601,7 +601,7 @@ open_garden_planner/
 | ID | User Story | Priority |
 |----|------------|----------|
 | ~~US-3.1~~ | ~~As a user, I can add property objects (house, fence, path, etc.)~~ | ✅ Must |
-| US-3.2 | As a user, I can set fill color for objects | Must |
+| ~~US-3.2~~ | ~~As a user, I can set fill color for objects~~ | ✅ Must |
 | US-3.3 | As a user, I can apply textures/patterns to objects | Must |
 | US-3.4 | As a user, I can set stroke style (color, width, dash pattern) | Should |
 | US-3.5 | As a user, I can add labels to objects displayed on canvas | Should |

--- a/src/open_garden_planner/ui/canvas/items/circle_item.py
+++ b/src/open_garden_planner/ui/canvas/items/circle_item.py
@@ -11,6 +11,38 @@ from open_garden_planner.core.object_types import ObjectType, get_style
 from .garden_item import GardenItemMixin
 
 
+def _show_properties_dialog(item: QGraphicsEllipseItem) -> None:
+    """Show properties dialog for an item (imported locally to avoid circular import)."""
+    from open_garden_planner.core.object_types import get_style
+    from open_garden_planner.ui.dialogs import PropertiesDialog
+
+    dialog = PropertiesDialog(item)
+    if dialog.exec():
+        # Apply name change
+        if hasattr(item, 'name'):
+            item.name = dialog.get_name()
+
+        # Apply object type change (updates styling)
+        new_object_type = dialog.get_object_type()
+        if new_object_type and hasattr(item, 'object_type'):
+            item.object_type = new_object_type
+            # Update to default styling for new type
+            style = get_style(new_object_type)
+            pen = item.pen()
+            pen.setColor(style.stroke_color)
+            pen.setWidthF(style.stroke_width)
+            item.setPen(pen)
+            brush = item.brush()
+            brush.setColor(style.fill_color)
+            item.setBrush(brush)
+
+        # Apply custom fill color (overrides type default)
+        fill_color = dialog.get_fill_color()
+        brush = item.brush()
+        brush.setColor(fill_color)
+        item.setBrush(brush)
+
+
 class CircleItem(GardenItemMixin, QGraphicsEllipseItem):
     """A circle shape on the garden canvas.
 
@@ -96,13 +128,14 @@ class CircleItem(GardenItemMixin, QGraphicsEllipseItem):
         duplicate_action.setEnabled(False)  # Placeholder
 
         properties_action = menu.addAction("Properties...")
-        properties_action.setEnabled(False)  # Placeholder
 
         # Execute menu and handle result
         action = menu.exec(event.screenPos())
 
         if action == delete_action:
             self.scene().removeItem(self)
+        elif action == properties_action:
+            _show_properties_dialog(self)
 
     def to_dict(self) -> dict:
         """Serialize the item to a dictionary for saving."""

--- a/src/open_garden_planner/ui/canvas/items/polygon_item.py
+++ b/src/open_garden_planner/ui/canvas/items/polygon_item.py
@@ -11,6 +11,38 @@ from open_garden_planner.core.object_types import ObjectType, get_style
 from .garden_item import GardenItemMixin
 
 
+def _show_properties_dialog(item: QGraphicsPolygonItem) -> None:
+    """Show properties dialog for an item (imported locally to avoid circular import)."""
+    from open_garden_planner.core.object_types import get_style
+    from open_garden_planner.ui.dialogs import PropertiesDialog
+
+    dialog = PropertiesDialog(item)
+    if dialog.exec():
+        # Apply name change
+        if hasattr(item, 'name'):
+            item.name = dialog.get_name()
+
+        # Apply object type change (updates styling)
+        new_object_type = dialog.get_object_type()
+        if new_object_type and hasattr(item, 'object_type'):
+            item.object_type = new_object_type
+            # Update to default styling for new type
+            style = get_style(new_object_type)
+            pen = item.pen()
+            pen.setColor(style.stroke_color)
+            pen.setWidthF(style.stroke_width)
+            item.setPen(pen)
+            brush = item.brush()
+            brush.setColor(style.fill_color)
+            item.setBrush(brush)
+
+        # Apply custom fill color (overrides type default)
+        fill_color = dialog.get_fill_color()
+        brush = item.brush()
+        brush.setColor(fill_color)
+        item.setBrush(brush)
+
+
 class PolygonItem(GardenItemMixin, QGraphicsPolygonItem):
     """A polygon shape on the garden canvas.
 
@@ -75,7 +107,6 @@ class PolygonItem(GardenItemMixin, QGraphicsPolygonItem):
         duplicate_action.setEnabled(False)  # Placeholder
 
         properties_action = menu.addAction("Properties...")
-        properties_action.setEnabled(False)  # Placeholder
 
         # Execute menu and handle result
         action = menu.exec(event.screenPos())
@@ -85,6 +116,8 @@ class PolygonItem(GardenItemMixin, QGraphicsPolygonItem):
             scene = self.scene()
             for item in scene.selectedItems():
                 scene.removeItem(item)
+        elif action == properties_action:
+            _show_properties_dialog(self)
 
     @classmethod
     def from_polygon(cls, polygon: QPolygonF) -> "PolygonItem":

--- a/src/open_garden_planner/ui/canvas/items/polyline_item.py
+++ b/src/open_garden_planner/ui/canvas/items/polyline_item.py
@@ -86,7 +86,6 @@ class PolylineItem(GardenItemMixin, QGraphicsPathItem):
         duplicate_action.setEnabled(False)
 
         properties_action = menu.addAction("Properties...")
-        properties_action.setEnabled(False)
 
         # Execute menu and handle result
         action = menu.exec(event.screenPos())
@@ -96,3 +95,10 @@ class PolylineItem(GardenItemMixin, QGraphicsPathItem):
             scene = self.scene()
             for item in scene.selectedItems():
                 scene.removeItem(item)
+        elif action == properties_action:
+            # Note: Polylines don't have fill, only stroke
+            from open_garden_planner.ui.dialogs import PropertiesDialog
+            dialog = PropertiesDialog(self)
+            if dialog.exec() and hasattr(self, 'name'):
+                # Apply changes
+                self.name = dialog.get_name()

--- a/src/open_garden_planner/ui/dialogs/__init__.py
+++ b/src/open_garden_planner/ui/dialogs/__init__.py
@@ -2,5 +2,6 @@
 
 from open_garden_planner.ui.dialogs.calibration_dialog import CalibrationDialog
 from open_garden_planner.ui.dialogs.new_project_dialog import NewProjectDialog
+from open_garden_planner.ui.dialogs.properties_dialog import PropertiesDialog
 
-__all__ = ["CalibrationDialog", "NewProjectDialog"]
+__all__ = ["CalibrationDialog", "NewProjectDialog", "PropertiesDialog"]


### PR DESCRIPTION
## Summary
- Added PropertiesDialog for editing object properties with full RGBA color picker
- Enabled changing object type after creation via dropdown
- Implemented color persistence with alpha channel across save/load
- Fixed color dialog background inheritance issue

## Technical Details
- Created `PropertiesDialog` with ColorButton widget for color selection
- Used `QColor.NameFormat.HexArgb` for color serialization to preserve alpha
- Fixed color dialog background by creating QColorDialog with no parent
- Object type dropdown allows reassigning types (e.g., circle → pool)
- Integrated properties dialog with context menu for all item types

## Changes
- New file: `src/open_garden_planner/ui/dialogs/properties_dialog.py`
- Updated: All item files (rectangle, polygon, circle) with properties dialog integration
- Updated: `project.py` serialization to save/load colors with alpha channel
- Updated: Progress tracking in CLAUDE.md and prd.md

## Test Plan
- [x] Draw shapes and verify color picker opens with full RGBA controls
- [x] Change fill color and verify it applies immediately
- [x] Save project and reload, verify custom colors persist
- [x] Change object type via dropdown and verify styling updates
- [x] Verify color dialog has normal window background (not object color)
- [x] Test alpha/opacity adjustments in color picker

🤖 Generated with [Claude Code](https://claude.com/claude-code)