### PR TITLE
feat(US-3.4): Add stroke style customization for objects

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,3 +150,4 @@ tests/
 | ✅ | 3.1 | Add property objects (house, fence, path, etc.) |
 | ✅ | 3.2 | Set fill color for objects |
 | ✅ | 3.3 | Apply textures/patterns to objects |
+| ✅ | 3.4 | Set stroke style (color, width, dash pattern) |

--- a/prd.md
+++ b/prd.md
@@ -603,7 +603,7 @@ open_garden_planner/
 | ~~US-3.1~~ | ~~As a user, I can add property objects (house, fence, path, etc.)~~ | ✅ Must |
 | ~~US-3.2~~ | ~~As a user, I can set fill color for objects~~ | ✅ Must |
 | ~~US-3.3~~ | ~~As a user, I can apply textures/patterns to objects~~ | ✅ Must |
-| US-3.4 | As a user, I can set stroke style (color, width, dash pattern) | Should |
+| ~~US-3.4~~ | ~~As a user, I can set stroke style (color, width, dash pattern)~~ | ✅ Should |
 | US-3.5 | As a user, I can add labels to objects displayed on canvas | Should |
 | US-3.6 | As a user, I can organize objects into layers | Must |
 | US-3.7 | As a user, I can show/hide and lock layers | Must |

--- a/src/open_garden_planner/core/object_types.py
+++ b/src/open_garden_planner/core/object_types.py
@@ -3,9 +3,33 @@
 from dataclasses import dataclass
 from enum import Enum, auto
 
+from PyQt6.QtCore import Qt
 from PyQt6.QtGui import QColor
 
 from .fill_patterns import FillPattern
+
+
+class StrokeStyle(Enum):
+    """Stroke/line styles for object outlines."""
+
+    SOLID = auto()
+    DASHED = auto()
+    DOTTED = auto()
+    DASH_DOT = auto()
+
+    def to_qt_pen_style(self) -> Qt.PenStyle:
+        """Convert to Qt pen style.
+
+        Returns:
+            Corresponding Qt.PenStyle enum value
+        """
+        mapping = {
+            StrokeStyle.SOLID: Qt.PenStyle.SolidLine,
+            StrokeStyle.DASHED: Qt.PenStyle.DashLine,
+            StrokeStyle.DOTTED: Qt.PenStyle.DotLine,
+            StrokeStyle.DASH_DOT: Qt.PenStyle.DashDotLine,
+        }
+        return mapping[self]
 
 
 class ObjectType(Enum):
@@ -39,6 +63,7 @@ class ObjectStyle:
     stroke_width: float
     display_name: str
     fill_pattern: FillPattern = FillPattern.SOLID
+    stroke_style: StrokeStyle = StrokeStyle.SOLID
 
 
 # Default styles for each object type

--- a/src/open_garden_planner/core/project.py
+++ b/src/open_garden_planner/core/project.py
@@ -14,6 +14,7 @@ from PyQt6.QtGui import QColor
 from PyQt6.QtWidgets import QGraphicsItem, QGraphicsScene
 
 from open_garden_planner.core.fill_patterns import FillPattern, create_pattern_brush
+from open_garden_planner.core.object_types import StrokeStyle
 
 # File format version for backward compatibility
 FILE_VERSION = "1.0"
@@ -195,6 +196,9 @@ class ProjectManager(QObject):
             # Save fill pattern
             if hasattr(item, "fill_pattern") and item.fill_pattern:
                 data["fill_pattern"] = item.fill_pattern.name
+            # Save stroke style
+            if hasattr(item, "stroke_style") and item.stroke_style:
+                data["stroke_style"] = item.stroke_style.name
             return data
         elif isinstance(item, CircleItem):
             data = {
@@ -222,6 +226,9 @@ class ProjectManager(QObject):
             # Save fill pattern
             if hasattr(item, "fill_pattern") and item.fill_pattern:
                 data["fill_pattern"] = item.fill_pattern.name
+            # Save stroke style
+            if hasattr(item, "stroke_style") and item.stroke_style:
+                data["stroke_style"] = item.stroke_style.name
             return data
         elif isinstance(item, PolylineItem):
             data = {
@@ -271,6 +278,9 @@ class ProjectManager(QObject):
             # Save fill pattern
             if hasattr(item, "fill_pattern") and item.fill_pattern:
                 data["fill_pattern"] = item.fill_pattern.name
+            # Save stroke style
+            if hasattr(item, "stroke_style") and item.stroke_style:
+                data["stroke_style"] = item.stroke_style.name
             return data
         return None
 
@@ -335,6 +345,13 @@ class ProjectManager(QObject):
             except KeyError:
                 fill_pattern = None
 
+        stroke_style = None
+        if "stroke_style" in obj:
+            try:
+                stroke_style = StrokeStyle[obj["stroke_style"]]
+            except KeyError:
+                stroke_style = None
+
         if obj_type == "background_image":
             try:
                 return BackgroundImageItem.from_dict(obj)
@@ -351,6 +368,7 @@ class ProjectManager(QObject):
                 name=name,
                 metadata=metadata,
                 fill_pattern=fill_pattern,
+                stroke_style=stroke_style,
             )
             # Restore custom colors if saved
             if "fill_color" in obj:
@@ -366,6 +384,8 @@ class ProjectManager(QObject):
                 pen.setColor(QColor(obj["stroke_color"]))
                 if "stroke_width" in obj:
                     pen.setWidthF(obj["stroke_width"])
+                if stroke_style:
+                    pen.setStyle(stroke_style.to_qt_pen_style())
                 item.setPen(pen)
             return item
         elif obj_type == "circle":
@@ -377,6 +397,7 @@ class ProjectManager(QObject):
                 name=name,
                 metadata=metadata,
                 fill_pattern=fill_pattern,
+                stroke_style=stroke_style,
             )
             # Restore custom colors if saved
             if "fill_color" in obj:
@@ -396,6 +417,8 @@ class ProjectManager(QObject):
                 pen.setColor(QColor(obj["stroke_color"]))
                 if "stroke_width" in obj:
                     pen.setWidthF(obj["stroke_width"])
+                if stroke_style:
+                    pen.setStyle(stroke_style.to_qt_pen_style())
                 item.setPen(pen)
             return item
         elif obj_type == "polyline":
@@ -423,6 +446,7 @@ class ProjectManager(QObject):
                     name=name,
                     metadata=metadata,
                     fill_pattern=fill_pattern,
+                    stroke_style=stroke_style,
                 )
                 # Restore custom colors if saved
                 if "fill_color" in obj:
@@ -442,6 +466,8 @@ class ProjectManager(QObject):
                     pen.setColor(QColor(obj["stroke_color"]))
                     if "stroke_width" in obj:
                         pen.setWidthF(obj["stroke_width"])
+                    if stroke_style:
+                        pen.setStyle(stroke_style.to_qt_pen_style())
                     item.setPen(pen)
                 return item
         return None

--- a/src/open_garden_planner/core/tools/circle_tool.py
+++ b/src/open_garden_planner/core/tools/circle_tool.py
@@ -25,7 +25,7 @@ class CircleTool(BaseTool):
 
     tool_type = ToolType.CIRCLE
     display_name = "Circle"
-    shortcut = ""  # Will be set by specific instances
+    shortcut = "C"
     cursor = Qt.CursorShape.CrossCursor
 
     def __init__(

--- a/src/open_garden_planner/core/tools/polygon_tool.py
+++ b/src/open_garden_planner/core/tools/polygon_tool.py
@@ -26,7 +26,7 @@ class PolygonTool(BaseTool):
 
     tool_type = ToolType.POLYGON
     display_name = "Polygon"
-    shortcut = ""  # Will be set by specific instances
+    shortcut = "P"
     cursor = Qt.CursorShape.CrossCursor
 
     CLOSE_THRESHOLD = 15.0  # Scene units (cm) for closing detection

--- a/src/open_garden_planner/core/tools/rectangle_tool.py
+++ b/src/open_garden_planner/core/tools/rectangle_tool.py
@@ -25,7 +25,7 @@ class RectangleTool(BaseTool):
 
     tool_type = ToolType.RECTANGLE
     display_name = "Rectangle"
-    shortcut = ""  # Will be set by specific instances
+    shortcut = "R"
     cursor = Qt.CursorShape.CrossCursor
 
     def __init__(

--- a/src/open_garden_planner/ui/canvas/items/garden_item.py
+++ b/src/open_garden_planner/ui/canvas/items/garden_item.py
@@ -4,7 +4,7 @@ import uuid
 from typing import Any
 
 from open_garden_planner.core.fill_patterns import FillPattern
-from open_garden_planner.core.object_types import ObjectType
+from open_garden_planner.core.object_types import ObjectType, StrokeStyle
 
 
 class GardenItemMixin:
@@ -24,6 +24,9 @@ class GardenItemMixin:
         metadata: dict[str, Any] | None = None,
         fill_pattern: FillPattern | None = None,
         fill_color: Any = None,  # QColor, but avoiding import
+        stroke_color: Any = None,  # QColor, but avoiding import
+        stroke_width: float | None = None,
+        stroke_style: StrokeStyle | None = None,
     ) -> None:
         """Initialize the garden item mixin.
 
@@ -33,6 +36,9 @@ class GardenItemMixin:
             metadata: Optional metadata dictionary
             fill_pattern: Fill pattern (optional, defaults to pattern from object type)
             fill_color: Base fill color (optional, used with patterns)
+            stroke_color: Stroke/outline color (optional)
+            stroke_width: Stroke/outline width (optional)
+            stroke_style: Stroke/outline style (optional)
         """
         self._item_id = uuid.uuid4()
         self._object_type = object_type
@@ -40,6 +46,9 @@ class GardenItemMixin:
         self._metadata = metadata or {}
         self._fill_pattern = fill_pattern
         self._fill_color = fill_color  # Store base color for serialization
+        self._stroke_color = stroke_color
+        self._stroke_width = stroke_width
+        self._stroke_style = stroke_style
 
     @property
     def item_id(self) -> uuid.UUID:
@@ -95,6 +104,36 @@ class GardenItemMixin:
     def fill_color(self, value: Any) -> None:  # QColor, but avoiding import
         """Set the base fill color."""
         self._fill_color = value
+
+    @property
+    def stroke_color(self) -> Any | None:  # QColor, but avoiding import
+        """Stroke/outline color for this item."""
+        return self._stroke_color
+
+    @stroke_color.setter
+    def stroke_color(self, value: Any) -> None:  # QColor, but avoiding import
+        """Set the stroke/outline color."""
+        self._stroke_color = value
+
+    @property
+    def stroke_width(self) -> float | None:
+        """Stroke/outline width for this item."""
+        return self._stroke_width
+
+    @stroke_width.setter
+    def stroke_width(self, value: float) -> None:
+        """Set the stroke/outline width."""
+        self._stroke_width = value
+
+    @property
+    def stroke_style(self) -> StrokeStyle | None:
+        """Stroke/outline style for this item."""
+        return self._stroke_style
+
+    @stroke_style.setter
+    def stroke_style(self, value: StrokeStyle | None) -> None:
+        """Set the stroke/outline style."""
+        self._stroke_style = value
 
     def set_metadata(self, key: str, value: Any) -> None:
         """Set a metadata value.

--- a/src/open_garden_planner/ui/canvas/items/polygon_item.py
+++ b/src/open_garden_planner/ui/canvas/items/polygon_item.py
@@ -7,7 +7,7 @@ from PyQt6.QtGui import QPen, QPolygonF
 from PyQt6.QtWidgets import QGraphicsPolygonItem, QGraphicsSceneContextMenuEvent, QMenu
 
 from open_garden_planner.core.fill_patterns import FillPattern, create_pattern_brush
-from open_garden_planner.core.object_types import ObjectType, get_style
+from open_garden_planner.core.object_types import ObjectType, StrokeStyle, get_style
 
 from .garden_item import GardenItemMixin
 
@@ -32,6 +32,7 @@ def _show_properties_dialog(item: QGraphicsPolygonItem) -> None:
             pen = item.pen()
             pen.setColor(style.stroke_color)
             pen.setWidthF(style.stroke_width)
+            pen.setStyle(style.stroke_style.to_qt_pen_style())
             item.setPen(pen)
             # Apply pattern brush and store pattern
             if hasattr(item, 'fill_pattern'):
@@ -50,6 +51,23 @@ def _show_properties_dialog(item: QGraphicsPolygonItem) -> None:
         brush = create_pattern_brush(fill_pattern, fill_color)
         item.setBrush(brush)
 
+        # Apply custom stroke properties (overrides type default)
+        stroke_color = dialog.get_stroke_color()
+        stroke_width = dialog.get_stroke_width()
+        stroke_style = dialog.get_stroke_style()
+        # Store stroke properties
+        if hasattr(item, 'stroke_color'):
+            item.stroke_color = stroke_color
+        if hasattr(item, 'stroke_width'):
+            item.stroke_width = stroke_width
+        if hasattr(item, 'stroke_style'):
+            item.stroke_style = stroke_style
+        pen = item.pen()
+        pen.setColor(stroke_color)
+        pen.setWidthF(stroke_width)
+        pen.setStyle(stroke_style.to_qt_pen_style())
+        item.setPen(pen)
+
 
 class PolygonItem(GardenItemMixin, QGraphicsPolygonItem):
     """A polygon shape on the garden canvas.
@@ -65,6 +83,7 @@ class PolygonItem(GardenItemMixin, QGraphicsPolygonItem):
         name: str = "",
         metadata: dict[str, Any] | None = None,
         fill_pattern: FillPattern | None = None,
+        stroke_style: StrokeStyle | None = None,
     ) -> None:
         """Initialize the polygon item.
 
@@ -74,15 +93,20 @@ class PolygonItem(GardenItemMixin, QGraphicsPolygonItem):
             name: Optional name/label for the object
             metadata: Optional metadata dictionary
             fill_pattern: Fill pattern (defaults to pattern from object type)
+            stroke_style: Stroke style (defaults to style from object type)
         """
         # Get default pattern and color from object type if not provided
         style = get_style(object_type)
         if fill_pattern is None:
             fill_pattern = style.fill_pattern
+        if stroke_style is None:
+            stroke_style = style.stroke_style
 
         GardenItemMixin.__init__(
             self, object_type=object_type, name=name, metadata=metadata,
-            fill_pattern=fill_pattern, fill_color=style.fill_color
+            fill_pattern=fill_pattern, fill_color=style.fill_color,
+            stroke_color=style.stroke_color, stroke_width=style.stroke_width,
+            stroke_style=stroke_style
         )
         polygon = QPolygonF(vertices)
         QGraphicsPolygonItem.__init__(self, polygon)
@@ -94,8 +118,14 @@ class PolygonItem(GardenItemMixin, QGraphicsPolygonItem):
         """Configure visual appearance based on object type."""
         style = get_style(self.object_type) if self.object_type else get_style(ObjectType.GENERIC_POLYGON)
 
-        pen = QPen(style.stroke_color)
-        pen.setWidthF(style.stroke_width)
+        # Use stored stroke properties if available, otherwise use style defaults
+        stroke_color = self.stroke_color if self.stroke_color is not None else style.stroke_color
+        stroke_width = self.stroke_width if self.stroke_width is not None else style.stroke_width
+        stroke_style = self.stroke_style if self.stroke_style is not None else style.stroke_style
+
+        pen = QPen(stroke_color)
+        pen.setWidthF(stroke_width)
+        pen.setStyle(stroke_style.to_qt_pen_style())
         self.setPen(pen)
 
         # Use stored fill_pattern and color if available, otherwise use style defaults

--- a/src/open_garden_planner/ui/canvas/items/rectangle_item.py
+++ b/src/open_garden_planner/ui/canvas/items/rectangle_item.py
@@ -7,7 +7,7 @@ from PyQt6.QtGui import QPen
 from PyQt6.QtWidgets import QGraphicsRectItem, QGraphicsSceneContextMenuEvent, QMenu
 
 from open_garden_planner.core.fill_patterns import FillPattern, create_pattern_brush
-from open_garden_planner.core.object_types import ObjectType, get_style
+from open_garden_planner.core.object_types import ObjectType, StrokeStyle, get_style
 
 from .garden_item import GardenItemMixin
 
@@ -32,6 +32,7 @@ def _show_properties_dialog(item: QGraphicsRectItem) -> None:
             pen = item.pen()
             pen.setColor(style.stroke_color)
             pen.setWidthF(style.stroke_width)
+            pen.setStyle(style.stroke_style.to_qt_pen_style())
             item.setPen(pen)
             # Apply pattern brush and store pattern
             if hasattr(item, 'fill_pattern'):
@@ -49,6 +50,23 @@ def _show_properties_dialog(item: QGraphicsRectItem) -> None:
             item.fill_color = fill_color
         brush = create_pattern_brush(fill_pattern, fill_color)
         item.setBrush(brush)
+
+        # Apply custom stroke properties (overrides type default)
+        stroke_color = dialog.get_stroke_color()
+        stroke_width = dialog.get_stroke_width()
+        stroke_style = dialog.get_stroke_style()
+        # Store stroke properties
+        if hasattr(item, 'stroke_color'):
+            item.stroke_color = stroke_color
+        if hasattr(item, 'stroke_width'):
+            item.stroke_width = stroke_width
+        if hasattr(item, 'stroke_style'):
+            item.stroke_style = stroke_style
+        pen = item.pen()
+        pen.setColor(stroke_color)
+        pen.setWidthF(stroke_width)
+        pen.setStyle(stroke_style.to_qt_pen_style())
+        item.setPen(pen)
 
 
 class RectangleItem(GardenItemMixin, QGraphicsRectItem):
@@ -68,6 +86,7 @@ class RectangleItem(GardenItemMixin, QGraphicsRectItem):
         name: str = "",
         metadata: dict[str, Any] | None = None,
         fill_pattern: FillPattern | None = None,
+        stroke_style: StrokeStyle | None = None,
     ) -> None:
         """Initialize the rectangle item.
 
@@ -80,15 +99,20 @@ class RectangleItem(GardenItemMixin, QGraphicsRectItem):
             name: Optional name/label for the object
             metadata: Optional metadata dictionary
             fill_pattern: Fill pattern (defaults to pattern from object type)
+            stroke_style: Stroke style (defaults to style from object type)
         """
         # Get default pattern and color from object type if not provided
         style = get_style(object_type)
         if fill_pattern is None:
             fill_pattern = style.fill_pattern
+        if stroke_style is None:
+            stroke_style = style.stroke_style
 
         GardenItemMixin.__init__(
             self, object_type=object_type, name=name, metadata=metadata,
-            fill_pattern=fill_pattern, fill_color=style.fill_color
+            fill_pattern=fill_pattern, fill_color=style.fill_color,
+            stroke_color=style.stroke_color, stroke_width=style.stroke_width,
+            stroke_style=stroke_style
         )
         QGraphicsRectItem.__init__(self, x, y, width, height)
 
@@ -99,8 +123,14 @@ class RectangleItem(GardenItemMixin, QGraphicsRectItem):
         """Configure visual appearance based on object type."""
         style = get_style(self.object_type) if self.object_type else get_style(ObjectType.GENERIC_RECTANGLE)
 
-        pen = QPen(style.stroke_color)
-        pen.setWidthF(style.stroke_width)
+        # Use stored stroke properties if available, otherwise use style defaults
+        stroke_color = self.stroke_color if self.stroke_color is not None else style.stroke_color
+        stroke_width = self.stroke_width if self.stroke_width is not None else style.stroke_width
+        stroke_style = self.stroke_style if self.stroke_style is not None else style.stroke_style
+
+        pen = QPen(stroke_color)
+        pen.setWidthF(stroke_width)
+        pen.setStyle(stroke_style.to_qt_pen_style())
         self.setPen(pen)
 
         # Use stored fill_pattern and color if available, otherwise use style defaults

--- a/src/open_garden_planner/ui/widgets/toolbar.py
+++ b/src/open_garden_planner/ui/widgets/toolbar.py
@@ -61,8 +61,8 @@ class MainToolbar(QToolBar):
         self._add_tool_button(
             ToolType.POLYGON,
             "Polygon",
-            "Draw polygon (G)\nClick to add vertices, double-click to close",
-            "G",
+            "Draw polygon (P)\nClick to add vertices, double-click to close",
+            "P",
         )
 
         self._add_tool_button(

--- a/tests/unit/test_stroke_styles.py
+++ b/tests/unit/test_stroke_styles.py
@@ -1,0 +1,111 @@
+"""Tests for stroke style functionality."""
+
+import pytest
+from PyQt6.QtCore import Qt
+from PyQt6.QtGui import QColor
+
+from open_garden_planner.core.object_types import ObjectType, StrokeStyle, get_style
+from open_garden_planner.ui.canvas.items import CircleItem, PolygonItem, RectangleItem
+
+
+class TestStrokeStyle:
+    """Test the StrokeStyle enum."""
+
+    def test_stroke_style_exists(self):
+        """Test that StrokeStyle enum has expected values."""
+        assert hasattr(StrokeStyle, "SOLID")
+        assert hasattr(StrokeStyle, "DASHED")
+        assert hasattr(StrokeStyle, "DOTTED")
+        assert hasattr(StrokeStyle, "DASH_DOT")
+
+    def test_to_qt_pen_style(self):
+        """Test conversion to Qt pen style."""
+        assert StrokeStyle.SOLID.to_qt_pen_style() == Qt.PenStyle.SolidLine
+        assert StrokeStyle.DASHED.to_qt_pen_style() == Qt.PenStyle.DashLine
+        assert StrokeStyle.DOTTED.to_qt_pen_style() == Qt.PenStyle.DotLine
+        assert StrokeStyle.DASH_DOT.to_qt_pen_style() == Qt.PenStyle.DashDotLine
+
+
+class TestObjectStyleWithStroke:
+    """Test ObjectStyle includes stroke style."""
+
+    def test_object_style_has_stroke_style(self):
+        """Test that ObjectStyle has stroke_style field."""
+        style = get_style(ObjectType.HOUSE)
+        assert hasattr(style, "stroke_style")
+        assert isinstance(style.stroke_style, StrokeStyle)
+
+    def test_default_stroke_style_is_solid(self):
+        """Test that default stroke style is SOLID."""
+        for obj_type in ObjectType:
+            style = get_style(obj_type)
+            assert style.stroke_style == StrokeStyle.SOLID
+
+
+class TestRectangleItemStroke:
+    """Test RectangleItem stroke customization."""
+
+    def test_default_stroke_style(self, qtbot):  # noqa: ARG002
+        """Test rectangle has default solid stroke."""
+        item = RectangleItem(0, 0, 100, 100)
+        assert item.stroke_style == StrokeStyle.SOLID
+        assert item.pen().style() == Qt.PenStyle.SolidLine
+
+    def test_custom_stroke_style(self, qtbot):  # noqa: ARG002
+        """Test rectangle can have custom stroke style."""
+        item = RectangleItem(0, 0, 100, 100, stroke_style=StrokeStyle.DASHED)
+        assert item.stroke_style == StrokeStyle.DASHED
+        assert item.pen().style() == Qt.PenStyle.DashLine
+
+    def test_stroke_color_customization(self, qtbot):  # noqa: ARG002
+        """Test rectangle stroke color can be customized."""
+        item = RectangleItem(0, 0, 100, 100)
+        red = QColor(255, 0, 0)
+        item.stroke_color = red
+        item._setup_styling()  # Re-apply styling
+        assert item.pen().color() == red
+
+    def test_stroke_width_customization(self, qtbot):  # noqa: ARG002
+        """Test rectangle stroke width can be customized."""
+        item = RectangleItem(0, 0, 100, 100)
+        item.stroke_width = 5.0
+        item._setup_styling()  # Re-apply styling
+        assert item.pen().widthF() == 5.0
+
+
+class TestPolygonItemStroke:
+    """Test PolygonItem stroke customization."""
+
+    def test_default_stroke_style(self, qtbot):  # noqa: ARG002
+        """Test polygon has default solid stroke."""
+        from PyQt6.QtCore import QPointF
+
+        points = [QPointF(0, 0), QPointF(100, 0), QPointF(50, 100)]
+        item = PolygonItem(points)
+        assert item.stroke_style == StrokeStyle.SOLID
+        assert item.pen().style() == Qt.PenStyle.SolidLine
+
+    def test_custom_stroke_style(self, qtbot):  # noqa: ARG002
+        """Test polygon can have custom stroke style."""
+        from PyQt6.QtCore import QPointF
+
+        points = [QPointF(0, 0), QPointF(100, 0), QPointF(50, 100)]
+        item = PolygonItem(points, stroke_style=StrokeStyle.DOTTED)
+        assert item.stroke_style == StrokeStyle.DOTTED
+        assert item.pen().style() == Qt.PenStyle.DotLine
+
+
+class TestCircleItemStroke:
+    """Test CircleItem stroke customization."""
+
+    def test_default_stroke_style(self, qtbot):  # noqa: ARG002
+        """Test circle has default solid stroke."""
+        item = CircleItem(50, 50, 25)
+        assert item.stroke_style == StrokeStyle.SOLID
+        assert item.pen().style() == Qt.PenStyle.SolidLine
+
+    def test_custom_stroke_style(self, qtbot):  # noqa: ARG002
+        """Test circle can have custom stroke style."""
+        item = CircleItem(50, 50, 25, stroke_style=StrokeStyle.DASH_DOT)
+        assert item.stroke_style == StrokeStyle.DASH_DOT
+        assert item.pen().style() == Qt.PenStyle.DashDotLine


### PR DESCRIPTION
## Summary
- Added StrokeStyle enum with four options: SOLID, DASHED, DOTTED, DASH_DOT
- Implemented stroke color, width, and style customization in properties dialog
- Updated all shape items (Rectangle, Polygon, Circle) to support stroke styles
- Fixed properties dialog color preservation bug
- Fixed keyboard shortcuts for drawing tools

## Technical Details
- New `StrokeStyle` enum with Qt pen style conversion
- Extended `ObjectStyle` dataclass with `stroke_style` field
- Added stroke properties to `GardenItemMixin` (color, width, style)
- Properties dialog now has stroke color picker, width spinner, and style dropdown
- All stroke properties are serialized/deserialized in project files
- Color retrieval now checks stored properties first before reading from Qt objects

## Test Plan
- [x] All 343 tests passing (including 12 new stroke style tests)
- [x] Linting passes
- [x] Manual testing: Draw shapes and customize stroke via properties dialog
- [x] Manual testing: Save/load projects with custom strokes
- [x] Manual testing: Color preservation when changing only stroke style
- [x] Keyboard shortcuts (R/P/C) work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)