### PR TITLE
feat(US-4.8): Organized sidebar with collapsible tool panels

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,3 +163,4 @@ tests/
 | Status | US | Description |
 |--------|-----|-------------|
 | ✅ | 4.1 | Add plant objects (tree, shrub, perennial) |
+| ✅ | 4.8 | Organized sidebar with tool panels |

--- a/prd.md
+++ b/prd.md
@@ -663,7 +663,7 @@ open_garden_planner/
 | US-4.5 | As a user, I can view plant details in a properties panel | Must |
 | US-4.6 | As a user, I can add garden beds with area calculation | Must |
 | US-4.7 | As a user, I can filter/search plants in my project | Should |
-| US-4.8 | As a user, I have a well-organized sidebar with icon-based tool panels | Must |
+| ~~US-4.8~~ | ~~As a user, I have a well-organized sidebar with icon-based tool panels~~ | ✅ Must |
 
 **Technical Milestones**:
 - [ ] Plant model with full metadata schema

--- a/src/open_garden_planner/resources/icons/tools/README.md
+++ b/src/open_garden_planner/resources/icons/tools/README.md
@@ -1,0 +1,75 @@
+# Drawing Tool Icons
+
+This directory contains SVG icons for the drawing tools panel.
+
+## Icon Naming Convention
+
+Icons should be named according to their tool function:
+- `select.svg` - Selection tool
+- `measure.svg` - Measurement tool
+- `rectangle.svg` - Rectangle tool
+- `polygon.svg` - Polygon tool
+- `circle.svg` - Circle tool
+- `house.svg` - House tool
+- `shed.svg` - Garage/Shed tool
+- `greenhouse.svg` - Greenhouse tool
+- `terrace.svg` - Terrace/Patio tool
+- `driveway.svg` - Driveway tool
+- `pond.svg` - Pond/Pool tool
+- `fence.svg` - Fence tool
+- `wall.svg` - Wall tool
+- `path.svg` - Path tool
+- `tree.svg` - Tree tool
+- `shrub.svg` - Shrub tool
+- `flower.svg` - Perennial/Flower tool
+
+## Icon Requirements
+
+- **Format**: SVG (Scalable Vector Graphics)
+- **Size**: Icons should be designed on a square canvas (recommended: 24×24, 32×32, or 48×48 pixels)
+- **Color**: Can be colored or monochrome
+- **Style**: Should be consistent across all icons
+
+## Recommended Free Icon Sources
+
+### 1. Tabler Icons (MIT License)
+- **Website**: https://tabler.io/icons
+- **License**: MIT (commercial use allowed)
+- **Style**: Clean, minimal, consistent
+- **Download**: Browse and download individual SVG files
+- **Examples**:
+  - Tree: https://tabler.io/icons/icon/tree
+  - Fence: https://tabler.io/icons/icon/fence
+  - Building: https://tabler.io/icons/icon/building
+
+### 2. Heroicons (MIT License)
+- **Website**: https://heroicons.com
+- **License**: MIT (commercial use allowed)
+- **Style**: Modern, clean
+
+### 3. Lucide Icons (ISC License)
+- **Website**: https://lucide.dev
+- **License**: ISC (similar to MIT)
+- **Style**: Feather-inspired, minimal
+
+## Using IconScout Icons
+
+If you purchase icons from IconScout:
+1. Download the SVG file
+2. Rename it according to the naming convention above
+3. Place it in this directory
+4. Restart the application
+
+The icons you mentioned are great choices:
+- Tree icon: https://iconscout.com/icon/tree-icon_7124175
+- Fence icon: https://iconscout.com/icon/fence-icon_7124194
+
+## How It Works
+
+The application automatically:
+1. Looks for SVG files in this directory
+2. If found, loads the SVG and displays it in the button
+3. If not found, falls back to emoji icons
+4. Icons are rendered at 32×32 pixels
+
+No code changes needed - just drop SVG files here!

--- a/src/open_garden_planner/resources/icons/tools/circle.svg
+++ b/src/open_garden_planner/resources/icons/tools/circle.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64" fill="none">
+  <g stroke="#1F2937" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+
+  <circle cx="32" cy="32" r="18" fill="#3B82F6"/>
+  <circle cx="32" cy="32" r="18" fill="none" stroke-dasharray="6 4"/>
+
+  </g>
+</svg>

--- a/src/open_garden_planner/resources/icons/tools/driveway.svg
+++ b/src/open_garden_planner/resources/icons/tools/driveway.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64" fill="none">
+  <g stroke="#1F2937" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+
+  <path d="M22 54 L28 10 H36 L42 54 Z" fill="#9CA3AF"/>
+  <path d="M32 12 V52" stroke="white" stroke-dasharray="4 5"/>
+
+  </g>
+</svg>

--- a/src/open_garden_planner/resources/icons/tools/fence.svg
+++ b/src/open_garden_planner/resources/icons/tools/fence.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64" fill="none">
+  <g stroke="#1F2937" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+<path d="M12 24 L16 20 L20 24 V48 H12 Z" fill="#F59E0B"/>
+  <line x1="12" y1="34" x2="20" y2="34"/>
+  <path d="M20 24 L24 20 L28 24 V48 H20 Z" fill="#F59E0B"/>
+  <line x1="20" y1="34" x2="28" y2="34"/>
+  <path d="M28 24 L32 20 L36 24 V48 H28 Z" fill="#F59E0B"/>
+  <line x1="28" y1="34" x2="36" y2="34"/>
+  <path d="M36 24 L40 20 L44 24 V48 H36 Z" fill="#F59E0B"/>
+  <line x1="36" y1="34" x2="44" y2="34"/>
+  <path d="M44 24 L48 20 L52 24 V48 H44 Z" fill="#F59E0B"/>
+  <line x1="44" y1="34" x2="52" y2="34"/>
+  <path d="M52 24 L56 20 L60 24 V48 H52 Z" fill="#F59E0B"/>
+  <line x1="52" y1="34" x2="60" y2="34"/>
+  </g>
+</svg>

--- a/src/open_garden_planner/resources/icons/tools/flower.svg
+++ b/src/open_garden_planner/resources/icons/tools/flower.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64" fill="none">
+  <g stroke="#1F2937" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+
+  <ellipse cx="32" cy="24" rx="6" ry="10" fill="#EC4899" transform="rotate(0 32 32) translate(0, -8)"/><ellipse cx="32" cy="24" rx="6" ry="10" fill="#EC4899" transform="rotate(72 32 32) translate(0, -8)"/><ellipse cx="32" cy="24" rx="6" ry="10" fill="#EC4899" transform="rotate(144 32 32) translate(0, -8)"/><ellipse cx="32" cy="24" rx="6" ry="10" fill="#EC4899" transform="rotate(216 32 32) translate(0, -8)"/><ellipse cx="32" cy="24" rx="6" ry="10" fill="#EC4899" transform="rotate(288 32 32) translate(0, -8)"/>
+  <circle cx="32" cy="32" r="6" fill="#F59E0B"/>
+
+  </g>
+</svg>

--- a/src/open_garden_planner/resources/icons/tools/greenhouse.svg
+++ b/src/open_garden_planner/resources/icons/tools/greenhouse.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64" fill="none">
+  <g stroke="#1F2937" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+
+  <path d="M12 30 L32 16 L52 30 V50 H12 Z" fill="#06B6D4" opacity="0.25"/>
+  <path d="M12 30 L32 16 L52 30 V50 H12 Z" fill="none"/>
+  <path d="M34 38 C34 34 40 30 44 30 C44 36 40 42 36 44 C34 44 34 40 34 38 Z" fill="#22C55E"/>
+  <line x1="34" y1="38" x2="44" y2="34"/>
+
+  </g>
+</svg>

--- a/src/open_garden_planner/resources/icons/tools/house.svg
+++ b/src/open_garden_planner/resources/icons/tools/house.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64" fill="none">
+  <g stroke="#1F2937" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+
+  <path d="M12 28 L32 12 L52 28" fill="#EF4444"/>
+  <rect x="16" y="28" width="32" height="24" rx="4" fill="#EC4899"/>
+  <rect x="30" y="36" width="8" height="16" rx="2" fill="white"/>
+
+  </g>
+</svg>

--- a/src/open_garden_planner/resources/icons/tools/measure.svg
+++ b/src/open_garden_planner/resources/icons/tools/measure.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64" fill="none">
+<rect x='12' y='26' width='40' height='12' rx='2' fill='#F59E0B' stroke='#1F2937' stroke-width='2'/>
+<line x1='20' y1='26' x2='20' y2='38' stroke='#1F2937' stroke-width='2'/>
+<line x1='28' y1='26' x2='28' y2='38' stroke='#1F2937' stroke-width='2'/>
+<line x1='36' y1='26' x2='36' y2='38' stroke='#1F2937' stroke-width='2'/>
+<line x1='44' y1='26' x2='44' y2='38' stroke='#1F2937' stroke-width='2'/>
+</svg>

--- a/src/open_garden_planner/resources/icons/tools/path.svg
+++ b/src/open_garden_planner/resources/icons/tools/path.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64" fill="none">
+  
+  <path d="M10 54 C18 46 22 42 28 40 C36 38 44 36 54 26" stroke="#A16207" stroke-width="6" stroke-linecap="round"/>
+  <path d="M10 54 C18 46 22 42 28 40 C36 38 44 36 54 26" stroke="white" stroke-width="1.8" stroke-dasharray="2 6" stroke-linecap="round"/>
+
+</svg>

--- a/src/open_garden_planner/resources/icons/tools/polygon.svg
+++ b/src/open_garden_planner/resources/icons/tools/polygon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64" fill="none"><g stroke="#1F2937" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+<polygon points='32,10 52,26 44,50 20,50 12,26' fill='#FB923C' />
+</g></svg>

--- a/src/open_garden_planner/resources/icons/tools/pond.svg
+++ b/src/open_garden_planner/resources/icons/tools/pond.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64" fill="none">
+  <g stroke="#1F2937" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+
+  <path d="M18 40 C12 36 14 28 22 26 C26 24 30 24 34 26 C42 22 52 26 50 34 C48 42 38 46 30 46 C24 46 20 44 18 40 Z" fill="#3B82F6"/>
+  <path d="M26 34 C30 32 36 32 40 34" stroke="white"/>
+  <path d="M28 38 C32 36 36 36 38 38" stroke="white"/>
+
+  </g>
+</svg>

--- a/src/open_garden_planner/resources/icons/tools/rectangle.svg
+++ b/src/open_garden_planner/resources/icons/tools/rectangle.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64" fill="none">
+  <g stroke="#1F2937" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+
+  <rect x="10" y="14" width="44" height="36" rx="6" fill="#06B6D4"/>
+  <rect x="10" y="14" width="44" height="36" rx="6" fill="none" stroke-dasharray="6 4"/>
+
+  </g>
+</svg>

--- a/src/open_garden_planner/resources/icons/tools/select.svg
+++ b/src/open_garden_planner/resources/icons/tools/select.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64" fill="none"><g stroke="#1F2937" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+<path d='M18 10 L18 46 L26 38 L38 54 L42 50 L30 34 L38 26 Z' fill='#8B5CF6'/>
+</g></svg>

--- a/src/open_garden_planner/resources/icons/tools/shed.svg
+++ b/src/open_garden_planner/resources/icons/tools/shed.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64" fill="none">
+  <g stroke="#1F2937" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+
+  <path d="M14 28 L48 20 L50 26 L16 34 Z" fill="#A16207"/>
+  <rect x="16" y="32" width="28" height="18" rx="3" fill="#FB923C"/>
+  <rect x="26" y="36" width="8" height="14" rx="2" fill="white"/>
+
+  </g>
+</svg>

--- a/src/open_garden_planner/resources/icons/tools/shrub.svg
+++ b/src/open_garden_planner/resources/icons/tools/shrub.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64" fill="none">
+  <g stroke="#1F2937" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+
+  <circle cx="24" cy="38" r="10" fill="#22C55E"/>
+  <circle cx="36" cy="40" r="12" fill="#84CC16"/>
+  <circle cx="44" cy="36" r="8" fill="#22C55E"/>
+
+  </g>
+</svg>

--- a/src/open_garden_planner/resources/icons/tools/terrace.svg
+++ b/src/open_garden_planner/resources/icons/tools/terrace.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64" fill="none">
+  <g stroke="#1F2937" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+
+  <rect x="10" y="26" width="44" height="24" rx="4" fill="#84CC16"/>
+  <path d="M10 34 H54 M10 42 H54 M26 26 V50 M38 26 V50"/>
+
+  </g>
+</svg>

--- a/src/open_garden_planner/resources/icons/tools/tree.svg
+++ b/src/open_garden_planner/resources/icons/tools/tree.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64" fill="none">
+  <g stroke="#1F2937" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+
+  <circle cx="34" cy="26" r="14" fill="#22C55E"/>
+  <circle cx="22" cy="28" r="10" fill="#84CC16"/>
+  <rect x="28" y="34" width="8" height="16" rx="2" fill="#A16207"/>
+
+  </g>
+</svg>

--- a/src/open_garden_planner/resources/icons/tools/wall.svg
+++ b/src/open_garden_planner/resources/icons/tools/wall.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64" fill="none">
+  <g stroke="#1F2937" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+<rect x="10" y="18" width="44" height="32" rx="3" fill="#EC4899" opacity="0.2"/>
+<rect x="10" y="20" width="10" height="6" rx="1" fill="#EF4444"/><rect x="22" y="20" width="10" height="6" rx="1" fill="#EF4444"/><rect x="34" y="20" width="10" height="6" rx="1" fill="#EF4444"/><rect x="46" y="20" width="10" height="6" rx="1" fill="#EF4444"/><rect x="16" y="28" width="10" height="6" rx="1" fill="#EF4444"/><rect x="28" y="28" width="10" height="6" rx="1" fill="#EF4444"/><rect x="40" y="28" width="10" height="6" rx="1" fill="#EF4444"/><rect x="52" y="28" width="10" height="6" rx="1" fill="#EF4444"/><rect x="10" y="36" width="10" height="6" rx="1" fill="#EF4444"/><rect x="22" y="36" width="10" height="6" rx="1" fill="#EF4444"/><rect x="34" y="36" width="10" height="6" rx="1" fill="#EF4444"/><rect x="46" y="36" width="10" height="6" rx="1" fill="#EF4444"/><rect x="16" y="44" width="10" height="6" rx="1" fill="#EF4444"/><rect x="28" y="44" width="10" height="6" rx="1" fill="#EF4444"/><rect x="40" y="44" width="10" height="6" rx="1" fill="#EF4444"/><rect x="52" y="44" width="10" height="6" rx="1" fill="#EF4444"/>
+  </g>
+</svg>

--- a/src/open_garden_planner/ui/canvas/items/circle_item.py
+++ b/src/open_garden_planner/ui/canvas/items/circle_item.py
@@ -210,15 +210,11 @@ class CircleItem(GardenItemMixin, QGraphicsEllipseItem):
         duplicate_action = menu.addAction("Duplicate")
         duplicate_action.setEnabled(False)  # Placeholder
 
-        properties_action = menu.addAction("Properties...")
-
         # Execute menu and handle result
         action = menu.exec(event.screenPos())
 
         if action == delete_action:
             self.scene().removeItem(self)
-        elif action == properties_action:
-            _show_properties_dialog(self)
 
     def to_dict(self) -> dict:
         """Serialize the item to a dictionary for saving."""

--- a/src/open_garden_planner/ui/canvas/items/polygon_item.py
+++ b/src/open_garden_planner/ui/canvas/items/polygon_item.py
@@ -189,8 +189,6 @@ class PolygonItem(GardenItemMixin, QGraphicsPolygonItem):
         duplicate_action = menu.addAction("Duplicate")
         duplicate_action.setEnabled(False)  # Placeholder
 
-        properties_action = menu.addAction("Properties...")
-
         # Execute menu and handle result
         action = menu.exec(event.screenPos())
 
@@ -199,8 +197,6 @@ class PolygonItem(GardenItemMixin, QGraphicsPolygonItem):
             scene = self.scene()
             for item in scene.selectedItems():
                 scene.removeItem(item)
-        elif action == properties_action:
-            _show_properties_dialog(self)
 
     @classmethod
     def from_polygon(cls, polygon: QPolygonF) -> "PolygonItem":

--- a/src/open_garden_planner/ui/canvas/items/polyline_item.py
+++ b/src/open_garden_planner/ui/canvas/items/polyline_item.py
@@ -90,8 +90,6 @@ class PolylineItem(GardenItemMixin, QGraphicsPathItem):
         duplicate_action = menu.addAction("Duplicate")
         duplicate_action.setEnabled(False)
 
-        properties_action = menu.addAction("Properties...")
-
         # Execute menu and handle result
         action = menu.exec(event.screenPos())
 
@@ -100,13 +98,3 @@ class PolylineItem(GardenItemMixin, QGraphicsPathItem):
             scene = self.scene()
             for item in scene.selectedItems():
                 scene.removeItem(item)
-        elif action == properties_action:
-            # Note: Polylines don't have fill, only stroke
-            from open_garden_planner.ui.dialogs import PropertiesDialog
-            dialog = PropertiesDialog(self)
-            if dialog.exec() and hasattr(self, 'name'):
-                # Apply changes
-                self.name = dialog.get_name()
-                # Update the label if it exists
-                if hasattr(self, '_update_label'):
-                    self._update_label()  # type: ignore[attr-defined]

--- a/src/open_garden_planner/ui/canvas/items/rectangle_item.py
+++ b/src/open_garden_planner/ui/canvas/items/rectangle_item.py
@@ -194,8 +194,6 @@ class RectangleItem(GardenItemMixin, QGraphicsRectItem):
         duplicate_action = menu.addAction("Duplicate")
         duplicate_action.setEnabled(False)  # Placeholder
 
-        properties_action = menu.addAction("Properties...")
-
         # Execute menu and handle result
         action = menu.exec(event.screenPos())
 
@@ -204,8 +202,6 @@ class RectangleItem(GardenItemMixin, QGraphicsRectItem):
             scene = self.scene()
             for item in scene.selectedItems():
                 scene.removeItem(item)
-        elif action == properties_action:
-            _show_properties_dialog(self)
 
     @classmethod
     def from_rect(cls, rect: QRectF) -> "RectangleItem":

--- a/src/open_garden_planner/ui/dialogs/new_project_dialog.py
+++ b/src/open_garden_planner/ui/dialogs/new_project_dialog.py
@@ -80,7 +80,7 @@ class NewProjectDialog(QDialog):
         info_label = QLabel(
             "Tip: You can resize the canvas later from Edit > Canvas Size."
         )
-        info_label.setStyleSheet("color: gray; font-size: 11px;")
+        info_label.setStyleSheet("color: gray;")
         info_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         layout.addWidget(info_label)
 

--- a/src/open_garden_planner/ui/panels/__init__.py
+++ b/src/open_garden_planner/ui/panels/__init__.py
@@ -1,1 +1,11 @@
 """Side panel components (tools, properties, layers)."""
+
+from .drawing_tools_panel import DrawingToolsPanel
+from .layers_panel import LayersPanel
+from .properties_panel import PropertiesPanel
+
+__all__ = [
+    "DrawingToolsPanel",
+    "LayersPanel",
+    "PropertiesPanel",
+]

--- a/src/open_garden_planner/ui/panels/drawing_tools_panel.py
+++ b/src/open_garden_planner/ui/panels/drawing_tools_panel.py
@@ -1,0 +1,229 @@
+"""Drawing tools panel with SVG icon-based tool buttons."""
+
+from pathlib import Path
+
+from PyQt6.QtCore import QSize, pyqtSignal
+from PyQt6.QtGui import QIcon, QPixmap
+from PyQt6.QtSvg import QSvgRenderer
+from PyQt6.QtWidgets import (
+    QButtonGroup,
+    QGridLayout,
+    QLabel,
+    QToolButton,
+    QVBoxLayout,
+    QWidget,
+)
+
+from open_garden_planner.core.tools import ToolType
+
+
+class DrawingToolsPanel(QWidget):
+    """Panel with SVG icon-based buttons for all drawing tools.
+
+    Tools are organized into categories with colorful, descriptive icons.
+    Icons are loaded from SVG files in resources/icons/tools/.
+    Falls back to emoji if SVG file not found.
+    """
+
+    tool_selected = pyqtSignal(ToolType)
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        """Initialize the drawing tools panel.
+
+        Args:
+            parent: Parent widget
+        """
+        super().__init__(parent)
+        self._button_group = QButtonGroup(self)
+        self._button_group.setExclusive(True)
+        self._buttons: dict[ToolType, QToolButton] = {}
+        self._icons_dir = Path(__file__).parent.parent.parent / "resources" / "icons" / "tools"
+        self._setup_ui()
+
+    def _load_icon(self, icon_name: str, fallback_emoji: str) -> QIcon | str:
+        """Load an SVG icon or fall back to emoji.
+
+        Args:
+            icon_name: Name of the SVG file (without .svg extension)
+            fallback_emoji: Emoji to use if SVG not found
+
+        Returns:
+            QIcon if SVG found, emoji string otherwise
+        """
+        svg_path = self._icons_dir / f"{icon_name}.svg"
+        if svg_path.exists():
+            # Load SVG and create QIcon
+            from PyQt6.QtCore import Qt
+            from PyQt6.QtGui import QPainter
+
+            renderer = QSvgRenderer(str(svg_path))
+            pixmap = QPixmap(32, 32)
+            pixmap.fill(Qt.GlobalColor.transparent)  # Transparent background
+            painter = QPainter(pixmap)
+            renderer.render(painter)
+            painter.end()
+            return QIcon(pixmap)
+        return fallback_emoji
+
+    def _setup_ui(self) -> None:
+        """Set up the UI components."""
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(4, 4, 4, 4)
+        layout.setSpacing(4)
+
+        # SELECTION & MEASUREMENT
+        self._add_category("Selection & Measurement", layout)
+        grid1 = QGridLayout()
+        grid1.setSpacing(0)
+        self._add_tool(grid1, 0, 0, ToolType.SELECT, "select", "↖️", "Select (V)", "V")
+        self._add_tool(grid1, 0, 1, ToolType.MEASURE, "measure", "📐", "Measure (M)", "M")
+        layout.addLayout(grid1)
+
+        # BASIC SHAPES
+        self._add_category("Basic Shapes", layout)
+        grid2 = QGridLayout()
+        grid2.setSpacing(0)
+        self._add_tool(grid2, 0, 0, ToolType.RECTANGLE, "rectangle", "⬜", "Rectangle (R)", "R")
+        self._add_tool(grid2, 0, 1, ToolType.POLYGON, "polygon", "⬢", "Polygon (P)", "P")
+        self._add_tool(grid2, 0, 2, ToolType.CIRCLE, "circle", "⭕", "Circle (C)", "C")
+        layout.addLayout(grid2)
+
+        # STRUCTURES
+        self._add_category("Structures", layout)
+        grid3 = QGridLayout()
+        grid3.setSpacing(0)
+        self._add_tool(grid3, 0, 0, ToolType.HOUSE, "house", "🏠", "House (H)", "H")
+        self._add_tool(grid3, 0, 1, ToolType.GARAGE_SHED, "shed", "🛖", "Garage/Shed", "")
+        self._add_tool(grid3, 0, 2, ToolType.GREENHOUSE, "greenhouse", "🪟", "Greenhouse", "")
+        layout.addLayout(grid3)
+
+        # HARDSCAPE
+        self._add_category("Hardscape", layout)
+        grid4 = QGridLayout()
+        grid4.setSpacing(0)
+        self._add_tool(grid4, 0, 0, ToolType.TERRACE_PATIO, "terrace", "🟫", "Terrace (T)", "T")
+        self._add_tool(grid4, 0, 1, ToolType.DRIVEWAY, "driveway", "🛣️", "Driveway (D)", "D")
+        self._add_tool(grid4, 0, 2, ToolType.POND_POOL, "pond", "💧", "Pond/Pool", "")
+        layout.addLayout(grid4)
+
+        # LINEAR FEATURES
+        self._add_category("Linear Features", layout)
+        grid5 = QGridLayout()
+        grid5.setSpacing(0)
+        self._add_tool(grid5, 0, 0, ToolType.FENCE, "fence", "🪵", "Fence (F)", "F")
+        self._add_tool(grid5, 0, 1, ToolType.WALL, "wall", "🧱", "Wall (W)", "W")
+        self._add_tool(grid5, 0, 2, ToolType.PATH, "path", "👣", "Path (L)", "L")
+        layout.addLayout(grid5)
+
+        # PLANTS
+        self._add_category("Plants", layout)
+        grid6 = QGridLayout()
+        grid6.setSpacing(0)
+        self._add_tool(grid6, 0, 0, ToolType.TREE, "tree", "🌳", "Tree (1)", "1")
+        self._add_tool(grid6, 0, 1, ToolType.SHRUB, "shrub", "🪴", "Shrub (2)", "2")
+        self._add_tool(grid6, 0, 2, ToolType.PERENNIAL, "flower", "🌸", "Perennial (3)", "3")
+        layout.addLayout(grid6)
+
+        layout.addStretch()
+
+        # Select tool is default
+        if ToolType.SELECT in self._buttons:
+            self._buttons[ToolType.SELECT].setChecked(True)
+
+    def _add_category(self, title: str, layout: QVBoxLayout) -> None:
+        """Add a category header label.
+
+        Args:
+            title: Category title
+            layout: Layout to add to
+        """
+        label = QLabel(title)
+        label.setStyleSheet("""
+            QLabel {
+                color: palette(text);
+                font-weight: bold;
+                padding: 2px 0px 2px 0px;
+                border-bottom: 1px solid palette(mid);
+                margin-bottom: 1px;
+            }
+        """)
+        layout.addWidget(label)
+
+    def _add_tool(
+        self,
+        grid: QGridLayout,
+        row: int,
+        col: int,
+        tool_type: ToolType,
+        icon_name: str,
+        fallback_emoji: str,
+        tooltip: str,
+        shortcut: str,
+    ) -> None:
+        """Add a tool button to the grid.
+
+        Args:
+            grid: Grid layout to add to
+            row: Row position
+            col: Column position
+            tool_type: The tool type
+            icon_name: Name of SVG icon file (without .svg)
+            fallback_emoji: Emoji to use if SVG not found
+            tooltip: Tooltip text
+            shortcut: Keyboard shortcut
+        """
+        button = QToolButton()
+        button.setToolTip(tooltip)
+        button.setCheckable(True)
+        button.setFixedSize(44, 44)
+
+        # Load icon (SVG or emoji fallback)
+        icon_or_emoji = self._load_icon(icon_name, fallback_emoji)
+        if isinstance(icon_or_emoji, QIcon):
+            button.setIcon(icon_or_emoji)
+            button.setIconSize(QSize(32, 32))
+        else:
+            # Fallback to emoji
+            button.setText(icon_or_emoji)
+            font = button.font()
+            font.setPointSize(18)
+            button.setFont(font)
+
+        button.setStyleSheet("""
+            QToolButton {
+                border: 1px solid palette(mid);
+                background-color: palette(button);
+                margin: 0px;
+                padding: 0px;
+            }
+            QToolButton:hover {
+                background-color: palette(light);
+                border-color: palette(dark);
+            }
+            QToolButton:checked {
+                background-color: #e3f2fd;
+                border: 2px solid #2196f3;
+                font-weight: bold;
+            }
+        """)
+
+        # Set keyboard shortcut
+        if shortcut:
+            button.setShortcut(shortcut)
+
+        self._button_group.addButton(button)
+        self._buttons[tool_type] = button
+
+        # Connect signal
+        button.clicked.connect(lambda: self.tool_selected.emit(tool_type))
+
+        grid.addWidget(button, row, col)
+
+    def set_active_tool(self, tool_type: ToolType) -> None:
+        """Set the active tool.
+
+        Args:
+            tool_type: The tool type to activate
+        """
+        if tool_type in self._buttons:
+            self._buttons[tool_type].setChecked(True)

--- a/src/open_garden_planner/ui/panels/layers_panel.py
+++ b/src/open_garden_planner/ui/panels/layers_panel.py
@@ -172,7 +172,7 @@ class LayersPanel(QWidget):
 
         # Title
         title = QLabel("Layers")
-        title.setStyleSheet("font-weight: bold; font-size: 14px;")
+        title.setStyleSheet("font-weight: bold;")
         layout.addWidget(title)
 
         # Layer list with limited height

--- a/src/open_garden_planner/ui/panels/properties_panel.py
+++ b/src/open_garden_planner/ui/panels/properties_panel.py
@@ -1,0 +1,499 @@
+"""Properties panel for live editing of selected objects."""
+
+from PyQt6.QtCore import Qt
+from PyQt6.QtGui import QColor, QPen
+from PyQt6.QtWidgets import (
+    QColorDialog,
+    QComboBox,
+    QDoubleSpinBox,
+    QFormLayout,
+    QGraphicsItem,
+    QLabel,
+    QLineEdit,
+    QPushButton,
+    QScrollArea,
+    QVBoxLayout,
+    QWidget,
+)
+
+from open_garden_planner.core.fill_patterns import FillPattern, create_pattern_brush
+from open_garden_planner.core.object_types import ObjectType, StrokeStyle, get_style
+from open_garden_planner.ui.canvas.items import (
+    CircleItem,
+    PolygonItem,
+    PolylineItem,
+    RectangleItem,
+)
+
+
+class ColorButton(QPushButton):
+    """A button that displays a color and opens a color picker when clicked."""
+
+    def __init__(self, color: QColor, parent: QWidget | None = None) -> None:
+        """Initialize the color button.
+
+        Args:
+            color: Initial color
+            parent: Parent widget
+        """
+        super().__init__(parent)
+        self._color = color
+        self.setFixedHeight(30)
+        self._update_style()
+        self.clicked.connect(self._pick_color)
+
+    @property
+    def color(self) -> QColor:
+        """Get the current color."""
+        return self._color
+
+    def set_color(self, color: QColor) -> None:
+        """Set the button color.
+
+        Args:
+            color: New color
+        """
+        self._color = color
+        self._update_style()
+
+    def _update_style(self) -> None:
+        """Update the button style to show the current color."""
+        self.setStyleSheet(
+            f"background-color: rgba({self._color.red()}, {self._color.green()}, "
+            f"{self._color.blue()}, {self._color.alpha() / 255.0}); "
+            f"border: 1px solid #888;"
+        )
+
+    def _pick_color(self) -> None:
+        """Open color picker dialog."""
+        dialog = QColorDialog()
+        dialog.setCurrentColor(self._color)
+        dialog.setOption(QColorDialog.ColorDialogOption.ShowAlphaChannel, True)
+        dialog.setWindowTitle("Choose Color")
+
+        if dialog.exec():
+            color = dialog.selectedColor()
+            if color.isValid():
+                self.set_color(color)
+
+
+class PropertiesPanel(QWidget):
+    """Panel for live editing of selected object properties.
+
+    Shows properties of currently selected objects and allows immediate editing.
+    Changes are applied in real-time to the canvas.
+    """
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        """Initialize the properties panel.
+
+        Args:
+            parent: Parent widget
+        """
+        super().__init__(parent)
+        self._current_items: list[QGraphicsItem] = []
+        self._updating = False  # Prevent feedback loops
+        self._setup_ui()
+
+    def _setup_ui(self) -> None:
+        """Set up the UI components."""
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(4, 4, 4, 4)
+        layout.setSpacing(4)
+
+        # Scroll area for properties
+        scroll = QScrollArea()
+        scroll.setWidgetResizable(True)
+        scroll.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+        scroll.setFrameShape(QScrollArea.Shape.NoFrame)
+
+        # Content widget
+        self._content = QWidget()
+        self._content_layout = QVBoxLayout(self._content)
+        self._content_layout.setContentsMargins(0, 0, 0, 0)
+        self._content_layout.setSpacing(8)
+
+        # Form layout for properties
+        self._form_layout = QFormLayout()
+        self._form_layout.setFieldGrowthPolicy(QFormLayout.FieldGrowthPolicy.ExpandingFieldsGrow)
+        self._content_layout.addLayout(self._form_layout)
+        self._content_layout.addStretch()
+
+        scroll.setWidget(self._content)
+        layout.addWidget(scroll)
+
+        # Initially show "no selection" message
+        self._show_no_selection()
+
+    def _clear_form(self) -> None:
+        """Clear all widgets from the form."""
+        while self._form_layout.rowCount() > 0:
+            self._form_layout.removeRow(0)
+
+    def _show_no_selection(self) -> None:
+        """Show message when nothing is selected."""
+        self._clear_form()
+        label = QLabel("No objects selected")
+        label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        label.setStyleSheet("color: gray; padding: 20px;")
+        self._form_layout.addRow(label)
+
+    def _show_multi_selection(self, count: int) -> None:
+        """Show message for multiple selection.
+
+        Args:
+            count: Number of selected objects
+        """
+        self._clear_form()
+        label = QLabel(f"{count} objects selected")
+        label.setStyleSheet("font-weight: bold;")
+        self._form_layout.addRow(label)
+
+        # TODO: Show common properties for batch editing
+        info = QLabel("Multi-selection editing\nnot yet implemented")
+        info.setStyleSheet("color: gray; padding: 10px;")
+        info.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self._form_layout.addRow(info)
+
+    def set_selected_items(self, items: list[QGraphicsItem]) -> None:
+        """Set the selected items to display properties for.
+
+        Args:
+            items: List of selected graphics items
+        """
+        self._current_items = items
+
+        if not items:
+            self._show_no_selection()
+        elif len(items) > 1:
+            self._show_multi_selection(len(items))
+        else:
+            self._show_single_item(items[0])
+
+    def _show_single_item(self, item: QGraphicsItem) -> None:
+        """Show properties for a single selected item.
+
+        Args:
+            item: The selected graphics item
+        """
+        self._clear_form()
+        self._updating = True
+
+        # Object Type (if applicable)
+        if hasattr(item, 'object_type'):
+            type_combo = QComboBox()
+            self._populate_object_type_combo(type_combo, item)
+            type_combo.currentIndexChanged.connect(
+                lambda: self._on_property_changed(item, 'object_type', type_combo.currentData())
+            )
+            self._form_layout.addRow("Type:", type_combo)
+
+        # Name/Label
+        if hasattr(item, 'name'):
+            name_edit = QLineEdit(item.name)
+            name_edit.textChanged.connect(
+                lambda text: self._on_property_changed(item, 'name', text)
+            )
+            self._form_layout.addRow("Name:", name_edit)
+
+        # Layer
+        if hasattr(item, 'layer_id'):
+            layer_combo = QComboBox()
+            self._populate_layer_combo(layer_combo, item)
+            layer_combo.currentIndexChanged.connect(
+                lambda: self._on_property_changed(item, 'layer_id', layer_combo.currentData())
+            )
+            self._form_layout.addRow("Layer:", layer_combo)
+
+        # Geometry section
+        self._add_geometry_properties(item)
+
+        # Styling section
+        self._add_styling_properties(item)
+
+        # Plant-specific fields
+        if hasattr(item, 'plant_type'):
+            self._add_plant_properties(item)
+
+        self._updating = False
+
+    def _populate_object_type_combo(self, combo: QComboBox, item: QGraphicsItem) -> None:
+        """Populate object type combobox.
+
+        Args:
+            combo: Combobox to populate
+            item: Item to get valid types for
+        """
+        # Determine valid types based on item type
+        if isinstance(item, (RectangleItem, PolygonItem, CircleItem)):
+            valid_types = [
+                ObjectType.GENERIC_RECTANGLE if isinstance(item, RectangleItem) else (
+                    ObjectType.GENERIC_CIRCLE if isinstance(item, CircleItem) else ObjectType.GENERIC_POLYGON
+                ),
+                ObjectType.HOUSE,
+                ObjectType.GARAGE_SHED,
+                ObjectType.TERRACE_PATIO,
+                ObjectType.DRIVEWAY,
+                ObjectType.POND_POOL,
+                ObjectType.GREENHOUSE,
+            ]
+        elif isinstance(item, PolylineItem):
+            valid_types = [
+                ObjectType.FENCE,
+                ObjectType.WALL,
+                ObjectType.PATH,
+            ]
+        else:
+            valid_types = list(ObjectType)
+
+        # Populate combo
+        current_idx = 0
+        for idx, obj_type in enumerate(valid_types):
+            style = get_style(obj_type)
+            combo.addItem(style.display_name, obj_type)
+            if hasattr(item, 'object_type') and item.object_type == obj_type:
+                current_idx = idx
+
+        combo.setCurrentIndex(current_idx)
+
+    def _populate_layer_combo(self, combo: QComboBox, item: QGraphicsItem) -> None:
+        """Populate layer combobox.
+
+        Args:
+            combo: Combobox to populate
+            item: Item to get current layer for
+        """
+        scene = item.scene()
+        if scene and hasattr(scene, 'layers'):
+            current_idx = 0
+            for idx, layer in enumerate(scene.layers):
+                combo.addItem(layer.name, layer.id)
+                if hasattr(item, 'layer_id') and item.layer_id == layer.id:
+                    current_idx = idx
+            combo.setCurrentIndex(current_idx)
+
+    def _add_geometry_properties(self, item: QGraphicsItem) -> None:
+        """Add geometry property fields.
+
+        Args:
+            item: Item to show geometry for
+        """
+        # Position
+        pos = item.pos()
+        pos_label = QLabel(f"({pos.x():.1f}, {pos.y():.1f}) cm")
+        self._form_layout.addRow("Position:", pos_label)
+
+        # Type-specific geometry
+        if isinstance(item, CircleItem):
+            radius_label = QLabel(f"{item.radius * 2:.1f} cm")
+            self._form_layout.addRow("Diameter:", radius_label)
+        elif isinstance(item, RectangleItem):
+            rect = item.rect()
+            size_label = QLabel(f"{rect.width():.1f} × {rect.height():.1f} cm")
+            self._form_layout.addRow("Size:", size_label)
+
+    def _add_styling_properties(self, item: QGraphicsItem) -> None:
+        """Add styling property fields.
+
+        Args:
+            item: Item to show styling for
+        """
+        if not isinstance(item, (RectangleItem, PolygonItem, CircleItem, PolylineItem)):
+            return
+
+        # Fill color (not for polylines)
+        if not isinstance(item, PolylineItem):
+            fill_color = item.fill_color if hasattr(item, 'fill_color') and item.fill_color else item.brush().color()
+            fill_btn = ColorButton(fill_color)
+            fill_btn.clicked.connect(
+                lambda: self._on_color_changed(item, 'fill_color', fill_btn)
+            )
+            self._form_layout.addRow("Fill Color:", fill_btn)
+
+            # Fill pattern
+            pattern_combo = QComboBox()
+            for pattern in FillPattern:
+                pattern_combo.addItem(pattern.name.replace("_", " ").title(), pattern)
+
+            current_pattern = item.fill_pattern if hasattr(item, 'fill_pattern') else FillPattern.SOLID
+            for i in range(pattern_combo.count()):
+                if pattern_combo.itemData(i) == current_pattern:
+                    pattern_combo.setCurrentIndex(i)
+                    break
+
+            pattern_combo.currentIndexChanged.connect(
+                lambda: self._on_property_changed(item, 'fill_pattern', pattern_combo.currentData())
+            )
+            self._form_layout.addRow("Fill Pattern:", pattern_combo)
+
+        # Stroke color
+        stroke_color = item.stroke_color if hasattr(item, 'stroke_color') and item.stroke_color else item.pen().color()
+        stroke_btn = ColorButton(stroke_color)
+        stroke_btn.clicked.connect(
+            lambda: self._on_color_changed(item, 'stroke_color', stroke_btn)
+        )
+        self._form_layout.addRow("Stroke Color:", stroke_btn)
+
+        # Stroke width
+        width_spin = QDoubleSpinBox()
+        width_spin.setRange(0.5, 20.0)
+        width_spin.setSingleStep(0.5)
+        width_spin.setDecimals(1)
+        width_spin.setSuffix(" px")
+        width_spin.setValue(
+            item.stroke_width if hasattr(item, 'stroke_width') and item.stroke_width else item.pen().widthF()
+        )
+        width_spin.valueChanged.connect(
+            lambda val: self._on_property_changed(item, 'stroke_width', val)
+        )
+        self._form_layout.addRow("Stroke Width:", width_spin)
+
+        # Stroke style
+        style_combo = QComboBox()
+        for style in StrokeStyle:
+            style_combo.addItem(style.name.replace("_", " ").title(), style)
+
+        current_style = item.stroke_style if hasattr(item, 'stroke_style') else StrokeStyle.SOLID
+        for i in range(style_combo.count()):
+            if style_combo.itemData(i) == current_style:
+                style_combo.setCurrentIndex(i)
+                break
+
+        style_combo.currentIndexChanged.connect(
+            lambda: self._on_property_changed(item, 'stroke_style', style_combo.currentData())
+        )
+        self._form_layout.addRow("Stroke Style:", style_combo)
+
+    def _add_plant_properties(self, item: QGraphicsItem) -> None:  # noqa: ARG002
+        """Add plant-specific property fields.
+
+        Args:
+            item: Plant item to show properties for
+        """
+        # TODO: Add plant metadata fields when plant metadata is implemented
+        # For now, just show a placeholder
+        plant_label = QLabel("Plant metadata\ncoming in US-4.2")
+        plant_label.setStyleSheet("color: gray; padding: 10px;")
+        plant_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self._form_layout.addRow(plant_label)
+
+    def _on_property_changed(self, item: QGraphicsItem, property_name: str, value) -> None:
+        """Handle property change.
+
+        Args:
+            item: Item being edited
+            property_name: Name of the property
+            value: New value
+        """
+        if self._updating:
+            return
+
+        # Apply the change to the item
+        if property_name == 'object_type' and hasattr(item, 'object_type'):
+            item.object_type = value
+            # Apply default style for new type
+            style = get_style(value)
+
+            # Update stroke
+            pen = QPen(style.stroke_color)
+            pen.setWidthF(style.stroke_width)
+            pen.setStyle(style.stroke_style.to_qt_pen_style())
+            item.setPen(pen)
+
+            # Update fill (not for polylines)
+            if not isinstance(item, PolylineItem):
+                if hasattr(item, 'fill_pattern'):
+                    item.fill_pattern = style.fill_pattern
+                if hasattr(item, 'fill_color'):
+                    item.fill_color = style.fill_color
+                brush = create_pattern_brush(style.fill_pattern, style.fill_color)
+                item.setBrush(brush)
+
+            # Store properties
+            if hasattr(item, 'stroke_color'):
+                item.stroke_color = style.stroke_color
+            if hasattr(item, 'stroke_width'):
+                item.stroke_width = style.stroke_width
+            if hasattr(item, 'stroke_style'):
+                item.stroke_style = style.stroke_style
+
+            # Refresh the panel to show updated properties
+            self.set_selected_items([item])
+
+        elif property_name == 'name' and hasattr(item, 'name'):
+            item.name = value
+            # Update label if it exists
+            if hasattr(item, '_update_label'):
+                item._update_label()
+
+        elif property_name == 'layer_id' and hasattr(item, 'layer_id'):
+            item.layer_id = value
+            # Update z-order based on new layer
+            scene = item.scene()
+            if scene and hasattr(scene, 'get_layer_by_id'):
+                layer = scene.get_layer_by_id(value)
+                if layer:
+                    item.setZValue(layer.z_order * 100)
+
+        elif property_name == 'fill_pattern':
+            if hasattr(item, 'fill_pattern'):
+                item.fill_pattern = value
+            # Get current color
+            color = item.fill_color if hasattr(item, 'fill_color') and item.fill_color else item.brush().color()
+            brush = create_pattern_brush(value, color)
+            item.setBrush(brush)
+
+        elif property_name == 'stroke_width':
+            if hasattr(item, 'stroke_width'):
+                item.stroke_width = value
+            pen = item.pen()
+            pen.setWidthF(value)
+            item.setPen(pen)
+
+        elif property_name == 'stroke_style':
+            if hasattr(item, 'stroke_style'):
+                item.stroke_style = value
+            pen = item.pen()
+            pen.setStyle(value.to_qt_pen_style())
+            item.setPen(pen)
+
+        # Mark scene as modified
+        scene = item.scene()
+        if scene:
+            scene.update()
+
+    def _on_color_changed(self, item: QGraphicsItem, property_name: str, button: ColorButton) -> None:
+        """Handle color button change.
+
+        Args:
+            item: Item being edited
+            property_name: Name of the color property ('fill_color' or 'stroke_color')
+            button: The color button that was changed
+        """
+        if self._updating:
+            return
+
+        color = button.color
+
+        if property_name == 'fill_color':
+            # Store the color
+            if hasattr(item, 'fill_color'):
+                item.fill_color = color
+            # Apply to brush
+            pattern = item.fill_pattern if hasattr(item, 'fill_pattern') else FillPattern.SOLID
+            brush = create_pattern_brush(pattern, color)
+            item.setBrush(brush)
+
+        elif property_name == 'stroke_color':
+            # Store the color
+            if hasattr(item, 'stroke_color'):
+                item.stroke_color = color
+            # Apply to pen
+            pen = item.pen()
+            pen.setColor(color)
+            item.setPen(pen)
+
+        # Mark scene as modified
+        scene = item.scene()
+        if scene:
+            scene.update()

--- a/src/open_garden_planner/ui/widgets/__init__.py
+++ b/src/open_garden_planner/ui/widgets/__init__.py
@@ -1,7 +1,9 @@
 """Reusable UI widgets."""
 
+from .collapsible_panel import CollapsiblePanel
 from .toolbar import MainToolbar
 
 __all__ = [
+    "CollapsiblePanel",
     "MainToolbar",
 ]

--- a/src/open_garden_planner/ui/widgets/collapsible_panel.py
+++ b/src/open_garden_planner/ui/widgets/collapsible_panel.py
@@ -1,0 +1,138 @@
+"""Collapsible panel widget for sidebar organization."""
+
+from PyQt6.QtCore import Qt, pyqtSignal
+from PyQt6.QtWidgets import (
+    QFrame,
+    QHBoxLayout,
+    QLabel,
+    QVBoxLayout,
+    QWidget,
+)
+
+
+class CollapsiblePanel(QWidget):
+    """A collapsible panel with a header and content area.
+
+    The panel can be collapsed/expanded by clicking the header.
+    """
+
+    expanded_changed = pyqtSignal(bool)
+
+    def __init__(
+        self,
+        title: str,
+        content: QWidget | None = None,
+        parent: QWidget | None = None,
+        expanded: bool = True,
+    ) -> None:
+        """Initialize the collapsible panel.
+
+        Args:
+            title: Panel title displayed in header
+            content: Widget to display in the content area
+            parent: Parent widget
+            expanded: Initial expanded state
+        """
+        super().__init__(parent)
+        self._title = title
+        self._expanded = expanded
+        self._content_widget = content
+
+        self._setup_ui()
+        self.set_expanded(expanded, emit=False)
+
+    def _setup_ui(self) -> None:
+        """Set up the UI components."""
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(0)
+
+        # Header frame with background
+        self._header = QFrame()
+        self._header.setFrameShape(QFrame.Shape.StyledPanel)
+        self._header.setStyleSheet("""
+            QFrame {
+                background-color: palette(button);
+                border: 1px solid palette(mid);
+                border-radius: 3px;
+            }
+            QFrame:hover {
+                background-color: palette(light);
+            }
+        """)
+        self._header.setCursor(Qt.CursorShape.PointingHandCursor)
+        self._header.mousePressEvent = lambda _: self.toggle()
+
+        header_layout = QHBoxLayout(self._header)
+        header_layout.setContentsMargins(6, 4, 6, 4)
+
+        # Expand/collapse indicator
+        self._indicator = QLabel()
+        self._indicator.setFixedWidth(16)
+        header_layout.addWidget(self._indicator)
+
+        # Title label
+        title_label = QLabel(self._title)
+        title_label.setStyleSheet("font-weight: bold; border: none;")
+        header_layout.addWidget(title_label)
+
+        header_layout.addStretch()
+
+        layout.addWidget(self._header)
+
+        # Content area
+        if self._content_widget:
+            layout.addWidget(self._content_widget)
+
+    def set_content(self, widget: QWidget) -> None:
+        """Set the content widget.
+
+        Args:
+            widget: Widget to display in content area
+        """
+        if self._content_widget:
+            self._content_widget.setParent(None)
+
+        self._content_widget = widget
+        if widget:
+            self.layout().addWidget(widget)
+            widget.setVisible(self._expanded)
+
+    def is_expanded(self) -> bool:
+        """Check if panel is expanded.
+
+        Returns:
+            True if expanded, False if collapsed
+        """
+        return self._expanded
+
+    def set_expanded(self, expanded: bool, emit: bool = True) -> None:
+        """Set the expanded state.
+
+        Args:
+            expanded: True to expand, False to collapse
+            emit: Whether to emit the expanded_changed signal
+        """
+        self._expanded = expanded
+
+        # Update indicator
+        self._indicator.setText("▼" if expanded else "▶")
+
+        # Show/hide content
+        if self._content_widget:
+            self._content_widget.setVisible(expanded)
+
+        if emit:
+            self.expanded_changed.emit(expanded)
+
+    def toggle(self) -> None:
+        """Toggle the expanded state."""
+        self.set_expanded(not self._expanded)
+
+    def expand(self) -> None:
+        """Expand the panel."""
+        self.set_expanded(True)
+
+    def collapse(self) -> None:
+        """Collapse the panel."""
+        self.set_expanded(False)

--- a/tests/ui/test_collapsible_panel.py
+++ b/tests/ui/test_collapsible_panel.py
@@ -1,0 +1,100 @@
+"""Tests for collapsible panel widget."""
+
+import pytest
+from PyQt6.QtWidgets import QLabel
+
+from open_garden_planner.ui.widgets import CollapsiblePanel
+
+
+def test_collapsible_panel_creation(qtbot):  # noqa: ARG001
+    """Test that a collapsible panel can be created."""
+    content = QLabel("Test Content")
+    panel = CollapsiblePanel("Test Panel", content, expanded=True)
+
+    assert panel is not None
+    assert panel.is_expanded()
+
+
+def test_collapsible_panel_toggle(qtbot):
+    """Test toggling the panel state."""
+    content = QLabel("Test Content")
+    panel = CollapsiblePanel("Test Panel", content, expanded=True)
+    qtbot.addWidget(panel)
+    panel.show()
+
+    # Initially expanded
+    assert panel.is_expanded()
+    assert content.isVisible()
+
+    # Toggle to collapse
+    panel.toggle()
+    assert not panel.is_expanded()
+    assert not content.isVisible()
+
+    # Toggle back to expand
+    panel.toggle()
+    assert panel.is_expanded()
+    assert content.isVisible()
+
+
+def test_collapsible_panel_expand_collapse(qtbot):
+    """Test expand and collapse methods."""
+    content = QLabel("Test Content")
+    panel = CollapsiblePanel("Test Panel", content, expanded=False)
+    qtbot.addWidget(panel)
+    panel.show()
+
+    # Initially collapsed
+    assert not panel.is_expanded()
+    assert not content.isVisible()
+
+    # Expand
+    panel.expand()
+    assert panel.is_expanded()
+    assert content.isVisible()
+
+    # Collapse
+    panel.collapse()
+    assert not panel.is_expanded()
+    assert not content.isVisible()
+
+
+def test_collapsible_panel_set_content(qtbot):
+    """Test setting content after creation."""
+    panel = CollapsiblePanel("Test Panel", expanded=True)
+    qtbot.addWidget(panel)
+    panel.show()
+
+    # No content initially
+    assert panel._content_widget is None
+
+    # Set content
+    content = QLabel("New Content")
+    panel.set_content(content)
+
+    assert panel._content_widget is content
+    assert content.isVisible()
+
+
+def test_collapsible_panel_signal(qtbot):  # noqa: ARG001
+    """Test that expanded_changed signal is emitted."""
+    content = QLabel("Test Content")
+    panel = CollapsiblePanel("Test Panel", content, expanded=True)
+
+    # Track signal emissions
+    expanded_states = []
+
+    def on_expanded_changed(expanded: bool):
+        expanded_states.append(expanded)
+
+    panel.expanded_changed.connect(on_expanded_changed)
+
+    # Toggle should emit signal
+    panel.toggle()
+    assert len(expanded_states) == 1
+    assert expanded_states[0] is False
+
+    # Another toggle
+    panel.toggle()
+    assert len(expanded_states) == 2
+    assert expanded_states[1] is True

--- a/tests/ui/test_drawing_tools_panel.py
+++ b/tests/ui/test_drawing_tools_panel.py
@@ -1,0 +1,93 @@
+"""Tests for drawing tools panel."""
+
+import pytest
+
+from open_garden_planner.core.tools import ToolType
+from open_garden_planner.ui.panels import DrawingToolsPanel
+
+
+def test_drawing_tools_panel_creation(qtbot):  # noqa: ARG001
+    """Test that a drawing tools panel can be created."""
+    panel = DrawingToolsPanel()
+    qtbot.addWidget(panel)
+
+    assert panel is not None
+    assert len(panel._buttons) > 0
+
+
+def test_drawing_tools_panel_has_all_tools(qtbot):  # noqa: ARG001
+    """Test that all expected tools are present."""
+    panel = DrawingToolsPanel()
+    qtbot.addWidget(panel)
+
+    # Check that key tools are present
+    expected_tools = [
+        ToolType.SELECT,
+        ToolType.RECTANGLE,
+        ToolType.POLYGON,
+        ToolType.CIRCLE,
+        ToolType.HOUSE,
+        ToolType.TREE,
+        ToolType.SHRUB,
+        ToolType.PERENNIAL,
+        ToolType.MEASURE,
+    ]
+
+    for tool in expected_tools:
+        assert tool in panel._buttons, f"Tool {tool} not found in panel"
+
+
+def test_drawing_tools_panel_default_tool(qtbot):  # noqa: ARG001
+    """Test that SELECT tool is checked by default."""
+    panel = DrawingToolsPanel()
+    qtbot.addWidget(panel)
+
+    assert panel._buttons[ToolType.SELECT].isChecked()
+
+
+def test_drawing_tools_panel_tool_selection(qtbot):  # noqa: ARG001
+    """Test selecting a tool."""
+    panel = DrawingToolsPanel()
+    qtbot.addWidget(panel)
+
+    # Track tool selections
+    selected_tools = []
+
+    def on_tool_selected(tool: ToolType):
+        selected_tools.append(tool)
+
+    panel.tool_selected.connect(on_tool_selected)
+
+    # Click a tool button
+    panel._buttons[ToolType.RECTANGLE].click()
+
+    assert len(selected_tools) == 1
+    assert selected_tools[0] == ToolType.RECTANGLE
+    assert panel._buttons[ToolType.RECTANGLE].isChecked()
+
+
+def test_drawing_tools_panel_set_active_tool(qtbot):  # noqa: ARG001
+    """Test programmatically setting the active tool."""
+    panel = DrawingToolsPanel()
+    qtbot.addWidget(panel)
+
+    # Set a tool as active
+    panel.set_active_tool(ToolType.POLYGON)
+
+    assert panel._buttons[ToolType.POLYGON].isChecked()
+    assert not panel._buttons[ToolType.SELECT].isChecked()
+
+
+def test_drawing_tools_panel_exclusive_selection(qtbot):  # noqa: ARG001
+    """Test that only one tool can be selected at a time."""
+    panel = DrawingToolsPanel()
+    qtbot.addWidget(panel)
+
+    # Select first tool
+    panel._buttons[ToolType.RECTANGLE].setChecked(True)
+    assert panel._buttons[ToolType.RECTANGLE].isChecked()
+
+    # Select second tool
+    panel._buttons[ToolType.CIRCLE].setChecked(True)
+    assert panel._buttons[ToolType.CIRCLE].isChecked()
+    assert not panel._buttons[ToolType.RECTANGLE].isChecked()


### PR DESCRIPTION
## Summary
- Created organized right sidebar with three collapsible panels: Drawing Tools, Properties, and Layers
- Replaced horizontal toolbar with icon-based tool panel in sidebar
- Implemented live property editing in Properties panel (no more dialog popups)
- Added SVG icon support with emoji fallback for all 17 drawing tools
- Removed properties dialog from all context menus

## Technical Details
- **CollapsiblePanel**: Reusable widget with expand/collapse functionality
- **DrawingToolsPanel**: 3-column grid layout with categorized tools, SVG icon loading with transparent backgrounds
- **PropertiesPanel**: Live editing with color pickers, pattern selectors, stroke controls
- Tools organized into 6 categories: Selection & Measurement, Basic Shapes, Structures, Hardscape, Linear Features, Plants
- All keyboard shortcuts maintained (V, R, P, C, M, H, T, D, F, W, L, 1, 2, 3)
- Fixed QFont warnings by removing CSS font-size declarations

## Test Plan
- [x] All 369 tests pass
- [x] Linting clean
- [x] SVG icons display with transparent backgrounds
- [x] Tool selection works via clicking and keyboard shortcuts
- [x] Properties panel updates live when changing object properties
- [x] Panels can be collapsed/expanded
- [x] No QFont warnings in console
- [x] User manually tested and approved functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)