### PR TITLE
feat(US-3.8): Add copy/paste functionality

### DIFF
--- a/src/open_garden_planner/app/application.py
+++ b/src/open_garden_planner/app/application.py
@@ -161,18 +161,21 @@ class GardenPlannerApp(QMainWindow):
         cut_action = QAction("Cu&t", self)
         cut_action.setShortcut(QKeySequence("Ctrl+X"))
         cut_action.setStatusTip("Cut selected objects")
+        cut_action.triggered.connect(self._on_cut)
         menu.addAction(cut_action)
 
         # Copy
         copy_action = QAction("&Copy", self)
         copy_action.setShortcut(QKeySequence("Ctrl+C"))
         copy_action.setStatusTip("Copy selected objects")
+        copy_action.triggered.connect(self._on_copy)
         menu.addAction(copy_action)
 
         # Paste
         paste_action = QAction("&Paste", self)
         paste_action.setShortcut(QKeySequence("Ctrl+V"))
         paste_action.setStatusTip("Paste objects from clipboard")
+        paste_action.triggered.connect(self._on_paste)
         menu.addAction(paste_action)
 
         # Delete
@@ -464,6 +467,18 @@ class GardenPlannerApp(QMainWindow):
             self.statusBar().showMessage(f"Redo: {desc}")
         else:
             self.statusBar().showMessage("Nothing to redo")
+
+    def _on_copy(self) -> None:
+        """Handle Copy action."""
+        self.canvas_view.copy_selected()
+
+    def _on_cut(self) -> None:
+        """Handle Cut action."""
+        self.canvas_view.cut_selected()
+
+    def _on_paste(self) -> None:
+        """Handle Paste action."""
+        self.canvas_view.paste()
 
     def _on_toggle_grid(self, checked: bool) -> None:
         """Handle toggle grid action."""

--- a/src/open_garden_planner/core/__init__.py
+++ b/src/open_garden_planner/core/__init__.py
@@ -4,6 +4,7 @@ from open_garden_planner.core.commands import (
     Command,
     CommandManager,
     CreateItemCommand,
+    CreateItemsCommand,
     DeleteItemsCommand,
     MoveItemsCommand,
 )
@@ -21,6 +22,7 @@ __all__ = [
     "Command",
     "CommandManager",
     "CreateItemCommand",
+    "CreateItemsCommand",
     "DeleteItemsCommand",
     "MoveItemsCommand",
     "ProjectData",

--- a/src/open_garden_planner/core/commands.py
+++ b/src/open_garden_planner/core/commands.py
@@ -162,6 +162,47 @@ class CreateItemCommand(Command):
             self._scene.removeItem(self._item)
 
 
+class CreateItemsCommand(Command):
+    """Command for creating multiple items on the scene."""
+
+    def __init__(
+        self,
+        scene: QGraphicsScene,
+        items: list[QGraphicsItem],
+        item_type: str = "items",
+    ) -> None:
+        """Initialize the create items command.
+
+        Args:
+            scene: The scene to add the items to
+            items: List of items to add
+            item_type: Description of item type (e.g., "pasted objects")
+        """
+        self._scene = scene
+        self._items = list(items)  # Copy the list
+        self._item_type = item_type
+
+    @property
+    def description(self) -> str:
+        """Human-readable description."""
+        count = len(self._items)
+        if count == 1:
+            return f"Create {self._item_type}"
+        return f"Create {count} {self._item_type}"
+
+    def execute(self) -> None:
+        """Add the items to the scene."""
+        for item in self._items:
+            if item.scene() is None:
+                self._scene.addItem(item)
+
+    def undo(self) -> None:
+        """Remove the items from the scene."""
+        for item in self._items:
+            if item.scene() is not None:
+                self._scene.removeItem(item)
+
+
 class DeleteItemsCommand(Command):
     """Command for deleting one or more items from the scene."""
 


### PR DESCRIPTION
## Summary
Implements US-3.8: copy, cut, and paste operations for all object types.

## Changes
- Copy/cut/paste with Ctrl+C/V/X shortcuts
- Full undo/redo support via CreateItemsCommand
- 20cm offset for pasted items
- Works with all item types

## Tests
- 10 new tests added
- All 353 tests passing
- Linting clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)