### PR TITLE
feat(US-4.3): Add plant species search with inline-editable metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,8 @@ htmlcov/
 
 # Project specific
 *.ogp.backup
+
+# API keys and secrets
+.env
+.env.local
+api_keys.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,14 +16,18 @@ venv/Scripts/python.exe -m ruff check src/
 ```
 
 ## Tech Stack
+
+Note: Use context7 as required for up-to-date documentation in any scenario where you require it.
 Python 3.11+ | PyQt6 | QGraphicsView/Scene | pytest + pytest-qt | ruff | mypy
 
 ## Workflow
 
 ### CRITICAL: Always Use Feature Branches
+
 **NEVER commit directly to master!** Always work on feature branches.
 
 ### Step-by-Step Process
+
 1. **Create feature branch** FIRST (before any changes)
    - Branch naming: `feature/US-X.X-short-description` (e.g., `feature/US-2.5-measure-distances`)
    - Command: `git checkout -b feature/US-X.X-short-description`
@@ -64,6 +68,7 @@ Python 3.11+ | PyQt6 | QGraphicsView/Scene | pytest + pytest-qt | ruff | mypy
 10. After completing a US, `/clear` context
 
 **Important Reminders**:
+
 - Stay in working mode (no plan mode)
 - **NEVER commit directly to master branch**
 - **NEVER commit before user manually tests and explicitly approves**
@@ -71,23 +76,25 @@ Python 3.11+ | PyQt6 | QGraphicsView/Scene | pytest + pytest-qt | ruff | mypy
 - Only commit after user says "commit" or "looks good" or similar approval
 
 ## Testing Notes
+
 - PyQt6 tests require `qtbot` fixture parameter in test methods even when unused (needed for Qt initialization); configure ruff per-file ignore for ARG002 in test files
 
 ## Progress (Phase 1)
 
-| Status | US | Description |
-|--------|-----|-------------|
-| ✅ | 1.1 | Create new project with dimensions |
-| ✅ | 1.2 | Pan and zoom canvas |
-| ✅ | 1.7 | Cursor coordinates display |
-| ✅ | 1.8 | App icon |
-| ✅ | 1.9 | README banner |
-| ✅ | 1.3 | Draw rectangles and polygons |
-| ✅ | 1.4 | Select, move, delete objects |
-| ✅ | 1.5 | Save/load project files |
-| ✅ | 1.6 | Undo/redo |
+| Status | US  | Description                        |
+| ------ | --- | ---------------------------------- |
+| ✅     | 1.1 | Create new project with dimensions |
+| ✅     | 1.2 | Pan and zoom canvas                |
+| ✅     | 1.7 | Cursor coordinates display         |
+| ✅     | 1.8 | App icon                           |
+| ✅     | 1.9 | README banner                      |
+| ✅     | 1.3 | Draw rectangles and polygons       |
+| ✅     | 1.4 | Select, move, delete objects       |
+| ✅     | 1.5 | Save/load project files            |
+| ✅     | 1.6 | Undo/redo                          |
 
 ## Project Structure
+
 <!-- Keep this updated when adding/removing files -->
 
 ```
@@ -123,43 +130,20 @@ tests/
 
 ## Phase 2 Complete!
 
-## Progress (Phase 2: Precision & Calibration)
-
-| Status | US | Description |
-|--------|-----|-------------|
-| ✅ | 2.3 | Toggle grid overlay (was pre-implemented) |
-| ✅ | 2.4 | Snap to grid (was pre-implemented) |
-| ✅ | 2.1 | Import background image |
-| ✅ | 2.7 | Adjust background image opacity |
-| ✅ | 2.8 | Lock background image |
-| ✅ | 2.2 | Calibrate image (two-point) |
-| ✅ | 2.5 | Measure distances |
-| ✅ | 2.9 | Draw circles (center + rim) |
-| ✅ | 2.6 | Area/perimeter of selected polygons and circles |
-
-## Future Backlog
-1. Vertex coordinate annotations on selection
-2. Rotate objects (15° snap)
-3. Edit polygon vertices
-
-## Progress (Phase 3: Objects & Styling)
-
-| Status | US | Description |
-|--------|-----|-------------|
-| ✅ | 3.1 | Add property objects (house, fence, path, etc.) |
-| ✅ | 3.2 | Set fill color for objects |
-| ✅ | 3.3 | Apply textures/patterns to objects |
-| ✅ | 3.4 | Set stroke style (color, width, dash pattern) |
-| ✅ | 3.5 | Add labels to objects displayed on canvas |
-| ✅ | 3.6 | Organize objects into layers |
-| ✅ | 3.7 | Show/hide and lock layers |
-| ✅ | 3.8 | Copy and paste objects |
+## Phase 3 Complete!
 
 ## Progress (Phase 4: Plants & Metadata)
 
-| Status | US | Description |
-|--------|-----|-------------|
-| ✅ | 4.1 | Add plant objects (tree, shrub, perennial) |
-| ✅ | 4.6 | Add garden beds with area calculation |
-| ✅ | 4.8 | Organized sidebar with tool panels |
-| ✅ | 4.9 | Resize objects by dragging handles |
+| Status | US  | Description                                |
+| ------ | --- | ------------------------------------------ |
+| ✅     | 4.1 | Add plant objects (tree, shrub, perennial) |
+| ✅     | 4.3 | Search plant species from online database  |
+| ✅     | 4.6 | Add garden beds with area calculation      |
+| ✅     | 4.8 | Organized sidebar with tool panels         |
+| ✅     | 4.9 | Resize objects by dragging handles         |
+
+## Future Backlog
+
+1. Vertex coordinate annotations on selection
+2. Rotate objects (15° snap)
+3. Edit polygon vertices

--- a/docs/PLANT_API_SETUP.md
+++ b/docs/PLANT_API_SETUP.md
@@ -1,0 +1,156 @@
+# Plant API Setup Guide
+
+Open Garden Planner integrates with online plant databases to help you search for plant species and automatically populate botanical information. This guide explains how to obtain and configure API keys for the supported plant databases.
+
+## Supported Plant APIs
+
+The application supports multiple plant APIs with automatic fallback:
+
+1. **Trefle.io** (Primary) - Comprehensive botanical database, 400,000+ species
+2. **Perenual** (Secondary) - Most reliable, 10,000+ species
+3. **Permapeople** (Tertiary) - Community-driven, permaculture-focused
+4. Bundled Database (Future) - Offline fallback
+
+## Setup Instructions
+
+### Option 1: Trefle.io API (Recommended)
+
+Trefle.io offers a free tier with access to 400,000+ plant species with comprehensive botanical information including growth requirements, distribution, images, and more.
+
+**Steps:**
+1. Visit [https://trefle.io/](https://trefle.io/)
+2. Sign up for a free account
+3. Navigate to your profile to get your API token
+4. Set the environment variable or add to `.env` file:
+   ```bash
+   # Windows (Command Prompt)
+   set TREFLE_API_TOKEN=your_token_here
+
+   # Windows (PowerShell)
+   $env:TREFLE_API_TOKEN="your_token_here"
+
+   # Linux/Mac
+   export TREFLE_API_TOKEN=your_token_here
+
+   # Or add to .env file in project root:
+   TREFLE_API_TOKEN=your_token_here
+   ```
+
+**Features:**
+- 400,000+ plant species
+- Comprehensive botanical data
+- Growth requirements (light, pH, humidity)
+- Distribution and native range information
+- Multiple images per plant (flower, leaf, habit, fruit, bark)
+- Edible parts and toxicity information
+- Scientific taxonomy and synonyms
+
+### Option 2: Perenual API
+
+Perenual offers a free tier with 10,000 API requests per day and access to 10,000+ plant species.
+
+**Steps:**
+1. Visit [https://perenual.com/](https://perenual.com/)
+2. Sign up for a free account
+3. Navigate to your API dashboard
+4. Copy your API key
+5. Set the environment variable:
+   ```bash
+   # Windows (Command Prompt)
+   set PERENUAL_API_KEY=your_key_here
+
+   # Windows (PowerShell)
+   $env:PERENUAL_API_KEY="your_key_here"
+
+   # Linux/Mac
+   export PERENUAL_API_KEY=your_key_here
+   ```
+
+**Features:**
+- 10,000 requests/day (free tier)
+- Plant images included
+- Growth requirements (sun, water, hardiness zones)
+- Well-maintained and reliable
+
+### Option 3: Permapeople API
+
+Permapeople is a community-driven plant database focused on permaculture and edible plants. It's free for non-commercial use and licensed under CC BY-SA 4.0.
+
+**Steps:**
+1. Visit [https://permapeople.org/api_requests/new](https://permapeople.org/api_requests/new)
+2. Sign up for an account
+3. Request API access
+4. You'll receive a key ID and key secret
+5. Set the environment variables:
+   ```bash
+   # Windows (Command Prompt)
+   set PERMAPEOPLE_KEY_ID=your_key_id_here
+   set PERMAPEOPLE_KEY_SECRET=your_key_secret_here
+
+   # Windows (PowerShell)
+   $env:PERMAPEOPLE_KEY_ID="your_key_id_here"
+   $env:PERMAPEOPLE_KEY_SECRET="your_key_secret_here"
+
+   # Linux/Mac
+   export PERMAPEOPLE_KEY_ID=your_key_id_here
+   export PERMAPEOPLE_KEY_SECRET=your_key_secret_here
+   ```
+
+**Features:**
+- Free for non-commercial use
+- Edible and medicinal plant focus
+- Permaculture-specific information
+- Community-contributed data
+
+## Usage in the Application
+
+Once you've configured API keys, the plant search feature will automatically:
+
+1. Try each API in order (Trefle → Perenual → Permapeople → ...)
+2. Use the first one that successfully returns results
+3. Display plant information including:
+   - Common and scientific names
+   - Sun and water requirements
+   - Hardiness zones
+   - Growth characteristics
+   - Edible parts (if applicable)
+   - Images (when available)
+
+## Troubleshooting
+
+### "API key not configured" Error
+
+Make sure you've set the environment variables correctly and restarted the application after setting them.
+
+### No Results Found
+
+- Check your internet connection
+- Verify your API keys are correct
+- Try a different plant name or spelling
+- Some APIs may have rate limits - wait a few minutes and try again
+
+### All APIs Failed
+
+If all APIs fail:
+1. Check your internet connection
+2. Verify API keys are still valid
+3. Check the API status pages:
+   - Trefle: [https://trefle.io/](https://trefle.io/)
+   - Perenual: [https://perenual.com/](https://perenual.com/)
+   - Permapeople: [https://permapeople.org/](https://permapeople.org/)
+
+## API Credits and Attribution
+
+When using these APIs, please:
+
+- **Trefle.io**: Free for personal and commercial use with attribution
+- **Perenual**: Free for personal and commercial use
+- **Permapeople**: Provide attribution and link back to permapeople.org. Data is CC BY-SA 4.0 licensed.
+
+## Future Enhancements
+
+Planned features for future releases:
+- Bundled offline plant database
+- Custom plant library (user-defined entries)
+- Plant data caching for offline use
+- Advanced filtering (by zone, edibility, growth characteristics)

--- a/prd.md
+++ b/prd.md
@@ -663,7 +663,7 @@ open_garden_planner/
 |----|------------|----------|
 | ~~US-4.1~~ | ~~As a user, I can add plant objects (tree, shrub, perennial)~~ | ✅ Must |
 | US-4.2 | As a user, I can set plant metadata (species, variety, dates) | Must |
-| US-4.3 | As a user, I can search for plant species from online database | Should |
+| ~~US-4.3~~ | ~~As a user, I can search for plant species from online database~~ | ✅ Should |
 | US-4.4 | As a user, I can create custom plant species in my library | Must |
 | US-4.5 | As a user, I can view plant details in a properties panel | Must |
 | ~~US-4.6~~ | ~~As a user, I can add garden beds with area calculation~~ | ✅ Must |
@@ -672,8 +672,8 @@ open_garden_planner/
 | ~~US-4.9~~ | ~~As a user, I can resize objects by dragging handles or edges~~ | ✅ Must |
 
 **Technical Milestones**:
-- [ ] Plant model with full metadata schema
-- [ ] Trefle.io API integration
+- [x] Plant model with full metadata schema
+- [x] Trefle.io API integration
 - [ ] Local SQLite cache for plant data
 - [ ] Custom plant library storage
 - [ ] Properties panel for plant editing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,8 @@ classifiers = [
 dependencies = [
     "PyQt6>=6.6.0",
     "Pillow>=10.0.0",
+    "requests>=2.31.0",
+    "python-dotenv>=1.0.0",
 ]
 
 [project.optional-dependencies]

--- a/src/open_garden_planner/main.py
+++ b/src/open_garden_planner/main.py
@@ -3,6 +3,14 @@
 import sys
 from pathlib import Path
 
+from dotenv import load_dotenv
+
+# Load environment variables from .env file in project root
+# Find the .env file relative to this source file
+_src_dir = Path(__file__).parent.parent.parent  # Go up to project root
+_env_file = _src_dir / ".env"
+load_dotenv(_env_file)
+
 # Windows-specific imports for taskbar icon support
 try:
     import ctypes

--- a/src/open_garden_planner/models/__init__.py
+++ b/src/open_garden_planner/models/__init__.py
@@ -1,5 +1,22 @@
 """Data models for garden objects."""
 
 from .layer import Layer, create_default_layers
+from .plant_data import (
+    GrowthRate,
+    PlantCycle,
+    PlantInstance,
+    PlantSpeciesData,
+    SunRequirement,
+    WaterNeeds,
+)
 
-__all__ = ["Layer", "create_default_layers"]
+__all__ = [
+    "Layer",
+    "create_default_layers",
+    "PlantSpeciesData",
+    "PlantInstance",
+    "SunRequirement",
+    "WaterNeeds",
+    "PlantCycle",
+    "GrowthRate",
+]

--- a/src/open_garden_planner/models/plant_data.py
+++ b/src/open_garden_planner/models/plant_data.py
@@ -1,0 +1,253 @@
+"""Plant data models for storing botanical information from APIs."""
+
+from dataclasses import dataclass, field
+from datetime import date
+from enum import Enum
+from typing import Any
+
+
+class SunRequirement(Enum):
+    """Sunlight requirements for plants."""
+
+    FULL_SUN = "full_sun"
+    PARTIAL_SUN = "partial_sun"
+    PARTIAL_SHADE = "partial_shade"
+    FULL_SHADE = "full_shade"
+    UNKNOWN = "unknown"
+
+
+class WaterNeeds(Enum):
+    """Water requirements for plants."""
+
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+    UNKNOWN = "unknown"
+
+
+class PlantCycle(Enum):
+    """Plant life cycle."""
+
+    ANNUAL = "annual"
+    BIENNIAL = "biennial"
+    PERENNIAL = "perennial"
+    UNKNOWN = "unknown"
+
+
+class GrowthRate(Enum):
+    """Plant growth rate."""
+
+    SLOW = "slow"
+    MEDIUM = "medium"
+    FAST = "fast"
+    UNKNOWN = "unknown"
+
+
+@dataclass
+class PlantSpeciesData:
+    """Botanical data for a plant species from external APIs.
+
+    This model stores information fetched from plant databases like
+    Perenual, Permapeople, or Trefle.io. It represents species-level
+    data rather than individual plant instances.
+    """
+
+    # Core identification
+    scientific_name: str
+    common_name: str
+    family: str = ""
+    genus: str = ""
+
+    # Growth characteristics
+    cycle: PlantCycle = PlantCycle.UNKNOWN
+    growth_rate: GrowthRate = GrowthRate.UNKNOWN
+
+    # Size (in centimeters)
+    min_height_cm: float | None = None
+    max_height_cm: float | None = None
+    min_spread_cm: float | None = None
+    max_spread_cm: float | None = None
+
+    # Environmental requirements
+    sun_requirement: SunRequirement = SunRequirement.UNKNOWN
+    water_needs: WaterNeeds = WaterNeeds.UNKNOWN
+    hardiness_zone_min: int | None = None
+    hardiness_zone_max: int | None = None
+
+    # Soil preferences
+    soil_type: str = ""  # e.g., "Light (sandy), medium, heavy (clay)"
+    ph_min: float | None = None
+    ph_max: float | None = None
+
+    # Additional attributes
+    edible: bool = False
+    edible_parts: list[str] = field(default_factory=list)
+    flowering: bool = False
+    flower_color: str = ""
+    foliage_color: str = ""
+    foliage_texture: str = ""
+
+    # Images
+    image_url: str = ""
+    thumbnail_url: str = ""
+
+    # Source tracking
+    data_source: str = ""  # e.g., "perenual", "permapeople", "trefle", "custom"
+    source_id: str = ""  # ID in the source database
+    description: str = ""
+
+    # Extensible metadata for API-specific fields
+    raw_data: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for serialization.
+
+        Returns:
+            Dictionary representation of the plant data
+        """
+        return {
+            "scientific_name": self.scientific_name,
+            "common_name": self.common_name,
+            "family": self.family,
+            "genus": self.genus,
+            "cycle": self.cycle.value,
+            "growth_rate": self.growth_rate.value,
+            "min_height_cm": self.min_height_cm,
+            "max_height_cm": self.max_height_cm,
+            "min_spread_cm": self.min_spread_cm,
+            "max_spread_cm": self.max_spread_cm,
+            "sun_requirement": self.sun_requirement.value,
+            "water_needs": self.water_needs.value,
+            "hardiness_zone_min": self.hardiness_zone_min,
+            "hardiness_zone_max": self.hardiness_zone_max,
+            "soil_type": self.soil_type,
+            "ph_min": self.ph_min,
+            "ph_max": self.ph_max,
+            "edible": self.edible,
+            "edible_parts": self.edible_parts,
+            "flowering": self.flowering,
+            "flower_color": self.flower_color,
+            "foliage_color": self.foliage_color,
+            "foliage_texture": self.foliage_texture,
+            "image_url": self.image_url,
+            "thumbnail_url": self.thumbnail_url,
+            "data_source": self.data_source,
+            "source_id": self.source_id,
+            "description": self.description,
+            "raw_data": self.raw_data,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "PlantSpeciesData":
+        """Create from dictionary.
+
+        Args:
+            data: Dictionary representation
+
+        Returns:
+            PlantSpeciesData instance
+        """
+        # Convert enum strings back to enums
+        cycle = PlantCycle(data.get("cycle", "unknown"))
+        growth_rate = GrowthRate(data.get("growth_rate", "unknown"))
+        sun_requirement = SunRequirement(data.get("sun_requirement", "unknown"))
+        water_needs = WaterNeeds(data.get("water_needs", "unknown"))
+
+        return cls(
+            scientific_name=data["scientific_name"],
+            common_name=data["common_name"],
+            family=data.get("family", ""),
+            genus=data.get("genus", ""),
+            cycle=cycle,
+            growth_rate=growth_rate,
+            min_height_cm=data.get("min_height_cm"),
+            max_height_cm=data.get("max_height_cm"),
+            min_spread_cm=data.get("min_spread_cm"),
+            max_spread_cm=data.get("max_spread_cm"),
+            sun_requirement=sun_requirement,
+            water_needs=water_needs,
+            hardiness_zone_min=data.get("hardiness_zone_min"),
+            hardiness_zone_max=data.get("hardiness_zone_max"),
+            soil_type=data.get("soil_type", ""),
+            ph_min=data.get("ph_min"),
+            ph_max=data.get("ph_max"),
+            edible=data.get("edible", False),
+            edible_parts=data.get("edible_parts", []),
+            flowering=data.get("flowering", False),
+            flower_color=data.get("flower_color", ""),
+            foliage_color=data.get("foliage_color", ""),
+            foliage_texture=data.get("foliage_texture", ""),
+            image_url=data.get("image_url", ""),
+            thumbnail_url=data.get("thumbnail_url", ""),
+            data_source=data.get("data_source", ""),
+            source_id=data.get("source_id", ""),
+            description=data.get("description", ""),
+            raw_data=data.get("raw_data", {}),
+        )
+
+
+@dataclass
+class PlantInstance:
+    """Individual plant instance in a garden.
+
+    This represents a specific plant placed in the garden, with its own
+    metadata separate from the species data. Links to PlantSpeciesData
+    for botanical information.
+    """
+
+    # Instance-specific data
+    variety_cultivar: str = ""  # e.g., "Honeycrisp" for apple
+    planting_date: date | None = None
+    current_diameter_cm: float | None = None
+    current_height_cm: float | None = None
+    notes: str = ""
+
+    # Custom metadata (user-defined fields)
+    custom_fields: dict[str, Any] = field(default_factory=dict)
+
+    # Link to species data (optional - may be None for custom entries)
+    species_data: PlantSpeciesData | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for serialization.
+
+        Returns:
+            Dictionary representation of the plant instance
+        """
+        return {
+            "variety_cultivar": self.variety_cultivar,
+            "planting_date": self.planting_date.isoformat() if self.planting_date else None,
+            "current_diameter_cm": self.current_diameter_cm,
+            "current_height_cm": self.current_height_cm,
+            "notes": self.notes,
+            "custom_fields": self.custom_fields,
+            "species_data": self.species_data.to_dict() if self.species_data else None,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "PlantInstance":
+        """Create from dictionary.
+
+        Args:
+            data: Dictionary representation
+
+        Returns:
+            PlantInstance instance
+        """
+        planting_date = None
+        if data.get("planting_date"):
+            planting_date = date.fromisoformat(data["planting_date"])
+
+        species_data = None
+        if data.get("species_data"):
+            species_data = PlantSpeciesData.from_dict(data["species_data"])
+
+        return cls(
+            variety_cultivar=data.get("variety_cultivar", ""),
+            planting_date=planting_date,
+            current_diameter_cm=data.get("current_diameter_cm"),
+            current_height_cm=data.get("current_height_cm"),
+            notes=data.get("notes", ""),
+            custom_fields=data.get("custom_fields", {}),
+            species_data=species_data,
+        )

--- a/src/open_garden_planner/services/__init__.py
+++ b/src/open_garden_planner/services/__init__.py
@@ -1,1 +1,5 @@
 """External services (file I/O, plant API, etc.)."""
+
+from .plant_api import PlantAPIClient, PlantAPIError, PlantAPIManager
+
+__all__ = ["PlantAPIClient", "PlantAPIError", "PlantAPIManager"]

--- a/src/open_garden_planner/services/plant_api/__init__.py
+++ b/src/open_garden_planner/services/plant_api/__init__.py
@@ -1,0 +1,6 @@
+"""Plant API services for querying botanical databases."""
+
+from .base import PlantAPIClient, PlantAPIError
+from .manager import PlantAPIManager
+
+__all__ = ["PlantAPIClient", "PlantAPIError", "PlantAPIManager"]

--- a/src/open_garden_planner/services/plant_api/base.py
+++ b/src/open_garden_planner/services/plant_api/base.py
@@ -1,0 +1,69 @@
+"""Base interface for plant API clients."""
+
+from abc import ABC, abstractmethod
+
+from open_garden_planner.models.plant_data import PlantSpeciesData
+
+
+class PlantAPIError(Exception):
+    """Base exception for plant API errors."""
+
+    pass
+
+
+class PlantAPIClient(ABC):
+    """Abstract base class for plant API clients.
+
+    Defines the interface that all plant API clients must implement.
+    This enables a consistent fallback chain across different providers.
+    """
+
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        """Name of the API service (e.g., "Perenual", "Permapeople").
+
+        Returns:
+            Service name
+        """
+        pass
+
+    @abstractmethod
+    def search(self, query: str, limit: int = 10) -> list[PlantSpeciesData]:
+        """Search for plants by common or scientific name.
+
+        Args:
+            query: Search term (plant name or partial name)
+            limit: Maximum number of results to return
+
+        Returns:
+            List of matching plant species data
+
+        Raises:
+            PlantAPIError: If the API request fails
+        """
+        pass
+
+    @abstractmethod
+    def get_by_id(self, plant_id: str) -> PlantSpeciesData:
+        """Get detailed plant data by API-specific ID.
+
+        Args:
+            plant_id: Unique identifier in this API's database
+
+        Returns:
+            Complete plant species data
+
+        Raises:
+            PlantAPIError: If the API request fails or plant not found
+        """
+        pass
+
+    @abstractmethod
+    def is_available(self) -> bool:
+        """Check if the API service is currently available.
+
+        Returns:
+            True if service can be reached, False otherwise
+        """
+        pass

--- a/src/open_garden_planner/services/plant_api/manager.py
+++ b/src/open_garden_planner/services/plant_api/manager.py
@@ -1,0 +1,181 @@
+"""Plant API manager with fallback chain."""
+
+import logging
+from typing import Any
+
+from open_garden_planner.models.plant_data import PlantSpeciesData
+
+from .base import PlantAPIClient, PlantAPIError
+from .perenual_client import PerenualClient
+from .permapeople_client import PermapeopleClient
+from .trefle_client import TrefleClient
+
+logger = logging.getLogger(__name__)
+
+
+class PlantAPIManager:
+    """Manager for plant API clients with automatic fallback.
+
+    Implements the fallback chain specified in the PRD:
+    1. Trefle.io (primary) - Comprehensive botanical database, 400,000+ species
+    2. Perenual (secondary) - Most reliable, active maintenance
+    3. Permapeople (tertiary) - Community-driven
+    4. Bundled database (offline fallback) - Not yet implemented
+    5. User-defined entries (always available) - Not yet implemented
+
+    The manager automatically tries each service in order until one succeeds.
+    """
+
+    def __init__(
+        self,
+        trefle_api_token: str | None = None,
+        perenual_api_key: str | None = None,
+        permapeople_key_id: str | None = None,
+        permapeople_key_secret: str | None = None,
+    ) -> None:
+        """Initialize the plant API manager.
+
+        Args:
+            trefle_api_token: Optional Trefle API token
+            perenual_api_key: Optional Perenual API key
+            permapeople_key_id: Optional Permapeople key ID
+            permapeople_key_secret: Optional Permapeople key secret
+        """
+        self._clients: list[PlantAPIClient] = []
+
+        # Initialize clients in fallback order (Trefle first)
+        try:
+            trefle = TrefleClient(api_token=trefle_api_token)
+            self._clients.append(trefle)
+            logger.info("Trefle client initialized")
+        except Exception as e:
+            logger.warning(f"Failed to initialize Trefle client: {e}")
+
+        try:
+            perenual = PerenualClient(api_key=perenual_api_key)
+            self._clients.append(perenual)
+            logger.info("Perenual client initialized")
+        except Exception as e:
+            logger.warning(f"Failed to initialize Perenual client: {e}")
+
+        try:
+            permapeople = PermapeopleClient(
+                key_id=permapeople_key_id,
+                key_secret=permapeople_key_secret,
+            )
+            self._clients.append(permapeople)
+            logger.info("Permapeople client initialized")
+        except Exception as e:
+            logger.warning(f"Failed to initialize Permapeople client: {e}")
+
+        # TODO: Add bundled database client when implemented
+
+    def search(self, query: str, limit: int = 10) -> list[PlantSpeciesData]:
+        """Search for plants across all available APIs with fallback.
+
+        Tries each API in order until one succeeds. Returns results from
+        the first successful API.
+
+        Args:
+            query: Search term (plant name or partial name)
+            limit: Maximum number of results to return
+
+        Returns:
+            List of matching plant species data
+
+        Raises:
+            PlantAPIError: If all APIs fail
+        """
+        if not query or not query.strip():
+            return []
+
+        last_error: Exception | None = None
+
+        for client in self._clients:
+            try:
+                logger.info(f"Trying {client.name} API for search: '{query}'")
+                results = client.search(query, limit)
+
+                if results:
+                    logger.info(f"{client.name} returned {len(results)} results")
+                    return results
+                else:
+                    logger.info(f"{client.name} returned no results")
+
+            except PlantAPIError as e:
+                logger.warning(f"{client.name} API failed: {e}")
+                last_error = e
+                continue
+            except Exception as e:
+                logger.error(f"Unexpected error with {client.name}: {e}")
+                last_error = e
+                continue
+
+        # All APIs failed
+        error_msg = "All plant APIs failed"
+        if last_error:
+            error_msg += f": {last_error}"
+        raise PlantAPIError(error_msg)
+
+    def get_by_id(self, plant_id: str, source: str) -> PlantSpeciesData:
+        """Get detailed plant data by ID from a specific source.
+
+        Args:
+            plant_id: Unique identifier in the source's database
+            source: Source name ("perenual", "permapeople", etc.)
+
+        Returns:
+            Complete plant species data
+
+        Raises:
+            PlantAPIError: If the API request fails or source not found
+        """
+        # Find the client for this source
+        for client in self._clients:
+            if client.name.lower() == source.lower():
+                try:
+                    return client.get_by_id(plant_id)
+                except PlantAPIError as e:
+                    raise PlantAPIError(f"Failed to get plant from {source}: {e}") from e
+
+        raise PlantAPIError(f"No client available for source: {source}")
+
+    def get_available_sources(self) -> list[str]:
+        """Get list of currently available API sources.
+
+        Returns:
+            List of source names that are operational
+        """
+        available = []
+        for client in self._clients:
+            try:
+                if client.is_available():
+                    available.append(client.name)
+            except Exception as e:
+                logger.debug(f"Failed to check {client.name} availability: {e}")
+                continue
+
+        return available
+
+    def check_status(self) -> dict[str, Any]:
+        """Check status of all configured API clients.
+
+        Returns:
+            Dictionary mapping client names to their availability status
+        """
+        status = {}
+        for client in self._clients:
+            try:
+                is_available = client.is_available()
+                status[client.name] = {
+                    "available": is_available,
+                    "configured": True,
+                }
+            except Exception as e:
+                status[client.name] = {
+                    "available": False,
+                    "configured": True,
+                    "error": str(e),
+                }
+
+        return status

--- a/src/open_garden_planner/services/plant_api/perenual_client.py
+++ b/src/open_garden_planner/services/plant_api/perenual_client.py
@@ -1,0 +1,211 @@
+"""Perenual Plant API client implementation."""
+
+import logging
+from typing import Any
+
+import requests
+
+from open_garden_planner.models.plant_data import (
+    GrowthRate,
+    PlantCycle,
+    PlantSpeciesData,
+    SunRequirement,
+    WaterNeeds,
+)
+
+from .base import PlantAPIClient, PlantAPIError
+
+logger = logging.getLogger(__name__)
+
+
+class PerenualClient(PlantAPIClient):
+    """Client for the Perenual Plant API.
+
+    API Documentation: https://perenual.com/docs/api
+    Free tier: 10,000 requests/day, access to 10,000+ plant species
+    """
+
+    BASE_URL = "https://perenual.com/api"
+    API_KEY_ENV_VAR = "PERENUAL_API_KEY"
+
+    def __init__(self, api_key: str | None = None) -> None:
+        """Initialize the Perenual client.
+
+        Args:
+            api_key: Optional API key. If not provided, will look for
+                    PERENUAL_API_KEY environment variable.
+        """
+        import os
+
+        self._api_key = api_key or os.environ.get(self.API_KEY_ENV_VAR, "")
+        self._session = requests.Session()
+        self._session.headers.update({"User-Agent": "OpenGardenPlanner/1.0"})
+
+    @property
+    def name(self) -> str:
+        """Name of the API service.
+
+        Returns:
+            Service name
+        """
+        return "Perenual"
+
+    def search(self, query: str, limit: int = 10) -> list[PlantSpeciesData]:
+        """Search for plants by common or scientific name.
+
+        Args:
+            query: Search term (plant name or partial name)
+            limit: Maximum number of results to return
+
+        Returns:
+            List of matching plant species data
+
+        Raises:
+            PlantAPIError: If the API request fails
+        """
+        if not self._api_key:
+            raise PlantAPIError(f"{self.name} API key not configured")
+
+        try:
+            response = self._session.get(
+                f"{self.BASE_URL}/species-list",
+                params={"key": self._api_key, "q": query, "page": 1},
+                timeout=10,
+            )
+            response.raise_for_status()
+            data = response.json()
+
+            results: list[PlantSpeciesData] = []
+            for item in data.get("data", [])[:limit]:
+                try:
+                    plant_data = self._parse_species(item)
+                    results.append(plant_data)
+                except Exception as e:
+                    logger.warning(f"Failed to parse Perenual plant data: {e}")
+                    continue
+
+            return results
+
+        except requests.RequestException as e:
+            raise PlantAPIError(f"{self.name} API request failed: {e}") from e
+
+    def get_by_id(self, plant_id: str) -> PlantSpeciesData:
+        """Get detailed plant data by Perenual ID.
+
+        Args:
+            plant_id: Unique identifier in Perenual's database
+
+        Returns:
+            Complete plant species data
+
+        Raises:
+            PlantAPIError: If the API request fails or plant not found
+        """
+        if not self._api_key:
+            raise PlantAPIError(f"{self.name} API key not configured")
+
+        try:
+            response = self._session.get(
+                f"{self.BASE_URL}/species/details/{plant_id}",
+                params={"key": self._api_key},
+                timeout=10,
+            )
+            response.raise_for_status()
+            data = response.json()
+
+            return self._parse_species(data)
+
+        except requests.RequestException as e:
+            raise PlantAPIError(f"{self.name} API request failed: {e}") from e
+
+    def is_available(self) -> bool:
+        """Check if the Perenual API is currently available.
+
+        Returns:
+            True if service can be reached, False otherwise
+        """
+        if not self._api_key:
+            return False
+
+        try:
+            response = self._session.get(
+                f"{self.BASE_URL}/species-list",
+                params={"key": self._api_key, "page": 1},
+                timeout=5,
+            )
+            return response.status_code == 200
+        except requests.RequestException:
+            return False
+
+    def _parse_species(self, data: dict[str, Any]) -> PlantSpeciesData:
+        """Parse Perenual API response into PlantSpeciesData.
+
+        Args:
+            data: Raw API response data
+
+        Returns:
+            Parsed plant species data
+        """
+        # Extract basic info
+        scientific_name = data.get("scientific_name", ["Unknown"])[0] if isinstance(data.get("scientific_name"), list) else data.get("scientific_name", "Unknown")
+        common_name = data.get("common_name", "Unknown")
+
+        # Parse cycle (annual, perennial, etc.)
+        cycle_str = data.get("cycle", "").lower()
+        cycle = PlantCycle.UNKNOWN
+        if "annual" in cycle_str:
+            cycle = PlantCycle.ANNUAL
+        elif "biennial" in cycle_str:
+            cycle = PlantCycle.BIENNIAL
+        elif "perennial" in cycle_str:
+            cycle = PlantCycle.PERENNIAL
+
+        # Parse sun requirements
+        sunlight_list = data.get("sunlight", [])
+        sun_req = SunRequirement.UNKNOWN
+        if sunlight_list:
+            sunlight_str = " ".join(sunlight_list).lower()
+            if "full sun" in sunlight_str or "full_sun" in sunlight_str:
+                sun_req = SunRequirement.FULL_SUN
+            elif "part shade" in sunlight_str or "partial" in sunlight_str:
+                sun_req = SunRequirement.PARTIAL_SHADE
+
+        # Parse watering needs
+        watering = data.get("watering", "").lower()
+        water_needs = WaterNeeds.UNKNOWN
+        if "minimum" in watering or "low" in watering:
+            water_needs = WaterNeeds.LOW
+        elif "average" in watering or "moderate" in watering:
+            water_needs = WaterNeeds.MEDIUM
+        elif "frequent" in watering or "high" in watering:
+            water_needs = WaterNeeds.HIGH
+
+        # Extract images
+        default_image = data.get("default_image", {})
+        image_url = ""
+        thumbnail_url = ""
+        if isinstance(default_image, dict):
+            image_url = default_image.get("original_url", "")
+            thumbnail_url = default_image.get("thumbnail", "")
+
+        # Size information would be extracted here
+        # Perenual doesn't provide structured dimensions in free tier
+        # Would need detailed endpoint or premium tier for accurate measurements
+
+        return PlantSpeciesData(
+            scientific_name=scientific_name,
+            common_name=common_name,
+            family="",  # Not in basic response
+            genus="",  # Not in basic response
+            cycle=cycle,
+            growth_rate=GrowthRate.UNKNOWN,  # Not available in free tier
+            sun_requirement=sun_req,
+            water_needs=water_needs,
+            image_url=image_url,
+            thumbnail_url=thumbnail_url,
+            data_source="perenual",
+            source_id=str(data.get("id", "")),
+            description=data.get("description", ""),
+            flowering=data.get("flowering_season") is not None,
+            raw_data=data,
+        )

--- a/src/open_garden_planner/services/plant_api/permapeople_client.py
+++ b/src/open_garden_planner/services/plant_api/permapeople_client.py
@@ -1,0 +1,251 @@
+"""Permapeople Plant API client implementation."""
+
+import logging
+from typing import Any
+
+import requests
+
+from open_garden_planner.models.plant_data import (
+    GrowthRate,
+    PlantCycle,
+    PlantSpeciesData,
+    SunRequirement,
+    WaterNeeds,
+)
+
+from .base import PlantAPIClient, PlantAPIError
+
+logger = logging.getLogger(__name__)
+
+
+class PermapeopleClient(PlantAPIClient):
+    """Client for the Permapeople Plant API.
+
+    API Documentation: https://permapeople.org/knowledgebase/api-docs.html
+    Free for non-commercial use, requires authentication headers.
+    Licensed under CC BY-SA 4.0.
+    """
+
+    BASE_URL = "https://permapeople.org/api"
+    KEY_ID_ENV_VAR = "PERMAPEOPLE_KEY_ID"
+    KEY_SECRET_ENV_VAR = "PERMAPEOPLE_KEY_SECRET"
+
+    def __init__(self, key_id: str | None = None, key_secret: str | None = None) -> None:
+        """Initialize the Permapeople client.
+
+        Args:
+            key_id: Optional API key ID. If not provided, will look for
+                   PERMAPEOPLE_KEY_ID environment variable.
+            key_secret: Optional API key secret. If not provided, will look for
+                       PERMAPEOPLE_KEY_SECRET environment variable.
+        """
+        import os
+
+        self._key_id = key_id or os.environ.get(self.KEY_ID_ENV_VAR, "")
+        self._key_secret = key_secret or os.environ.get(self.KEY_SECRET_ENV_VAR, "")
+        self._session = requests.Session()
+        self._session.headers.update({
+            "User-Agent": "OpenGardenPlanner/1.0",
+            "Content-Type": "application/json",
+        })
+
+        if self._key_id and self._key_secret:
+            self._session.headers.update({
+                "x-permapeople-key-id": self._key_id,
+                "x-permapeople-key-secret": self._key_secret,
+            })
+
+    @property
+    def name(self) -> str:
+        """Name of the API service.
+
+        Returns:
+            Service name
+        """
+        return "Permapeople"
+
+    def search(self, query: str, limit: int = 10) -> list[PlantSpeciesData]:
+        """Search for plants by common or scientific name.
+
+        Args:
+            query: Search term (plant name or partial name)
+            limit: Maximum number of results to return
+
+        Returns:
+            List of matching plant species data
+
+        Raises:
+            PlantAPIError: If the API request fails
+        """
+        if not self._key_id or not self._key_secret:
+            raise PlantAPIError(f"{self.name} API credentials not configured")
+
+        try:
+            response = self._session.post(
+                f"{self.BASE_URL}/search",
+                json={"q": query},
+                timeout=10,
+            )
+            response.raise_for_status()
+            data = response.json()
+
+            results: list[PlantSpeciesData] = []
+            for item in data.get("plants", [])[:limit]:
+                try:
+                    plant_data = self._parse_species(item)
+                    results.append(plant_data)
+                except Exception as e:
+                    logger.warning(f"Failed to parse Permapeople plant data: {e}")
+                    continue
+
+            return results
+
+        except requests.RequestException as e:
+            raise PlantAPIError(f"{self.name} API request failed: {e}") from e
+
+    def get_by_id(self, plant_id: str) -> PlantSpeciesData:
+        """Get detailed plant data by Permapeople ID.
+
+        Args:
+            plant_id: Unique identifier in Permapeople's database
+
+        Returns:
+            Complete plant species data
+
+        Raises:
+            PlantAPIError: If the API request fails or plant not found
+        """
+        if not self._key_id or not self._key_secret:
+            raise PlantAPIError(f"{self.name} API credentials not configured")
+
+        try:
+            response = self._session.get(
+                f"{self.BASE_URL}/plants/{plant_id}",
+                timeout=10,
+            )
+            response.raise_for_status()
+            data = response.json()
+
+            return self._parse_species(data)
+
+        except requests.RequestException as e:
+            raise PlantAPIError(f"{self.name} API request failed: {e}") from e
+
+    def is_available(self) -> bool:
+        """Check if the Permapeople API is currently available.
+
+        Returns:
+            True if service can be reached, False otherwise
+        """
+        if not self._key_id or not self._key_secret:
+            return False
+
+        try:
+            # Try to list plants with a limit of 1
+            response = self._session.get(
+                f"{self.BASE_URL}/plants",
+                params={"last_id": 0},
+                timeout=5,
+            )
+            return response.status_code == 200
+        except requests.RequestException:
+            return False
+
+    def _parse_species(self, data: dict[str, Any]) -> PlantSpeciesData:
+        """Parse Permapeople API response into PlantSpeciesData.
+
+        Args:
+            data: Raw API response data
+
+        Returns:
+            Parsed plant species data
+        """
+        scientific_name = data.get("scientific_name", "Unknown")
+        common_name = data.get("name", "Unknown")
+
+        # Parse the flexible key-value data array
+        data_dict: dict[str, str] = {}
+        for item in data.get("data", []):
+            if isinstance(item, dict):
+                key = item.get("key", "")
+                value = item.get("value", "")
+                if key:
+                    data_dict[key.lower()] = value
+
+        # Extract structured data from key-value pairs
+        family = data_dict.get("family", "")
+
+        # Parse cycle
+        cycle = PlantCycle.UNKNOWN
+        # Permapeople uses "Layer" field which might indicate plant type
+
+        # Parse sun requirements
+        light_req = data_dict.get("light requirement", "").lower()
+        sun_req = SunRequirement.UNKNOWN
+        if "full sun" in light_req:
+            sun_req = SunRequirement.FULL_SUN
+        elif "partial sun" in light_req or "partial shade" in light_req:
+            sun_req = SunRequirement.PARTIAL_SHADE
+        elif "shade" in light_req:
+            sun_req = SunRequirement.FULL_SHADE
+
+        # Parse water requirements
+        water_req = data_dict.get("water requirement", "").lower()
+        water_needs = WaterNeeds.UNKNOWN
+        if "dry" in water_req or "minimal" in water_req:
+            water_needs = WaterNeeds.LOW
+        elif "moist" in water_req or "moderate" in water_req:
+            water_needs = WaterNeeds.MEDIUM
+        elif "wet" in water_req or "frequent" in water_req:
+            water_needs = WaterNeeds.HIGH
+
+        # Parse hardiness zone
+        hardiness_str = data_dict.get("usda hardiness zone", "")
+        hardiness_min, hardiness_max = None, None
+        if hardiness_str:
+            # Format might be "3-9" or just "5"
+            parts = hardiness_str.split("-")
+            try:
+                hardiness_min = int(parts[0].strip())
+                hardiness_max = int(parts[1].strip()) if len(parts) > 1 else hardiness_min
+            except ValueError:
+                pass
+
+        # Parse growth rate
+        growth_str = data_dict.get("growth", "").lower()
+        growth_rate = GrowthRate.UNKNOWN
+        if "slow" in growth_str:
+            growth_rate = GrowthRate.SLOW
+        elif "medium" in growth_str or "moderate" in growth_str:
+            growth_rate = GrowthRate.MEDIUM
+        elif "fast" in growth_str or "rapid" in growth_str:
+            growth_rate = GrowthRate.FAST
+
+        # Check if edible
+        edible = data_dict.get("edible", "").lower() == "true"
+        edible_parts_str = data_dict.get("edible parts", "")
+        edible_parts = [part.strip() for part in edible_parts_str.split(",")] if edible_parts_str else []
+
+        soil_type = data_dict.get("soil type", "")
+
+        return PlantSpeciesData(
+            scientific_name=scientific_name,
+            common_name=common_name,
+            family=family,
+            genus="",  # Not always provided
+            cycle=cycle,
+            growth_rate=growth_rate,
+            sun_requirement=sun_req,
+            water_needs=water_needs,
+            hardiness_zone_min=hardiness_min,
+            hardiness_zone_max=hardiness_max,
+            soil_type=soil_type,
+            edible=edible,
+            edible_parts=edible_parts,
+            image_url="",  # Permapeople doesn't provide images in API
+            thumbnail_url="",
+            data_source="permapeople",
+            source_id=str(data.get("id", "")),
+            description=data.get("description", ""),
+            raw_data=data,
+        )

--- a/src/open_garden_planner/services/plant_api/trefle_client.py
+++ b/src/open_garden_planner/services/plant_api/trefle_client.py
@@ -1,0 +1,252 @@
+"""Trefle Plant API client implementation."""
+
+import logging
+from typing import Any
+
+import requests
+
+from open_garden_planner.models.plant_data import (
+    GrowthRate,
+    PlantCycle,
+    PlantSpeciesData,
+    SunRequirement,
+    WaterNeeds,
+)
+
+from .base import PlantAPIClient, PlantAPIError
+
+logger = logging.getLogger(__name__)
+
+
+class TrefleClient(PlantAPIClient):
+    """Client for the Trefle Plant API.
+
+    API Documentation: https://docs.trefle.io/
+    Comprehensive botanical database with 400,000+ species.
+    """
+
+    BASE_URL = "https://trefle.io/api/v1"
+    API_TOKEN_ENV_VAR = "TREFLE_API_TOKEN"
+
+    def __init__(self, api_token: str | None = None) -> None:
+        """Initialize the Trefle client.
+
+        Args:
+            api_token: Optional API token. If not provided, will look for
+                      TREFLE_API_TOKEN environment variable.
+        """
+        import os
+
+        self._api_token = api_token or os.environ.get(self.API_TOKEN_ENV_VAR, "")
+        self._session = requests.Session()
+        self._session.headers.update({"User-Agent": "OpenGardenPlanner/1.0"})
+
+    @property
+    def name(self) -> str:
+        """Name of the API service.
+
+        Returns:
+            Service name
+        """
+        return "Trefle"
+
+    def search(self, query: str, limit: int = 10) -> list[PlantSpeciesData]:
+        """Search for plants by common or scientific name.
+
+        Args:
+            query: Search term (plant name or partial name)
+            limit: Maximum number of results to return
+
+        Returns:
+            List of matching plant species data
+
+        Raises:
+            PlantAPIError: If the API request fails
+        """
+        if not self._api_token:
+            raise PlantAPIError(f"{self.name} API token not configured")
+
+        try:
+            response = self._session.get(
+                f"{self.BASE_URL}/plants/search",
+                params={"token": self._api_token, "q": query},
+                timeout=10,
+            )
+            response.raise_for_status()
+            data = response.json()
+
+            results: list[PlantSpeciesData] = []
+            for item in data.get("data", [])[:limit]:
+                try:
+                    plant_data = self._parse_species(item)
+                    results.append(plant_data)
+                except Exception as e:
+                    logger.warning(f"Failed to parse Trefle plant data: {e}")
+                    continue
+
+            return results
+
+        except requests.RequestException as e:
+            raise PlantAPIError(f"{self.name} API request failed: {e}") from e
+
+    def get_by_id(self, plant_id: str) -> PlantSpeciesData:
+        """Get detailed plant data by Trefle ID.
+
+        Args:
+            plant_id: Unique identifier in Trefle's database (slug or numeric ID)
+
+        Returns:
+            Complete plant species data
+
+        Raises:
+            PlantAPIError: If the API request fails or plant not found
+        """
+        if not self._api_token:
+            raise PlantAPIError(f"{self.name} API token not configured")
+
+        try:
+            response = self._session.get(
+                f"{self.BASE_URL}/plants/{plant_id}",
+                params={"token": self._api_token},
+                timeout=10,
+            )
+            response.raise_for_status()
+            data = response.json()
+
+            # The response has data.main_species for detailed species info
+            plant_data = data.get("data", {})
+            main_species = plant_data.get("main_species", plant_data)
+
+            return self._parse_species(main_species)
+
+        except requests.RequestException as e:
+            raise PlantAPIError(f"{self.name} API request failed: {e}") from e
+
+    def is_available(self) -> bool:
+        """Check if the Trefle API is currently available.
+
+        Returns:
+            True if service can be reached, False otherwise
+        """
+        if not self._api_token:
+            return False
+
+        try:
+            response = self._session.get(
+                f"{self.BASE_URL}/kingdoms",
+                params={"token": self._api_token},
+                timeout=5,
+            )
+            return response.status_code == 200
+        except requests.RequestException:
+            return False
+
+    def _parse_species(self, data: dict[str, Any]) -> PlantSpeciesData:
+        """Parse Trefle API response into PlantSpeciesData.
+
+        Args:
+            data: Raw API response data
+
+        Returns:
+            Parsed plant species data
+        """
+        # Basic info
+        scientific_name = data.get("scientific_name", "Unknown")
+        common_name = data.get("common_name") or "Unknown"
+        family = data.get("family", "")
+        genus = data.get("genus", "")
+
+        # Parse duration/cycle (annual, perennial, etc.)
+        cycle = PlantCycle.UNKNOWN
+        duration_list = data.get("duration", []) or []
+        if duration_list:
+            duration_str = " ".join(duration_list).lower()
+            if "annual" in duration_str:
+                cycle = PlantCycle.ANNUAL
+            elif "biennial" in duration_str:
+                cycle = PlantCycle.BIENNIAL
+            elif "perennial" in duration_str:
+                cycle = PlantCycle.PERENNIAL
+
+        # Parse sun requirements from growth.light (0-10 scale)
+        sun_req = SunRequirement.UNKNOWN
+        growth = data.get("growth", {}) or {}
+        light_level = growth.get("light")
+        if light_level is not None:
+            # Trefle uses 0-10 scale: 0=no light, 10=very intensive
+            if light_level >= 8:
+                sun_req = SunRequirement.FULL_SUN
+            elif light_level >= 5:
+                sun_req = SunRequirement.PARTIAL_SHADE
+            elif light_level >= 0:
+                sun_req = SunRequirement.FULL_SHADE
+
+        # Parse water requirements from growth.atmospheric_humidity (0-10 scale)
+        water_needs = WaterNeeds.UNKNOWN
+        humidity_level = growth.get("atmospheric_humidity")
+        if humidity_level is not None:
+            # Trefle uses 0-10 scale for humidity
+            if humidity_level >= 7:
+                water_needs = WaterNeeds.HIGH
+            elif humidity_level >= 4:
+                water_needs = WaterNeeds.MEDIUM
+            elif humidity_level >= 0:
+                water_needs = WaterNeeds.LOW
+
+        # Growth rate (not directly available in Trefle, would need to infer from days_to_harvest)
+        growth_rate = GrowthRate.UNKNOWN
+        days_to_harvest = growth.get("days_to_harvest")
+        if days_to_harvest:
+            # Rough estimation: <60 days = fast, 60-120 = medium, >120 = slow
+            if days_to_harvest < 60:
+                growth_rate = GrowthRate.FAST
+            elif days_to_harvest < 120:
+                growth_rate = GrowthRate.MEDIUM
+            else:
+                growth_rate = GrowthRate.SLOW
+
+        # Height information
+        specifications = data.get("specifications", {}) or {}
+        max_height_data = specifications.get("maximum_height", {}) or {}
+        max_height_cm = max_height_data.get("cm")
+
+        # Edible information
+        edible = data.get("edible", False)
+        edible_part_list = data.get("edible_part", []) or []
+        edible_parts = [part for part in edible_part_list if part]
+
+        # Image URL
+        image_url = data.get("image_url", "")
+
+        # Flowering information
+        flower = data.get("flower", {}) or {}
+        flower_color = None
+        if flower.get("color"):
+            flower_color = ", ".join(flower["color"])
+
+        # Description from observations or growth description
+        observations = data.get("observations", "")
+        growth_desc = growth.get("description", "")
+        description = observations or growth_desc
+
+        return PlantSpeciesData(
+            scientific_name=scientific_name,
+            common_name=common_name,
+            family=family,
+            genus=genus,
+            cycle=cycle,
+            growth_rate=growth_rate,
+            sun_requirement=sun_req,
+            water_needs=water_needs,
+            max_height_cm=max_height_cm,
+            image_url=image_url,
+            thumbnail_url=image_url,  # Trefle doesn't provide separate thumbnails
+            data_source="trefle",
+            source_id=str(data.get("id", "")),
+            description=description,
+            edible=edible,
+            edible_parts=edible_parts,
+            flowering=flower.get("conspicuous", False),
+            flower_color=flower_color,
+            raw_data=data,
+        )

--- a/src/open_garden_planner/ui/dialogs/__init__.py
+++ b/src/open_garden_planner/ui/dialogs/__init__.py
@@ -2,6 +2,12 @@
 
 from open_garden_planner.ui.dialogs.calibration_dialog import CalibrationDialog
 from open_garden_planner.ui.dialogs.new_project_dialog import NewProjectDialog
+from open_garden_planner.ui.dialogs.plant_search_dialog import PlantSearchDialog
 from open_garden_planner.ui.dialogs.properties_dialog import PropertiesDialog
 
-__all__ = ["CalibrationDialog", "NewProjectDialog", "PropertiesDialog"]
+__all__ = [
+    "CalibrationDialog",
+    "NewProjectDialog",
+    "PlantSearchDialog",
+    "PropertiesDialog",
+]

--- a/src/open_garden_planner/ui/dialogs/plant_search_dialog.py
+++ b/src/open_garden_planner/ui/dialogs/plant_search_dialog.py
@@ -1,0 +1,315 @@
+"""Plant search dialog for finding species from online databases."""
+
+import logging
+
+from PyQt6.QtCore import Qt, QTimer
+from PyQt6.QtWidgets import (
+    QDialog,
+    QDialogButtonBox,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QListWidget,
+    QListWidgetItem,
+    QMessageBox,
+    QPushButton,
+    QTextEdit,
+    QVBoxLayout,
+)
+
+from open_garden_planner.models.plant_data import PlantSpeciesData
+from open_garden_planner.services.plant_api import PlantAPIError, PlantAPIManager
+
+logger = logging.getLogger(__name__)
+
+
+class PlantSearchDialog(QDialog):
+    """Dialog for searching plant species from online databases.
+
+    Allows users to search for plants using the PlantAPIManager,
+    which automatically tries multiple APIs with fallback.
+    """
+
+    def __init__(
+        self,
+        api_manager: PlantAPIManager,
+        parent: object = None,
+    ) -> None:
+        """Initialize the plant search dialog.
+
+        Args:
+            api_manager: PlantAPIManager instance for searching
+            parent: Parent widget
+        """
+        super().__init__(parent)
+
+        self._api_manager = api_manager
+        self._selected_plant: PlantSpeciesData | None = None
+        self._search_timer = QTimer()
+        self._search_timer.setSingleShot(True)
+        self._search_timer.timeout.connect(self._perform_search)
+
+        self.setWindowTitle("Search Plant Species")
+        self.setModal(True)
+        self.setMinimumSize(700, 500)
+
+        self._setup_ui()
+
+    def _setup_ui(self) -> None:
+        """Set up the dialog UI."""
+        layout = QVBoxLayout(self)
+
+        # Search input area
+        search_layout = QHBoxLayout()
+        search_label = QLabel("Search:")
+        self.search_input = QLineEdit()
+        self.search_input.setPlaceholderText("Enter plant common or scientific name...")
+        self.search_input.textChanged.connect(self._on_search_text_changed)
+        self.search_input.returnPressed.connect(self._perform_search)
+
+        self.search_button = QPushButton("Search")
+        self.search_button.clicked.connect(self._perform_search)
+
+        search_layout.addWidget(search_label)
+        search_layout.addWidget(self.search_input)
+        search_layout.addWidget(self.search_button)
+        layout.addLayout(search_layout)
+
+        # Status/info label
+        self.status_label = QLabel("Enter a plant name to search")
+        self.status_label.setStyleSheet("color: gray;")
+        layout.addWidget(self.status_label)
+
+        # Main content area
+        content_layout = QHBoxLayout()
+
+        # Left side: Search results list
+        results_layout = QVBoxLayout()
+        results_label = QLabel("Results:")
+        results_label.setStyleSheet("font-weight: bold;")
+        self.results_list = QListWidget()
+        self.results_list.itemSelectionChanged.connect(self._on_selection_changed)
+        self.results_list.itemDoubleClicked.connect(self._on_result_double_clicked)
+        results_layout.addWidget(results_label)
+        results_layout.addWidget(self.results_list)
+
+        # Right side: Plant details
+        details_layout = QVBoxLayout()
+        details_label = QLabel("Plant Details:")
+        details_label.setStyleSheet("font-weight: bold;")
+        self.details_text = QTextEdit()
+        self.details_text.setReadOnly(True)
+        self.details_text.setPlaceholderText("Select a plant to view details")
+        details_layout.addWidget(details_label)
+        details_layout.addWidget(self.details_text)
+
+        content_layout.addLayout(results_layout, 2)  # 40% width
+        content_layout.addLayout(details_layout, 3)  # 60% width
+        layout.addLayout(content_layout)
+
+        # Dialog buttons
+        button_box = QDialogButtonBox(
+            QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel
+        )
+        button_box.accepted.connect(self._on_accept)
+        button_box.rejected.connect(self.reject)
+        layout.addWidget(button_box)
+
+        self.ok_button = button_box.button(QDialogButtonBox.StandardButton.Ok)
+        self.ok_button.setEnabled(False)  # Disabled until a plant is selected
+
+        # Focus on search input
+        self.search_input.setFocus()
+
+    def _on_search_text_changed(self, text: str) -> None:
+        """Handle search text changes with debouncing.
+
+        Args:
+            text: New search text
+        """
+        # Debounce: wait 500ms after user stops typing before searching
+        self._search_timer.stop()
+        if text.strip():
+            self._search_timer.start(500)
+        else:
+            self.results_list.clear()
+            self.status_label.setText("Enter a plant name to search")
+            self.status_label.setStyleSheet("color: gray;")
+
+    def _perform_search(self) -> None:
+        """Perform plant search using the API manager."""
+        query = self.search_input.text().strip()
+        if not query:
+            return
+
+        # Clear previous results
+        self.results_list.clear()
+        self.details_text.clear()
+        self.ok_button.setEnabled(False)
+        self._selected_plant = None
+
+        # Show searching status
+        self.status_label.setText(f"Searching for '{query}'...")
+        self.status_label.setStyleSheet("color: blue;")
+        self.search_button.setEnabled(False)
+
+        try:
+            # Search using API manager (with automatic fallback)
+            results = self._api_manager.search(query, limit=20)
+
+            if results:
+                # Populate results list
+                for plant_data in results:
+                    item = QListWidgetItem(
+                        f"{plant_data.common_name} ({plant_data.scientific_name})"
+                    )
+                    item.setData(Qt.ItemDataRole.UserRole, plant_data)
+                    self.results_list.addItem(item)
+
+                self.status_label.setText(f"Found {len(results)} results")
+                self.status_label.setStyleSheet("color: green;")
+            else:
+                self.status_label.setText("No results found")
+                self.status_label.setStyleSheet("color: orange;")
+
+        except PlantAPIError as e:
+            self.status_label.setText(f"Search failed: {str(e)}")
+            self.status_label.setStyleSheet("color: red;")
+            logger.error(f"Plant search failed: {e}")
+
+            # Show error dialog
+            QMessageBox.warning(
+                self,
+                "Search Failed",
+                f"Failed to search plant database:\n{str(e)}\n\n"
+                "Please check your internet connection and API credentials.",
+            )
+
+        finally:
+            self.search_button.setEnabled(True)
+
+    def _on_selection_changed(self) -> None:
+        """Handle result selection change."""
+        selected_items = self.results_list.selectedItems()
+        if not selected_items:
+            self.details_text.clear()
+            self.ok_button.setEnabled(False)
+            self._selected_plant = None
+            return
+
+        # Get plant data from selected item
+        item = selected_items[0]
+        plant_data: PlantSpeciesData = item.data(Qt.ItemDataRole.UserRole)
+        self._selected_plant = plant_data
+        self.ok_button.setEnabled(True)
+
+        # Display plant details
+        self._display_plant_details(plant_data)
+
+    def _display_plant_details(self, plant: PlantSpeciesData) -> None:
+        """Display detailed information about a plant.
+
+        Args:
+            plant: Plant species data to display
+        """
+        html = "<html><body style='font-family: sans-serif;'>"
+
+        # Title
+        html += f"<h2>{plant.common_name}</h2>"
+        html += f"<p><i>{plant.scientific_name}</i></p>"
+
+        if plant.description:
+            html += f"<p>{plant.description}</p>"
+
+        html += "<hr>"
+
+        # Botanical info
+        if plant.family or plant.genus:
+            html += "<h3>Botanical Classification</h3><ul>"
+            if plant.family:
+                html += f"<li><b>Family:</b> {plant.family}</li>"
+            if plant.genus:
+                html += f"<li><b>Genus:</b> {plant.genus}</li>"
+            html += "</ul>"
+
+        # Growing requirements
+        html += "<h3>Growing Requirements</h3><ul>"
+        html += f"<li><b>Cycle:</b> {plant.cycle.value.replace('_', ' ').title()}</li>"
+        html += f"<li><b>Sun:</b> {plant.sun_requirement.value.replace('_', ' ').title()}</li>"
+        html += f"<li><b>Water:</b> {plant.water_needs.value.title()}</li>"
+
+        if plant.hardiness_zone_min and plant.hardiness_zone_max:
+            html += f"<li><b>Hardiness Zones:</b> {plant.hardiness_zone_min}-{plant.hardiness_zone_max}</li>"
+        elif plant.hardiness_zone_min:
+            html += f"<li><b>Hardiness Zone:</b> {plant.hardiness_zone_min}</li>"
+
+        if plant.soil_type:
+            html += f"<li><b>Soil:</b> {plant.soil_type}</li>"
+
+        html += "</ul>"
+
+        # Size info
+        if plant.max_height_cm or plant.max_spread_cm:
+            html += "<h3>Size</h3><ul>"
+            if plant.max_height_cm:
+                height_m = plant.max_height_cm / 100
+                html += f"<li><b>Max Height:</b> {height_m:.1f} m</li>"
+            if plant.max_spread_cm:
+                spread_m = plant.max_spread_cm / 100
+                html += f"<li><b>Max Spread:</b> {spread_m:.1f} m</li>"
+            html += "</ul>"
+
+        # Additional attributes
+        if plant.edible or plant.flowering or plant.flower_color:
+            html += "<h3>Attributes</h3><ul>"
+            if plant.edible:
+                html += "<li><b>Edible:</b> Yes"
+                if plant.edible_parts:
+                    html += f" ({', '.join(plant.edible_parts)})"
+                html += "</li>"
+            if plant.flowering:
+                html += "<li><b>Flowering:</b> Yes"
+                if plant.flower_color:
+                    html += f" ({plant.flower_color})"
+                html += "</li>"
+            html += "</ul>"
+
+        # Data source
+        html += "<hr><p style='color: gray; font-size: small;'>"
+        html += f"Source: {plant.data_source.title()}"
+        if plant.source_id:
+            html += f" (ID: {plant.source_id})"
+        html += "</p>"
+
+        html += "</body></html>"
+
+        self.details_text.setHtml(html)
+
+    def _on_result_double_clicked(self, _item: QListWidgetItem) -> None:
+        """Handle double-click on a result (accept immediately).
+
+        Args:
+            _item: Clicked list item (unused)
+        """
+        self._on_accept()
+
+    def _on_accept(self) -> None:
+        """Handle OK button click."""
+        if self._selected_plant is None:
+            QMessageBox.warning(
+                self,
+                "No Selection",
+                "Please select a plant from the search results.",
+            )
+            return
+
+        self.accept()
+
+    @property
+    def selected_plant(self) -> PlantSpeciesData | None:
+        """Get the selected plant species data.
+
+        Returns:
+            Selected plant data, or None if dialog was cancelled
+        """
+        return self._selected_plant

--- a/src/open_garden_planner/ui/panels/__init__.py
+++ b/src/open_garden_planner/ui/panels/__init__.py
@@ -2,10 +2,12 @@
 
 from .drawing_tools_panel import DrawingToolsPanel
 from .layers_panel import LayersPanel
+from .plant_database_panel import PlantDatabasePanel
 from .properties_panel import PropertiesPanel
 
 __all__ = [
     "DrawingToolsPanel",
     "LayersPanel",
+    "PlantDatabasePanel",
     "PropertiesPanel",
 ]

--- a/src/open_garden_planner/ui/panels/plant_database_panel.py
+++ b/src/open_garden_planner/ui/panels/plant_database_panel.py
@@ -1,0 +1,491 @@
+"""Plant database panel for displaying plant species metadata."""
+
+from PyQt6.QtCore import Qt, pyqtSignal
+from PyQt6.QtWidgets import (
+    QCheckBox,
+    QComboBox,
+    QFormLayout,
+    QGraphicsItem,
+    QLabel,
+    QLineEdit,
+    QPushButton,
+    QScrollArea,
+    QVBoxLayout,
+    QWidget,
+)
+
+from open_garden_planner.core.object_types import ObjectType
+from open_garden_planner.models.plant_data import (
+    PlantCycle,
+    PlantSpeciesData,
+    SunRequirement,
+    WaterNeeds,
+)
+
+
+class EditableField(QWidget):
+    """A field that shows a label and allows inline editing on double-click."""
+
+    value_changed = pyqtSignal()
+
+    def __init__(
+        self,
+        field_type: str = "text",
+        enum_class: type | None = None,
+        parent: QWidget | None = None,
+    ) -> None:
+        """Initialize the editable field.
+
+        Args:
+            field_type: Type of field - "text", "enum", "number", "bool"
+            enum_class: Enum class for enum fields
+            parent: Parent widget
+        """
+        super().__init__(parent)
+        self.field_type = field_type
+        self.enum_class = enum_class
+        self._value: str | int | float | bool | None = None
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(0)
+
+        # Common style for consistent sizing
+        common_style = "font-weight: bold; padding: 0px; margin: 0px;"
+
+        # Display label
+        self.label = QLabel()
+        self.label.setWordWrap(True)
+        self.label.setStyleSheet(common_style)
+        self.label.mouseDoubleClickEvent = lambda _: self._start_editing()
+        layout.addWidget(self.label)
+
+        # Edit widgets (hidden by default)
+        if field_type == "text":
+            self.edit_widget = QLineEdit()
+            self.edit_widget.setStyleSheet(common_style)
+            self.edit_widget.editingFinished.connect(self._finish_editing)
+            self.edit_widget.returnPressed.connect(self._finish_editing)
+        elif field_type == "enum":
+            self.edit_widget = QComboBox()
+            self.edit_widget.setStyleSheet(common_style)
+            if enum_class:
+                for item in enum_class:
+                    self.edit_widget.addItem(
+                        item.value.replace("_", " ").title(), item.value
+                    )
+            self.edit_widget.currentIndexChanged.connect(self._finish_editing)
+        elif field_type == "number":
+            self.edit_widget = QLineEdit()
+            self.edit_widget.setStyleSheet(common_style)
+            self.edit_widget.editingFinished.connect(self._finish_editing)
+            self.edit_widget.returnPressed.connect(self._finish_editing)
+        elif field_type == "bool":
+            self.edit_widget = QCheckBox()
+            self.edit_widget.setStyleSheet(common_style)
+            self.edit_widget.stateChanged.connect(self._finish_editing)
+        else:
+            self.edit_widget = QLineEdit()
+            self.edit_widget.setStyleSheet(common_style)
+            self.edit_widget.editingFinished.connect(self._finish_editing)
+
+        self.edit_widget.hide()
+        layout.addWidget(self.edit_widget)
+
+    def set_value(self, value: str | int | float | bool | None) -> None:
+        """Set the field value."""
+        self._value = value
+        if value is None or value == "":
+            self.label.setText("N/A")
+        else:
+            self.label.setText(str(value))
+
+    def get_value(self) -> str | int | float | bool | None:
+        """Get the field value."""
+        return self._value
+
+    def _start_editing(self) -> None:
+        """Start inline editing."""
+        self.label.hide()
+
+        if self.field_type == "text":
+            self.edit_widget.setText(self._value or "")
+            self.edit_widget.selectAll()
+        elif self.field_type == "enum":
+            # Find and select current value
+            index = self.edit_widget.findData(self._value)
+            if index >= 0:
+                self.edit_widget.setCurrentIndex(index)
+        elif self.field_type == "number":
+            self.edit_widget.setText(str(self._value) if self._value else "")
+            self.edit_widget.selectAll()
+        elif self.field_type == "bool":
+            self.edit_widget.setChecked(bool(self._value))
+
+        self.edit_widget.show()
+        self.edit_widget.setFocus()
+
+    def _finish_editing(self) -> None:
+        """Finish inline editing."""
+        old_value = self._value
+
+        if self.field_type == "text":
+            self._value = self.edit_widget.text().strip() or None
+        elif self.field_type == "enum":
+            self._value = self.edit_widget.currentData()
+        elif self.field_type == "number":
+            text = self.edit_widget.text().strip()
+            try:
+                self._value = float(text) if text else None
+            except ValueError:
+                self._value = old_value  # Keep old value if invalid
+        elif self.field_type == "bool":
+            self._value = self.edit_widget.isChecked()
+
+        self.edit_widget.hide()
+        self.set_value(self._value)
+        self.label.show()
+
+        # Emit signal if value changed
+        if self._value != old_value:
+            self.value_changed.emit()
+
+
+class PlantDatabasePanel(QWidget):
+    """Panel for displaying plant species information from the database.
+
+    Shows botanical and growing information when a plant object is selected.
+    Allows inline editing of all fields.
+    """
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        """Initialize the plant database panel.
+
+        Args:
+            parent: Parent widget
+        """
+        super().__init__(parent)
+        self._current_plant_data: PlantSpeciesData | None = None
+        self._current_plant_item: QGraphicsItem | None = None
+        self._setup_ui()
+
+    def _setup_ui(self) -> None:
+        """Set up the UI components."""
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(4, 4, 4, 4)
+        layout.setSpacing(8)
+
+        # Search button at top
+        self.search_button = QPushButton("Search Plant Database")
+        self.search_button.setToolTip("Search for plant species in online databases")
+        layout.addWidget(self.search_button)
+
+        # Scrollable area for plant info
+        scroll = QScrollArea()
+        scroll.setWidgetResizable(True)
+        scroll.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+
+        # Container for plant info
+        self.info_widget = QWidget()
+        self.info_layout = QVBoxLayout(self.info_widget)
+        self.info_layout.setContentsMargins(4, 4, 4, 4)
+        self.info_layout.setSpacing(4)
+
+        # Info labels
+        self.no_selection_label = QLabel("Select a plant to view details")
+        self.no_selection_label.setWordWrap(True)
+        self.no_selection_label.setStyleSheet("color: gray; font-style: italic;")
+        self.info_layout.addWidget(self.no_selection_label)
+
+        # Form layout for plant details (hidden initially)
+        self.details_form = QFormLayout()
+        self.details_form.setSpacing(4)
+        self.info_layout.addLayout(self.details_form)
+
+        # Editable fields
+        self._create_editable_fields()
+
+        self.info_layout.addStretch()
+
+        scroll.setWidget(self.info_widget)
+        layout.addWidget(scroll)
+
+        # Initially hide details
+        self._hide_details()
+
+    def _create_editable_fields(self) -> None:
+        """Create editable fields for displaying plant information."""
+        # Scientific name
+        self.scientific_field = EditableField("text")
+        self.scientific_field.value_changed.connect(self._on_field_changed)
+        self.details_form.addRow("Scientific:", self.scientific_field)
+
+        # Common name
+        self.common_field = EditableField("text")
+        self.common_field.value_changed.connect(self._on_field_changed)
+        self.details_form.addRow("Common:", self.common_field)
+
+        # Family
+        self.family_field = EditableField("text")
+        self.family_field.value_changed.connect(self._on_field_changed)
+        self.details_form.addRow("Family:", self.family_field)
+
+        # Cycle (annual/perennial)
+        self.cycle_field = EditableField("enum", PlantCycle)
+        self.cycle_field.value_changed.connect(self._on_field_changed)
+        self.details_form.addRow("Cycle:", self.cycle_field)
+
+        # Sun requirements
+        self.sun_field = EditableField("enum", SunRequirement)
+        self.sun_field.value_changed.connect(self._on_field_changed)
+        self.details_form.addRow("Sun:", self.sun_field)
+
+        # Water needs
+        self.water_field = EditableField("enum", WaterNeeds)
+        self.water_field.value_changed.connect(self._on_field_changed)
+        self.details_form.addRow("Water:", self.water_field)
+
+        # Height (max)
+        self.height_field = EditableField("number")
+        self.height_field.value_changed.connect(self._on_field_changed)
+        self.details_form.addRow("Max Height (cm):", self.height_field)
+
+        # Hardiness zones
+        self.hardiness_min_field = EditableField("number")
+        self.hardiness_min_field.value_changed.connect(self._on_field_changed)
+        self.details_form.addRow("Hardiness Min:", self.hardiness_min_field)
+
+        self.hardiness_max_field = EditableField("number")
+        self.hardiness_max_field.value_changed.connect(self._on_field_changed)
+        self.details_form.addRow("Hardiness Max:", self.hardiness_max_field)
+
+        # Edible
+        self.edible_field = EditableField("bool")
+        self.edible_field.value_changed.connect(self._on_field_changed)
+        self.details_form.addRow("Edible:", self.edible_field)
+
+        # Edible parts
+        self.edible_parts_field = EditableField("text")
+        self.edible_parts_field.value_changed.connect(self._on_field_changed)
+        self.details_form.addRow("Edible Parts:", self.edible_parts_field)
+
+        # Data source (read-only)
+        self.source_label = QLabel()
+        self.source_label.setStyleSheet("color: gray; font-size: 10pt;")
+        self.details_form.addRow("Source:", self.source_label)
+
+    def _on_field_changed(self) -> None:
+        """Handle field value changes - update plant metadata."""
+        if not self._current_plant_item or not self._current_plant_data:
+            return
+
+        # Update the PlantSpeciesData object
+        self._current_plant_data.scientific_name = (
+            self.scientific_field.get_value() or "Unknown"
+        )
+        self._current_plant_data.common_name = self.common_field.get_value() or ""
+        self._current_plant_data.family = self.family_field.get_value() or ""
+
+        # Enums
+        cycle_val = self.cycle_field.get_value()
+        if cycle_val:
+            self._current_plant_data.cycle = PlantCycle(cycle_val)
+
+        sun_val = self.sun_field.get_value()
+        if sun_val:
+            self._current_plant_data.sun_requirement = SunRequirement(sun_val)
+
+        water_val = self.water_field.get_value()
+        if water_val:
+            self._current_plant_data.water_needs = WaterNeeds(water_val)
+
+        # Numbers
+        height_val = self.height_field.get_value()
+        self._current_plant_data.max_height_cm = float(height_val) if height_val else None
+
+        hardiness_min = self.hardiness_min_field.get_value()
+        self._current_plant_data.hardiness_zone_min = (
+            int(hardiness_min) if hardiness_min else None
+        )
+
+        hardiness_max = self.hardiness_max_field.get_value()
+        self._current_plant_data.hardiness_zone_max = (
+            int(hardiness_max) if hardiness_max else None
+        )
+
+        # Boolean
+        self._current_plant_data.edible = bool(self.edible_field.get_value())
+
+        # Edible parts (comma-separated list)
+        edible_parts_str = self.edible_parts_field.get_value()
+        if edible_parts_str:
+            self._current_plant_data.edible_parts = [
+                p.strip() for p in str(edible_parts_str).split(",") if p.strip()
+            ]
+        else:
+            self._current_plant_data.edible_parts = []
+
+        # Save back to item metadata
+        if hasattr(self._current_plant_item, "metadata"):
+            if not self._current_plant_item.metadata:
+                self._current_plant_item.metadata = {}
+            self._current_plant_item.metadata["plant_species"] = (
+                self._current_plant_data.to_dict()
+            )
+
+            # Mark project as dirty
+            scene = self._current_plant_item.scene()
+            if scene and hasattr(scene, "views"):
+                for view in scene.views():
+                    if hasattr(view, "window"):
+                        window = view.window()
+                        if hasattr(window, "_project_manager"):
+                            window._project_manager.mark_dirty()
+                            break
+
+    def set_selected_items(self, items: list[QGraphicsItem]) -> None:
+        """Update panel based on selected items.
+
+        Args:
+            items: List of selected graphics items
+        """
+        # Check if exactly one plant item is selected
+        if len(items) != 1:
+            self._hide_details()
+            return
+
+        item = items[0]
+
+        # Check if it's a plant type
+        if not hasattr(item, "object_type"):
+            self._hide_details()
+            return
+
+        object_type = item.object_type
+        if object_type not in (ObjectType.TREE, ObjectType.SHRUB, ObjectType.PERENNIAL):
+            self._hide_details()
+            return
+
+        # Check if it has plant metadata
+        if not hasattr(item, "metadata") or not item.metadata:
+            self._show_no_metadata()
+            return
+
+        # Try to load plant species data from metadata
+        species_data = item.metadata.get("plant_species")
+        if not species_data:
+            self._show_no_metadata()
+            return
+
+        # Deserialize and display
+        try:
+            if isinstance(species_data, dict):
+                plant_data = PlantSpeciesData.from_dict(species_data)
+                self._show_plant_data(plant_data, item)
+            elif isinstance(species_data, PlantSpeciesData):
+                self._show_plant_data(species_data, item)
+            else:
+                self._show_no_metadata()
+        except Exception:
+            self._show_no_metadata()
+
+    def _hide_details(self) -> None:
+        """Hide plant details and show 'no selection' message."""
+        self._current_plant_data = None
+        self._current_plant_item = None
+        self.no_selection_label.setText("Select a plant to view details")
+        self.no_selection_label.setVisible(True)
+
+        # Hide all form widgets
+        for i in range(self.details_form.rowCount()):
+            label_item = self.details_form.itemAt(i, QFormLayout.ItemRole.LabelRole)
+            field_item = self.details_form.itemAt(i, QFormLayout.ItemRole.FieldRole)
+            if label_item and label_item.widget():
+                label_item.widget().setVisible(False)
+            if field_item and field_item.widget():
+                field_item.widget().setVisible(False)
+
+    def _show_no_metadata(self) -> None:
+        """Show message that selected plant has no metadata."""
+        self._current_plant_data = None
+        self._current_plant_item = None
+        self.no_selection_label.setText(
+            "No species data.\n\nClick 'Search Plant Database' to add species information."
+        )
+        self.no_selection_label.setVisible(True)
+
+        # Hide all form widgets
+        for i in range(self.details_form.rowCount()):
+            label_item = self.details_form.itemAt(i, QFormLayout.ItemRole.LabelRole)
+            field_item = self.details_form.itemAt(i, QFormLayout.ItemRole.FieldRole)
+            if label_item and label_item.widget():
+                label_item.widget().setVisible(False)
+            if field_item and field_item.widget():
+                field_item.widget().setVisible(False)
+
+    def _show_plant_data(
+        self, plant_data: PlantSpeciesData, plant_item: QGraphicsItem
+    ) -> None:
+        """Display plant species data.
+
+        Args:
+            plant_data: Plant species data to display
+            plant_item: The graphics item this data belongs to
+        """
+        self._current_plant_data = plant_data
+        self._current_plant_item = plant_item
+        self.no_selection_label.setVisible(False)
+
+        # Show all form widgets
+        for i in range(self.details_form.rowCount()):
+            label_item = self.details_form.itemAt(i, QFormLayout.ItemRole.LabelRole)
+            field_item = self.details_form.itemAt(i, QFormLayout.ItemRole.FieldRole)
+            if label_item and label_item.widget():
+                label_item.widget().setVisible(True)
+            if field_item and field_item.widget():
+                field_item.widget().setVisible(True)
+
+        # Update field values
+        self.scientific_field.set_value(plant_data.scientific_name)
+        self.common_field.set_value(plant_data.common_name or "N/A")
+        self.family_field.set_value(plant_data.family or "N/A")
+
+        # Enums
+        self.cycle_field.set_value(plant_data.cycle.value)
+        self.sun_field.set_value(plant_data.sun_requirement.value)
+        self.water_field.set_value(plant_data.water_needs.value)
+
+        # Height
+        if plant_data.max_height_cm:
+            self.height_field.set_value(
+                f"{plant_data.max_height_cm:.0f} cm ({plant_data.max_height_cm/100:.1f} m)"
+            )
+            # Store raw value for editing
+            self.height_field._value = plant_data.max_height_cm
+        else:
+            self.height_field.set_value(None)
+
+        # Hardiness
+        self.hardiness_min_field.set_value(
+            plant_data.hardiness_zone_min if plant_data.hardiness_zone_min else None
+        )
+        self.hardiness_max_field.set_value(
+            plant_data.hardiness_zone_max if plant_data.hardiness_zone_max else None
+        )
+
+        # Edible
+        self.edible_field.set_value("Yes" if plant_data.edible else "No")
+        self.edible_field._value = plant_data.edible
+
+        # Edible parts
+        if plant_data.edible_parts:
+            parts_text = ", ".join(plant_data.edible_parts)
+            self.edible_parts_field.set_value(parts_text)
+        else:
+            self.edible_parts_field.set_value(None)
+
+        # Data source (read-only)
+        source_text = f"{plant_data.data_source.title()}"
+        if plant_data.source_id:
+            source_text += f" (ID: {plant_data.source_id})"
+        self.source_label.setText(source_text)


### PR DESCRIPTION
## Summary

Implements US-4.3: Plant Species Search from Online Database

This PR adds comprehensive plant database integration, allowing users to search for plant species from online databases and attach botanical metadata to plant objects with inline editing capabilities.

## Features

### Plant Species Search
- **Search Dialog**: Accessible via `Ctrl+K` or Plants → Search Plant Database menu
- **Multi-API Integration**: Trefle.io (primary), Perenual (secondary), Permapeople (tertiary)
- **Automatic Fallback**: If one API fails, automatically tries the next
- **Search Results**: Display common name, scientific name, and cycle information
- **Live Search**: Debounced search with 500ms delay for responsive UX

### Plant Database Panel
- **Dedicated Sidebar**: New "Plant Database" panel in sidebar
- **Inline Editing**: Double-click any field to edit (like layer names)
- **Text Fields**: Scientific name, common name, family, edible parts
- **Enum Dropdowns**: Cycle (annual/perennial), sun requirements, water needs
- **Number Fields**: Max height (cm), hardiness zones (min/max)
- **Checkbox**: Edible yes/no indicator
- **Read-only Source**: Shows which database the data came from

### Data Model
- **Unified Schema**: All APIs normalize to common PlantSpeciesData model
- **Complete Metadata**: 30+ fields including growth characteristics, environmental requirements, edibility
- **Direct Storage**: Metadata saved directly in .ogp JSON format (no separate database)
- **Extensible**: raw_data field preserves API-specific information

## Technical Details

### New Files
- `src/open_garden_planner/models/plant_data.py` - PlantSpeciesData dataclass with serialization
- `src/open_garden_planner/services/plant_api/` - API client implementations (base, manager, trefle, perenual, permapeople)
- `src/open_garden_planner/ui/dialogs/plant_search_dialog.py` - Search dialog with live results
- `src/open_garden_planner/ui/panels/plant_database_panel.py` - Metadata display/edit panel with EditableField widget
- `docs/PLANT_API_SETUP.md` - API setup documentation

### Dependencies
- Added `python-dotenv>=1.0.0` for environment variable management

### Key Changes
- Updated `main.py` to load `.env` file at startup for API credentials
- Added Plants menu to `application.py` with search integration
- Runtime guards in `application.py` to prevent Qt object deletion crashes
- Updated `.gitignore` to exclude `.env` files

### API Integration
- **Trefle.io**: Primary source, 400,000+ species, comprehensive data
- **Perenual**: Secondary fallback, well-maintained API
- **Permapeople**: Tertiary fallback, community-driven database
- Fallback chain automatically tries next API if one fails
- Credentials loaded from `.env` file (see docs/PLANT_API_SETUP.md)

## Test Plan

- [x] All 406 existing tests pass
- [x] Linting clean (ruff)
- [x] Search for "tomato" returns results from Trefle
- [x] Search for "rose" returns results with proper formatting
- [x] Select a plant object, search for species, assign metadata
- [x] Metadata displays in Plant Database panel
- [x] Double-click fields to edit (text, enum dropdowns, numbers, checkbox)
- [x] Edited values save back to plant metadata
- [x] Project marked as dirty after metadata changes
- [x] Metadata persists in .ogp file save/load
- [x] No crashes when opening/closing search dialog

## Documentation

- Updated `CLAUDE.md` progress tracker (US-4.3 complete)
- Updated `prd.md` with completed user story
- Added `docs/PLANT_API_SETUP.md` with API setup instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)