### PR TITLE
feat(US-3.5): Add labels to objects displayed on canvas

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,3 +151,4 @@ tests/
 | ✅ | 3.2 | Set fill color for objects |
 | ✅ | 3.3 | Apply textures/patterns to objects |
 | ✅ | 3.4 | Set stroke style (color, width, dash pattern) |
+| ✅ | 3.5 | Add labels to objects displayed on canvas |

--- a/prd.md
+++ b/prd.md
@@ -604,7 +604,7 @@ open_garden_planner/
 | ~~US-3.2~~ | ~~As a user, I can set fill color for objects~~ | ✅ Must |
 | ~~US-3.3~~ | ~~As a user, I can apply textures/patterns to objects~~ | ✅ Must |
 | ~~US-3.4~~ | ~~As a user, I can set stroke style (color, width, dash pattern)~~ | ✅ Should |
-| US-3.5 | As a user, I can add labels to objects displayed on canvas | Should |
+| ~~US-3.5~~ | ~~As a user, I can add labels to objects displayed on canvas~~ | ✅ Should |
 | US-3.6 | As a user, I can organize objects into layers | Must |
 | US-3.7 | As a user, I can show/hide and lock layers | Must |
 | US-3.8 | As a user, I can copy and paste objects | Must |

--- a/src/open_garden_planner/core/tools/measure_tool.py
+++ b/src/open_garden_planner/core/tools/measure_tool.py
@@ -1,14 +1,7 @@
 """Measurement tool for measuring distances between points."""
 
 from PyQt6.QtCore import QLineF, QPointF, Qt
-from PyQt6.QtGui import (
-    QCursor,
-    QFont,
-    QKeyEvent,
-    QMouseEvent,
-    QPen,
-    QTransform,
-)
+from PyQt6.QtGui import QCursor, QFont, QKeyEvent, QMouseEvent, QPen
 from PyQt6.QtWidgets import QGraphicsTextItem
 
 from open_garden_planner.core.tools.base_tool import BaseTool, ToolType
@@ -274,19 +267,20 @@ class MeasureTool(BaseTool):
 
         # Set larger font size (similar to menu text)
         font = QFont()
-        font.setPointSize(14)
+        font.setPointSize(12)
         font.setBold(True)
         text_item.setFont(font)
 
         # Position text at midpoint
         mid_x = (start.x() + end.x()) / 2
         mid_y = (start.y() + end.y()) / 2
-        text_item.setPos(mid_x + 20, mid_y + 30)  # Offset to the right and down
 
-        # Counter-flip the text to make it readable (Y-axis is flipped in view)
-        transform = QTransform()
-        transform.scale(1, -1)  # Flip vertically to counter view's Y-flip
-        text_item.setTransform(transform)
+        # Center the text at the midpoint
+        text_rect = text_item.boundingRect()
+        text_item.setPos(mid_x - text_rect.width() / 2, mid_y - text_rect.height() / 2)
+
+        # Make text zoom-independent (stays readable at all zoom levels)
+        text_item.setFlag(QGraphicsTextItem.GraphicsItemFlag.ItemIgnoresTransformations)
 
         text_item.setZValue(1001)
 

--- a/src/open_garden_planner/ui/canvas/items/circle_item.py
+++ b/src/open_garden_planner/ui/canvas/items/circle_item.py
@@ -22,6 +22,9 @@ def _show_properties_dialog(item: QGraphicsEllipseItem) -> None:
         # Apply name change
         if hasattr(item, 'name'):
             item.name = dialog.get_name()
+            # Update the label if it exists
+            if hasattr(item, '_update_label'):
+                item._update_label()  # type: ignore[attr-defined]
 
         # Apply object type change (updates styling)
         new_object_type = dialog.get_object_type()
@@ -124,6 +127,7 @@ class CircleItem(GardenItemMixin, QGraphicsEllipseItem):
 
         self._setup_styling()
         self._setup_flags()
+        self.initialize_label()
 
     def _setup_styling(self) -> None:
         """Configure visual appearance based on object type."""

--- a/src/open_garden_planner/ui/canvas/items/polygon_item.py
+++ b/src/open_garden_planner/ui/canvas/items/polygon_item.py
@@ -22,6 +22,9 @@ def _show_properties_dialog(item: QGraphicsPolygonItem) -> None:
         # Apply name change
         if hasattr(item, 'name'):
             item.name = dialog.get_name()
+            # Update the label if it exists
+            if hasattr(item, '_update_label'):
+                item._update_label()  # type: ignore[attr-defined]
 
         # Apply object type change (updates styling)
         new_object_type = dialog.get_object_type()
@@ -113,6 +116,7 @@ class PolygonItem(GardenItemMixin, QGraphicsPolygonItem):
 
         self._setup_styling()
         self._setup_flags()
+        self.initialize_label()
 
     def _setup_styling(self) -> None:
         """Configure visual appearance based on object type."""

--- a/src/open_garden_planner/ui/canvas/items/polyline_item.py
+++ b/src/open_garden_planner/ui/canvas/items/polyline_item.py
@@ -43,6 +43,7 @@ class PolylineItem(GardenItemMixin, QGraphicsPathItem):
         self._points = points.copy()
         self._setup_styling()
         self._setup_flags()
+        self.initialize_label()
 
     @property
     def points(self) -> list[QPointF]:
@@ -102,3 +103,6 @@ class PolylineItem(GardenItemMixin, QGraphicsPathItem):
             if dialog.exec() and hasattr(self, 'name'):
                 # Apply changes
                 self.name = dialog.get_name()
+                # Update the label if it exists
+                if hasattr(self, '_update_label'):
+                    self._update_label()  # type: ignore[attr-defined]

--- a/src/open_garden_planner/ui/canvas/items/rectangle_item.py
+++ b/src/open_garden_planner/ui/canvas/items/rectangle_item.py
@@ -22,6 +22,9 @@ def _show_properties_dialog(item: QGraphicsRectItem) -> None:
         # Apply name change
         if hasattr(item, 'name'):
             item.name = dialog.get_name()
+            # Update the label if it exists
+            if hasattr(item, '_update_label'):
+                item._update_label()  # type: ignore[attr-defined]
 
         # Apply object type change (updates styling)
         new_object_type = dialog.get_object_type()
@@ -118,6 +121,7 @@ class RectangleItem(GardenItemMixin, QGraphicsRectItem):
 
         self._setup_styling()
         self._setup_flags()
+        self.initialize_label()
 
     def _setup_styling(self) -> None:
         """Configure visual appearance based on object type."""


### PR DESCRIPTION
## Summary
- Added label rendering for all object types (rectangles, polygons, circles, polylines)
- Labels display object names centered on each object
- Labels use zoom-independent rendering to remain readable at all zoom levels
- Labels appear in bold Arial 10pt font
- Labels automatically update when object name changes via properties dialog
- Labels persist with project save/load

## Additional Improvements
- Applied zoom-independent rendering to measure tool distance annotations
- Fixed polyline label initialization bug (labels now display correctly after loading from file)

## Technical Details
- Added `GardenItemMixin` label management methods:
  - `initialize_label()` - Creates label after item construction
  - `_create_label()` - Creates and styles QGraphicsTextItem as child
  - `_update_label()` - Updates/creates/removes label based on name
  - `_position_label()` - Centers label on object
- Labels use `ItemIgnoresTransformations` flag for zoom-independence
- Updated all item classes to initialize and update labels
- Updated measure tool to use same zoom-independent text rendering

## Test Plan
- [x] All 343 existing tests pass
- [x] Code passes ruff linting
- [x] Manually tested object label display, update, and persistence
- [x] Manually tested polyline label bug fix
- [x] Manually tested zoom-independent rendering for labels and measurements
- [x] Manually tested save/load persistence

🤖 Generated with [Claude Code](https://claude.com/claude-code)