### PR TITLE
feat(US-4.6): Add garden beds with undo support for property changes

### DIFF
--- a/src/open_garden_planner/app/application.py
+++ b/src/open_garden_planner/app/application.py
@@ -351,7 +351,9 @@ class GardenPlannerApp(QMainWindow):
         sidebar_layout.addWidget(tools_panel)
 
         # 2. Properties Panel (collapsible)
-        self.properties_panel = PropertiesPanel()
+        self.properties_panel = PropertiesPanel(
+            command_manager=self.canvas_view.command_manager
+        )
         props_panel = CollapsiblePanel("Properties", self.properties_panel, expanded=True)
         sidebar_layout.addWidget(props_panel)
 

--- a/src/open_garden_planner/core/object_types.py
+++ b/src/open_garden_planner/core/object_types.py
@@ -42,6 +42,7 @@ class ObjectType(Enum):
     DRIVEWAY = auto()
     POND_POOL = auto()
     GREENHOUSE = auto()
+    GARDEN_BED = auto()
 
     # Polyline-based structures
     FENCE = auto()
@@ -114,6 +115,13 @@ OBJECT_STYLES: dict[ObjectType, ObjectStyle] = {
         stroke_width=2.5,
         display_name="Greenhouse",
         fill_pattern=FillPattern.SOLID,
+    ),
+    ObjectType.GARDEN_BED: ObjectStyle(
+        fill_color=QColor(139, 90, 43, 120),  # Brown soil
+        stroke_color=QColor(34, 139, 34),  # Forest green border
+        stroke_width=2.5,
+        display_name="Garden Bed",
+        fill_pattern=FillPattern.SOIL,
     ),
     ObjectType.TREE: ObjectStyle(
         fill_color=QColor(34, 139, 34, 100),  # Forest green

--- a/src/open_garden_planner/core/tools/base_tool.py
+++ b/src/open_garden_planner/core/tools/base_tool.py
@@ -24,6 +24,7 @@ class ToolType(Enum):
     DRIVEWAY = auto()
     POND_POOL = auto()
     GREENHOUSE = auto()
+    GARDEN_BED = auto()
 
     # Property object types (polyline-based)
     FENCE = auto()

--- a/src/open_garden_planner/ui/canvas/canvas_view.py
+++ b/src/open_garden_planner/ui/canvas/canvas_view.py
@@ -161,6 +161,12 @@ class CanvasView(QGraphicsView):
         greenhouse_tool.display_name = "Greenhouse"
         self._tool_manager.register_tool(greenhouse_tool)
 
+        garden_bed_tool = PolygonTool(self, object_type=ObjectType.GARDEN_BED)
+        garden_bed_tool.tool_type = ToolType.GARDEN_BED
+        garden_bed_tool.display_name = "Garden Bed"
+        garden_bed_tool.shortcut = "B"
+        self._tool_manager.register_tool(garden_bed_tool)
+
         # Register property object tools (polyline-based)
         fence_tool = PolylineTool(self, object_type=ObjectType.FENCE)
         fence_tool.tool_type = ToolType.FENCE

--- a/src/open_garden_planner/ui/dialogs/properties_dialog.py
+++ b/src/open_garden_planner/ui/dialogs/properties_dialog.py
@@ -141,7 +141,7 @@ class PropertiesDialog(QDialog):
 
             # Determine which object types are valid for this item
             if isinstance(self._item, (RectangleItem, PolygonItem, CircleItem)):
-                # All filled shapes can be any polygon-based structure
+                # All filled shapes can be any structure type
                 valid_types = [
                     ObjectType.GENERIC_RECTANGLE if isinstance(self._item, RectangleItem) else (
                         ObjectType.GENERIC_CIRCLE if isinstance(self._item, CircleItem) else ObjectType.GENERIC_POLYGON
@@ -152,6 +152,10 @@ class PropertiesDialog(QDialog):
                     ObjectType.DRIVEWAY,
                     ObjectType.POND_POOL,
                     ObjectType.GREENHOUSE,
+                    ObjectType.GARDEN_BED,
+                    ObjectType.TREE,
+                    ObjectType.SHRUB,
+                    ObjectType.PERENNIAL,
                 ]
             else:
                 # Default to all types

--- a/src/open_garden_planner/ui/panels/drawing_tools_panel.py
+++ b/src/open_garden_planner/ui/panels/drawing_tools_panel.py
@@ -115,14 +115,21 @@ class DrawingToolsPanel(QWidget):
         self._add_tool(grid5, 0, 2, ToolType.PATH, "path", "👣", "Path (L)", "L")
         layout.addLayout(grid5)
 
-        # PLANTS
-        self._add_category("Plants", layout)
+        # GARDEN
+        self._add_category("Garden", layout)
         grid6 = QGridLayout()
         grid6.setSpacing(0)
-        self._add_tool(grid6, 0, 0, ToolType.TREE, "tree", "🌳", "Tree (1)", "1")
-        self._add_tool(grid6, 0, 1, ToolType.SHRUB, "shrub", "🪴", "Shrub (2)", "2")
-        self._add_tool(grid6, 0, 2, ToolType.PERENNIAL, "flower", "🌸", "Perennial (3)", "3")
+        self._add_tool(grid6, 0, 0, ToolType.GARDEN_BED, "garden_bed", "🌱", "Garden Bed (B)", "B")
         layout.addLayout(grid6)
+
+        # PLANTS
+        self._add_category("Plants", layout)
+        grid7 = QGridLayout()
+        grid7.setSpacing(0)
+        self._add_tool(grid7, 0, 0, ToolType.TREE, "tree", "🌳", "Tree (1)", "1")
+        self._add_tool(grid7, 0, 1, ToolType.SHRUB, "shrub", "🪴", "Shrub (2)", "2")
+        self._add_tool(grid7, 0, 2, ToolType.PERENNIAL, "flower", "🌸", "Perennial (3)", "3")
+        layout.addLayout(grid7)
 
         layout.addStretch()
 

--- a/tests/ui/test_drawing_tools_panel.py
+++ b/tests/ui/test_drawing_tools_panel.py
@@ -27,6 +27,7 @@ def test_drawing_tools_panel_has_all_tools(qtbot):  # noqa: ARG001
         ToolType.POLYGON,
         ToolType.CIRCLE,
         ToolType.HOUSE,
+        ToolType.GARDEN_BED,
         ToolType.TREE,
         ToolType.SHRUB,
         ToolType.PERENNIAL,

--- a/tests/ui/test_properties_panel.py
+++ b/tests/ui/test_properties_panel.py
@@ -1,0 +1,118 @@
+"""Tests for properties panel."""
+
+import pytest
+from PyQt6.QtCore import QPointF
+
+from open_garden_planner.core.object_types import ObjectType
+from open_garden_planner.ui.canvas.items import CircleItem, PolygonItem, RectangleItem
+from open_garden_planner.ui.panels import PropertiesPanel
+
+
+class TestPropertiesPanel:
+    """Tests for the PropertiesPanel class."""
+
+    def test_creation(self, qtbot):  # noqa: ARG002
+        """Test that a properties panel can be created."""
+        panel = PropertiesPanel()
+        assert panel is not None
+
+    def test_no_selection(self, qtbot):  # noqa: ARG002
+        """Test panel shows 'no selection' when nothing is selected."""
+        panel = PropertiesPanel()
+        panel.set_selected_items([])
+        # Panel should show no selection message
+        assert panel._form_layout.rowCount() > 0
+
+    def test_single_item_selection(self, qtbot):  # noqa: ARG002
+        """Test panel shows properties for single selected item."""
+        panel = PropertiesPanel()
+        item = RectangleItem(0, 0, 100, 50)
+        panel.set_selected_items([item])
+        # Panel should show properties
+        assert panel._form_layout.rowCount() > 0
+
+
+class TestObjectTypeChange:
+    """Tests for changing object types in the properties panel."""
+
+    def test_change_rectangle_to_house(self, qtbot):  # noqa: ARG002
+        """Test changing a rectangle to a house."""
+        item = RectangleItem(0, 0, 100, 50)
+        assert item.object_type == ObjectType.GENERIC_RECTANGLE
+
+        # Change the object type
+        item.object_type = ObjectType.HOUSE
+        assert item.object_type == ObjectType.HOUSE
+
+    def test_change_polygon_to_garden_bed(self, qtbot):  # noqa: ARG002
+        """Test changing a polygon to a garden bed."""
+        vertices = [QPointF(0, 0), QPointF(100, 0), QPointF(100, 50), QPointF(0, 50)]
+        item = PolygonItem(vertices)
+        assert item.object_type == ObjectType.GENERIC_POLYGON
+
+        # Change the object type
+        item.object_type = ObjectType.GARDEN_BED
+        assert item.object_type == ObjectType.GARDEN_BED
+
+    def test_change_circle_to_tree(self, qtbot):  # noqa: ARG002
+        """Test changing a circle to a tree."""
+        item = CircleItem(50, 50, 25)
+        assert item.object_type == ObjectType.GENERIC_CIRCLE
+
+        # Change the object type
+        item.object_type = ObjectType.TREE
+        assert item.object_type == ObjectType.TREE
+
+    def test_change_house_to_pool(self, qtbot):  # noqa: ARG002
+        """Test changing a house to a pool."""
+        vertices = [QPointF(0, 0), QPointF(100, 0), QPointF(100, 50), QPointF(0, 50)]
+        item = PolygonItem(vertices, object_type=ObjectType.HOUSE)
+        assert item.object_type == ObjectType.HOUSE
+
+        # Change the object type
+        item.object_type = ObjectType.POND_POOL
+        assert item.object_type == ObjectType.POND_POOL
+
+    def test_change_garden_bed_to_terrace(self, qtbot):  # noqa: ARG002
+        """Test changing a garden bed to a terrace."""
+        vertices = [QPointF(0, 0), QPointF(100, 0), QPointF(100, 50), QPointF(0, 50)]
+        item = PolygonItem(vertices, object_type=ObjectType.GARDEN_BED)
+        assert item.object_type == ObjectType.GARDEN_BED
+
+        # Change the object type
+        item.object_type = ObjectType.TERRACE_PATIO
+        assert item.object_type == ObjectType.TERRACE_PATIO
+
+    def test_properties_panel_type_combo_includes_garden_bed(self, qtbot):  # noqa: ARG002
+        """Test that the properties panel type combo includes Garden Bed."""
+        from PyQt6.QtWidgets import QComboBox
+
+        panel = PropertiesPanel()
+        vertices = [QPointF(0, 0), QPointF(100, 0), QPointF(100, 50), QPointF(0, 50)]
+        item = PolygonItem(vertices)
+        panel.set_selected_items([item])
+
+        # Find the type combo in the form layout
+        type_combo = None
+        for i in range(panel._form_layout.rowCount()):
+            widget = panel._form_layout.itemAt(i, panel._form_layout.ItemRole.FieldRole)
+            if widget and isinstance(widget.widget(), QComboBox):
+                combo = widget.widget()
+                # Check if this is the type combo by looking for object types
+                for j in range(combo.count()):
+                    if combo.itemData(j) == ObjectType.HOUSE:
+                        type_combo = combo
+                        break
+                if type_combo:
+                    break
+
+        assert type_combo is not None, "Type combo not found in properties panel"
+
+        # Check that Garden Bed is in the combo
+        garden_bed_found = False
+        for i in range(type_combo.count()):
+            if type_combo.itemData(i) == ObjectType.GARDEN_BED:
+                garden_bed_found = True
+                break
+
+        assert garden_bed_found, "Garden Bed not found in type combo"

--- a/tests/unit/test_canvas_items.py
+++ b/tests/unit/test_canvas_items.py
@@ -7,6 +7,8 @@ from PyQt6.QtCore import QPointF, QRectF
 from PyQt6.QtGui import QColor
 from PyQt6.QtWidgets import QGraphicsEllipseItem, QGraphicsPolygonItem, QGraphicsRectItem
 
+from open_garden_planner.core.fill_patterns import FillPattern
+from open_garden_planner.core.object_types import ObjectType
 from open_garden_planner.ui.canvas.items import (
     CircleItem,
     GardenItemMixin,
@@ -260,3 +262,70 @@ class TestCircleItem:
         assert item.radius == 25
         assert item.pos().x() == 10
         assert item.pos().y() == 20
+
+
+class TestGardenBedItem:
+    """Tests for garden bed items (PolygonItem with ObjectType.GARDEN_BED)."""
+
+    @pytest.fixture
+    def bed_vertices(self):
+        """Create garden bed vertices (rectangular bed)."""
+        return [
+            QPointF(0, 0),
+            QPointF(200, 0),
+            QPointF(200, 100),
+            QPointF(0, 100),
+        ]
+
+    def test_garden_bed_creation(self, bed_vertices) -> None:
+        """Test garden bed can be created."""
+        item = PolygonItem(bed_vertices, object_type=ObjectType.GARDEN_BED)
+        assert item is not None
+        assert item.object_type == ObjectType.GARDEN_BED
+
+    def test_garden_bed_fill_color(self, bed_vertices) -> None:
+        """Test garden bed has correct brown soil fill color."""
+        item = PolygonItem(bed_vertices, object_type=ObjectType.GARDEN_BED)
+        # Brown soil color (139, 90, 43) with alpha 120
+        expected = QColor(139, 90, 43, 120)
+        assert item.fill_color == expected
+
+    def test_garden_bed_stroke_color(self, bed_vertices) -> None:
+        """Test garden bed has correct forest green stroke color."""
+        item = PolygonItem(bed_vertices, object_type=ObjectType.GARDEN_BED)
+        # Forest green (#228B22)
+        expected = QColor(34, 139, 34)
+        assert item.pen().color() == expected
+
+    def test_garden_bed_fill_pattern(self, bed_vertices) -> None:
+        """Test garden bed has soil fill pattern."""
+        item = PolygonItem(bed_vertices, object_type=ObjectType.GARDEN_BED)
+        assert item.fill_pattern == FillPattern.SOIL
+
+    def test_garden_bed_metadata(self, bed_vertices) -> None:
+        """Test garden bed can store metadata."""
+        metadata = {
+            "soil_type": "loam",
+            "is_raised": True,
+            "height_cm": 30,
+        }
+        item = PolygonItem(
+            bed_vertices,
+            object_type=ObjectType.GARDEN_BED,
+            name="Vegetable Bed",
+            metadata=metadata,
+        )
+        assert item.name == "Vegetable Bed"
+        assert item.metadata["soil_type"] == "loam"
+        assert item.metadata["is_raised"] is True
+        assert item.metadata["height_cm"] == 30
+
+    def test_garden_bed_is_selectable(self, bed_vertices) -> None:
+        """Test garden bed is selectable."""
+        item = PolygonItem(bed_vertices, object_type=ObjectType.GARDEN_BED)
+        assert item.flags() & QGraphicsPolygonItem.GraphicsItemFlag.ItemIsSelectable
+
+    def test_garden_bed_is_movable(self, bed_vertices) -> None:
+        """Test garden bed is movable."""
+        item = PolygonItem(bed_vertices, object_type=ObjectType.GARDEN_BED)
+        assert item.flags() & QGraphicsPolygonItem.GraphicsItemFlag.ItemIsMovable


### PR DESCRIPTION
## Summary
- Add Garden Bed object type with soil fill pattern and forest green border
- Add Garden Bed drawing tool (shortcut B) in the sidebar
- Add full undo/redo support for property changes in the Properties panel

## Technical Details
- **New ObjectType**: `GARDEN_BED` with brown soil color and `SOIL` fill pattern
- **New ToolType**: `GARDEN_BED` registered with shortcut "B"
- **ChangePropertyCommand**: New command class for property-based undo operations
- **Properties Panel Integration**: All property changes now create undo commands:
  - Object type, name, layer changes
  - Fill color, fill pattern changes  
  - Stroke color, width, style changes

## Test Plan
- [x] Draw garden bed with B shortcut
- [x] Change object types in Properties panel without crashes
- [x] Undo/redo property changes with Ctrl+Z/Ctrl+Y
- [x] 385 tests passing
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)