### PR TITLE
feat(US-5.6): Add welcome screen with recent projects

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,7 +156,7 @@ tests/
 | ✅     | 5.3 | Export plant list as CSV                   |
 | ✅     | 5.4 | Keyboard shortcuts for all actions         |
 |        | 5.5 | Light/dark mode switch                     |
-|        | 5.6 | Welcome screen with recent projects        |
+| ✅     | 5.6 | Welcome screen with recent projects        |
 | ✅     | 5.7 | Auto-save periodically                     |
 |        | 5.8 | Professional SVG icons for tools           |
 

--- a/prd.md
+++ b/prd.md
@@ -690,7 +690,7 @@ open_garden_planner/
 | US-5.3 | As a user, I can export a plant list as CSV | Should |
 | ~~US-5.4~~ | ~~As a user, I can use keyboard shortcuts for all common actions~~ | ✅ Should |
 | US-5.5 | As a user, I can switch between light and dark mode | Should |
-| US-5.6 | As a user, I see a welcome screen with recent projects | Should |
+| ~~US-5.6~~ | ~~As a user, I see a welcome screen with recent projects~~ | ✅ Should |
 | ~~US-5.7~~ | ~~As a user, my work is auto-saved periodically~~ | ✅ Must |
 | US-5.8 | As a user, I have professional, consistent SVG icons for all drawing tools | Should |
 

--- a/src/open_garden_planner/app/settings.py
+++ b/src/open_garden_planner/app/settings.py
@@ -21,9 +21,11 @@ class AppSettings:
     KEY_RECENT_FILES = "recent_files"
     KEY_WINDOW_GEOMETRY = "window/geometry"
     KEY_WINDOW_STATE = "window/state"
+    KEY_SHOW_WELCOME = "startup/show_welcome"
 
     # Default values
     DEFAULT_AUTOSAVE_ENABLED = True
+    DEFAULT_SHOW_WELCOME = True
     DEFAULT_AUTOSAVE_INTERVAL_MINUTES = 5
     MIN_AUTOSAVE_INTERVAL_MINUTES = 1
     MAX_AUTOSAVE_INTERVAL_MINUTES = 30
@@ -99,6 +101,20 @@ class AppSettings:
     def clear_recent_files(self) -> None:
         """Clear the recent files list."""
         self.recent_files = []
+
+    @property
+    def show_welcome_on_startup(self) -> bool:
+        """Whether to show welcome screen on startup."""
+        return self._settings.value(
+            self.KEY_SHOW_WELCOME,
+            self.DEFAULT_SHOW_WELCOME,
+            type=bool,
+        )
+
+    @show_welcome_on_startup.setter
+    def show_welcome_on_startup(self, show: bool) -> None:
+        """Set whether to show welcome screen on startup."""
+        self._settings.setValue(self.KEY_SHOW_WELCOME, show)
 
     @property
     def window_geometry(self) -> bytes | None:

--- a/src/open_garden_planner/core/project.py
+++ b/src/open_garden_planner/core/project.py
@@ -14,6 +14,7 @@ from PyQt6.QtCore import QObject, QPointF, pyqtSignal
 from PyQt6.QtGui import QColor
 from PyQt6.QtWidgets import QGraphicsItem, QGraphicsScene
 
+from open_garden_planner.app.settings import get_settings
 from open_garden_planner.core.fill_patterns import FillPattern, create_pattern_brush
 from open_garden_planner.core.object_types import StrokeStyle
 from open_garden_planner.models.layer import Layer, create_default_layers
@@ -128,6 +129,9 @@ class ProjectManager(QObject):
         self.mark_clean()
         self.project_changed.emit(str(file_path))
 
+        # Track in recent files
+        get_settings().add_recent_file(str(file_path))
+
     def load(self, scene: QGraphicsScene, file_path: Path) -> None:
         """Load a project from a file.
 
@@ -147,6 +151,9 @@ class ProjectManager(QObject):
         self._current_file = file_path
         self.mark_clean()
         self.project_changed.emit(str(file_path))
+
+        # Track in recent files
+        get_settings().add_recent_file(str(file_path))
 
     def _sync_custom_plants(self, scene: QGraphicsScene) -> None:
         """Sync custom plants from loaded project to app library.

--- a/src/open_garden_planner/ui/dialogs/__init__.py
+++ b/src/open_garden_planner/ui/dialogs/__init__.py
@@ -6,6 +6,7 @@ from open_garden_planner.ui.dialogs.new_project_dialog import NewProjectDialog
 from open_garden_planner.ui.dialogs.plant_search_dialog import PlantSearchDialog
 from open_garden_planner.ui.dialogs.properties_dialog import PropertiesDialog
 from open_garden_planner.ui.dialogs.shortcuts_dialog import ShortcutsDialog
+from open_garden_planner.ui.dialogs.welcome_dialog import WelcomeDialog
 
 __all__ = [
     "CalibrationDialog",
@@ -14,4 +15,5 @@ __all__ = [
     "PlantSearchDialog",
     "PropertiesDialog",
     "ShortcutsDialog",
+    "WelcomeDialog",
 ]

--- a/src/open_garden_planner/ui/dialogs/welcome_dialog.py
+++ b/src/open_garden_planner/ui/dialogs/welcome_dialog.py
@@ -1,0 +1,326 @@
+"""Welcome dialog shown at application startup."""
+
+from pathlib import Path
+
+from PyQt6.QtCore import Qt, pyqtSignal
+from PyQt6.QtGui import QFont, QPixmap
+from PyQt6.QtWidgets import (
+    QCheckBox,
+    QDialog,
+    QFrame,
+    QHBoxLayout,
+    QLabel,
+    QListWidget,
+    QListWidgetItem,
+    QPushButton,
+    QVBoxLayout,
+    QWidget,
+)
+
+from open_garden_planner.app.settings import get_settings
+
+
+class WelcomeDialog(QDialog):
+    """Welcome screen shown at application startup.
+
+    Displays the application logo, recent projects list, and quick actions
+    for creating a new project or opening an existing one.
+
+    Signals:
+        new_project_requested: Emitted when user clicks "New Project"
+        open_project_requested: Emitted when user clicks "Open Project"
+        recent_project_selected: Emitted with file path when user selects a recent project
+    """
+
+    new_project_requested = pyqtSignal()
+    open_project_requested = pyqtSignal()
+    recent_project_selected = pyqtSignal(str)
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        """Initialize the Welcome dialog."""
+        super().__init__(parent)
+
+        self.setWindowTitle("Welcome to Open Garden Planner")
+        self.setModal(True)
+        self.setMinimumSize(600, 500)
+        self.setMaximumSize(800, 700)
+
+        self._selected_file: str | None = None
+        self._setup_ui()
+
+    def _setup_ui(self) -> None:
+        """Set up the dialog UI."""
+        layout = QVBoxLayout(self)
+        layout.setSpacing(20)
+        layout.setContentsMargins(30, 30, 30, 30)
+
+        # Banner/Logo at top
+        self._setup_banner(layout)
+
+        # Main content area with recent projects and actions
+        content_layout = QHBoxLayout()
+        content_layout.setSpacing(30)
+
+        # Left side: Recent Projects
+        self._setup_recent_projects(content_layout)
+
+        # Right side: Actions
+        self._setup_actions(content_layout)
+
+        layout.addLayout(content_layout, stretch=1)
+
+        # Bottom: Don't show again checkbox
+        self._setup_footer(layout)
+
+    def _setup_banner(self, layout: QVBoxLayout) -> None:
+        """Set up the banner image at the top."""
+        banner_label = QLabel()
+        banner_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+
+        # Load banner image
+        resources_dir = Path(__file__).parent.parent.parent / "resources" / "icons"
+        banner_path = resources_dir / "banner.png"
+
+        if banner_path.exists():
+            pixmap = QPixmap(str(banner_path))
+            # Scale to fit dialog width while maintaining aspect ratio
+            scaled = pixmap.scaledToWidth(
+                540, Qt.TransformationMode.SmoothTransformation
+            )
+            banner_label.setPixmap(scaled)
+        else:
+            # Fallback if banner not found
+            banner_label.setText("Open Garden Planner")
+            font = QFont()
+            font.setPointSize(24)
+            font.setBold(True)
+            banner_label.setFont(font)
+
+        layout.addWidget(banner_label)
+
+    def _setup_recent_projects(self, layout: QHBoxLayout) -> None:
+        """Set up the recent projects list."""
+        recent_widget = QWidget()
+        recent_layout = QVBoxLayout(recent_widget)
+        recent_layout.setContentsMargins(0, 0, 0, 0)
+        recent_layout.setSpacing(10)
+
+        # Header
+        header = QLabel("Recent Projects")
+        header_font = QFont()
+        header_font.setPointSize(12)
+        header_font.setBold(True)
+        header.setFont(header_font)
+        recent_layout.addWidget(header)
+
+        # List widget for recent files - use native styling
+        self._recent_list = QListWidget()
+        self._recent_list.setAlternatingRowColors(True)
+        self._recent_list.itemDoubleClicked.connect(self._on_recent_double_clicked)
+        self._recent_list.itemSelectionChanged.connect(self._on_selection_changed)
+
+        # Populate recent files
+        self._populate_recent_files()
+
+        recent_layout.addWidget(self._recent_list, stretch=1)
+
+        # Clear recent button - use native styling
+        clear_btn = QPushButton("Clear Recent")
+        clear_btn.clicked.connect(self._on_clear_recent)
+        recent_layout.addWidget(clear_btn)
+
+        layout.addWidget(recent_widget, stretch=2)
+
+    def _setup_actions(self, layout: QHBoxLayout) -> None:
+        """Set up the action buttons."""
+        actions_widget = QWidget()
+        actions_layout = QVBoxLayout(actions_widget)
+        actions_layout.setContentsMargins(0, 0, 0, 0)
+        actions_layout.setSpacing(15)
+
+        # Header
+        header = QLabel("Get Started")
+        header_font = QFont()
+        header_font.setPointSize(12)
+        header_font.setBold(True)
+        header.setFont(header_font)
+        actions_layout.addWidget(header)
+
+        # Primary button style (green background - works in both themes)
+        primary_button_style = """
+            QPushButton {
+                padding: 15px 20px;
+                font-size: 14px;
+                font-weight: bold;
+                border: none;
+                border-radius: 6px;
+                background-color: #4CAF50;
+                color: white;
+            }
+            QPushButton:hover {
+                background-color: #43A047;
+            }
+            QPushButton:pressed {
+                background-color: #388E3C;
+            }
+        """
+
+        # Secondary button style (green border - works in both themes)
+        secondary_button_style = """
+            QPushButton {
+                padding: 15px 20px;
+                font-size: 14px;
+                border: 2px solid #4CAF50;
+                border-radius: 6px;
+                color: #4CAF50;
+            }
+            QPushButton:hover {
+                background-color: rgba(76, 175, 80, 0.1);
+            }
+            QPushButton:pressed {
+                background-color: rgba(76, 175, 80, 0.2);
+            }
+            QPushButton:disabled {
+                border-color: gray;
+                color: gray;
+            }
+        """
+
+        # New Project button (primary)
+        new_project_btn = QPushButton("New Project")
+        new_project_btn.setStyleSheet(primary_button_style)
+        new_project_btn.clicked.connect(self._on_new_project)
+        actions_layout.addWidget(new_project_btn)
+
+        # Open Project button
+        open_project_btn = QPushButton("Open Project...")
+        open_project_btn.setStyleSheet(secondary_button_style)
+        open_project_btn.clicked.connect(self._on_open_project)
+        actions_layout.addWidget(open_project_btn)
+
+        # Open Selected button (for recent projects)
+        self._open_selected_btn = QPushButton("Open Selected")
+        self._open_selected_btn.setStyleSheet(secondary_button_style)
+        self._open_selected_btn.setEnabled(False)
+        self._open_selected_btn.clicked.connect(self._on_open_selected)
+        actions_layout.addWidget(self._open_selected_btn)
+
+        # Separator
+        separator = QFrame()
+        separator.setFrameShape(QFrame.Shape.HLine)
+        separator.setFrameShadow(QFrame.Shadow.Sunken)
+        actions_layout.addWidget(separator)
+
+        # Tips section - use default text color
+        tips_label = QLabel(
+            "<b>Tip:</b> Double-click a recent project to open it directly."
+        )
+        tips_label.setWordWrap(True)
+        actions_layout.addWidget(tips_label)
+
+        actions_layout.addStretch()
+
+        layout.addWidget(actions_widget, stretch=1)
+
+    def _setup_footer(self, layout: QVBoxLayout) -> None:
+        """Set up the footer with the checkbox."""
+        footer_layout = QHBoxLayout()
+
+        self._show_on_startup_checkbox = QCheckBox("Show this screen on startup")
+        self._show_on_startup_checkbox.setChecked(get_settings().show_welcome_on_startup)
+        self._show_on_startup_checkbox.stateChanged.connect(self._on_checkbox_changed)
+
+        footer_layout.addWidget(self._show_on_startup_checkbox)
+        footer_layout.addStretch()
+
+        # Close button - use native styling
+        close_btn = QPushButton("Close")
+        close_btn.clicked.connect(self.reject)
+        footer_layout.addWidget(close_btn)
+
+        layout.addLayout(footer_layout)
+
+    def _populate_recent_files(self) -> None:
+        """Populate the recent files list."""
+        self._recent_list.clear()
+        recent_files = get_settings().recent_files
+
+        if not recent_files:
+            # Show placeholder
+            placeholder = QListWidgetItem("No recent projects")
+            placeholder.setFlags(Qt.ItemFlag.NoItemFlags)
+            placeholder.setForeground(Qt.GlobalColor.gray)
+            self._recent_list.addItem(placeholder)
+            return
+
+        for file_path in recent_files:
+            path = Path(file_path)
+            if path.exists():
+                item = QListWidgetItem()
+                item.setText(path.stem)
+                item.setToolTip(str(path))
+                item.setData(Qt.ItemDataRole.UserRole, str(path))
+                self._recent_list.addItem(item)
+            else:
+                # Show missing files with indicator
+                item = QListWidgetItem()
+                item.setText(f"{path.stem} (not found)")
+                item.setToolTip(f"File not found: {path}")
+                item.setData(Qt.ItemDataRole.UserRole, str(path))
+                item.setForeground(Qt.GlobalColor.gray)
+                self._recent_list.addItem(item)
+
+    def _on_selection_changed(self) -> None:
+        """Handle selection change in recent list."""
+        selected_items = self._recent_list.selectedItems()
+        if selected_items:
+            item = selected_items[0]
+            file_path = item.data(Qt.ItemDataRole.UserRole)
+            if file_path and Path(file_path).exists():
+                self._selected_file = file_path
+                self._open_selected_btn.setEnabled(True)
+            else:
+                self._selected_file = None
+                self._open_selected_btn.setEnabled(False)
+        else:
+            self._selected_file = None
+            self._open_selected_btn.setEnabled(False)
+
+    def _on_recent_double_clicked(self, item: QListWidgetItem) -> None:
+        """Handle double-click on a recent project."""
+        file_path = item.data(Qt.ItemDataRole.UserRole)
+        if file_path and Path(file_path).exists():
+            self.recent_project_selected.emit(file_path)
+            self.accept()
+
+    def _on_new_project(self) -> None:
+        """Handle New Project button click."""
+        self.new_project_requested.emit()
+        self.accept()
+
+    def _on_open_project(self) -> None:
+        """Handle Open Project button click."""
+        self.open_project_requested.emit()
+        self.accept()
+
+    def _on_open_selected(self) -> None:
+        """Handle Open Selected button click."""
+        if self._selected_file:
+            self.recent_project_selected.emit(self._selected_file)
+            self.accept()
+
+    def _on_clear_recent(self) -> None:
+        """Handle Clear Recent button click."""
+        get_settings().clear_recent_files()
+        self._populate_recent_files()
+        self._open_selected_btn.setEnabled(False)
+        self._selected_file = None
+
+    def _on_checkbox_changed(self, state: int) -> None:
+        """Handle checkbox state change."""
+        get_settings().show_welcome_on_startup = state == Qt.CheckState.Checked.value
+
+    @property
+    def selected_file(self) -> str | None:
+        """Get the selected file path, if any."""
+        return self._selected_file

--- a/tests/ui/test_welcome_dialog.py
+++ b/tests/ui/test_welcome_dialog.py
@@ -1,0 +1,115 @@
+"""Tests for the Welcome dialog."""
+
+import pytest
+from PyQt6.QtCore import Qt
+from PyQt6.QtWidgets import QCheckBox, QListWidget, QPushButton
+
+from open_garden_planner.app.settings import get_settings
+from open_garden_planner.ui.dialogs import WelcomeDialog
+
+
+class TestWelcomeDialog:
+    """Tests for WelcomeDialog."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self, qtbot):  # noqa: ARG002
+        """Set up test fixtures."""
+        # Clear recent files before each test
+        get_settings().clear_recent_files()
+
+    def test_dialog_creation(self, qtbot):  # noqa: ARG002
+        """Test that dialog can be created."""
+        dialog = WelcomeDialog()
+        assert dialog is not None
+
+    def test_dialog_title(self, qtbot):  # noqa: ARG002
+        """Test dialog has correct title."""
+        dialog = WelcomeDialog()
+        assert "Welcome" in dialog.windowTitle()
+
+    def test_dialog_is_modal(self, qtbot):  # noqa: ARG002
+        """Test dialog is modal."""
+        dialog = WelcomeDialog()
+        assert dialog.isModal()
+
+    def test_dialog_has_new_project_button(self, qtbot):  # noqa: ARG002
+        """Test dialog has New Project button."""
+        dialog = WelcomeDialog()
+        buttons = dialog.findChildren(QPushButton)
+        button_texts = [b.text() for b in buttons]
+        assert "New Project" in button_texts
+
+    def test_dialog_has_open_project_button(self, qtbot):  # noqa: ARG002
+        """Test dialog has Open Project button."""
+        dialog = WelcomeDialog()
+        buttons = dialog.findChildren(QPushButton)
+        button_texts = [b.text() for b in buttons]
+        assert "Open Project..." in button_texts
+
+    def test_dialog_has_recent_list(self, qtbot):  # noqa: ARG002
+        """Test dialog has recent projects list."""
+        dialog = WelcomeDialog()
+        list_widget = dialog.findChild(QListWidget)
+        assert list_widget is not None
+
+    def test_dialog_has_checkbox(self, qtbot):  # noqa: ARG002
+        """Test dialog has 'show on startup' checkbox."""
+        dialog = WelcomeDialog()
+        checkbox = dialog.findChild(QCheckBox)
+        assert checkbox is not None
+        assert "startup" in checkbox.text().lower()
+
+    def test_new_project_signal(self, qtbot):  # noqa: ARG002
+        """Test new project signal is emitted."""
+        dialog = WelcomeDialog()
+        buttons = dialog.findChildren(QPushButton)
+        new_button = next(b for b in buttons if b.text() == "New Project")
+
+        with qtbot.waitSignal(dialog.new_project_requested):
+            new_button.click()
+
+    def test_open_project_signal(self, qtbot):  # noqa: ARG002
+        """Test open project signal is emitted."""
+        dialog = WelcomeDialog()
+        buttons = dialog.findChildren(QPushButton)
+        open_button = next(b for b in buttons if b.text() == "Open Project...")
+
+        with qtbot.waitSignal(dialog.open_project_requested):
+            open_button.click()
+
+    def test_checkbox_updates_settings(self, qtbot):  # noqa: ARG002
+        """Test checkbox updates settings."""
+        dialog = WelcomeDialog()
+        checkbox = dialog.findChild(QCheckBox)
+
+        # Uncheck the checkbox
+        checkbox.setChecked(False)
+        assert not get_settings().show_welcome_on_startup
+
+        # Check the checkbox
+        checkbox.setChecked(True)
+        assert get_settings().show_welcome_on_startup
+
+    def test_empty_recent_shows_placeholder(self, qtbot):  # noqa: ARG002
+        """Test empty recent list shows placeholder."""
+        dialog = WelcomeDialog()
+        list_widget = dialog.findChild(QListWidget)
+
+        assert list_widget.count() == 1
+        item = list_widget.item(0)
+        assert "No recent" in item.text()
+        # Placeholder should not be selectable
+        assert not (item.flags() & Qt.ItemFlag.ItemIsSelectable)
+
+    def test_clear_recent_button(self, qtbot):  # noqa: ARG002
+        """Test clear recent button exists."""
+        dialog = WelcomeDialog()
+        buttons = dialog.findChildren(QPushButton)
+        button_texts = [b.text() for b in buttons]
+        assert "Clear Recent" in button_texts
+
+    def test_minimum_size(self, qtbot):  # noqa: ARG002
+        """Test dialog has minimum size."""
+        dialog = WelcomeDialog()
+        assert dialog.minimumWidth() >= 400
+        assert dialog.minimumHeight() >= 300


### PR DESCRIPTION
## Summary
Implements US-5.6: Welcome screen with recent projects list.

This adds a professional welcome dialog that appears on startup, showing:
- Application banner at the top
- Recent projects list (up to 10 most recent)
- Quick action buttons (New Project, Open Project, Open Selected)
- "Show this screen on startup" preference checkbox
- Clear Recent button to reset history

Also adds a "File → Open Recent" submenu for quick access to recent projects.

## Technical Details
- **New files:**
  - `welcome_dialog.py` - Main welcome dialog with theme-aware styling
  - `test_welcome_dialog.py` - 13 tests for dialog functionality
- **Modified files:**
  - `application.py` - Integrated welcome dialog, added Open Recent menu
  - `settings.py` - Added `show_welcome_on_startup` setting, recent files tracking
  - `project.py` - Automatic recent file tracking on open/save
  - `dialogs/__init__.py` - Export WelcomeDialog

## Styling
- Theme-aware colors that work in both light and dark modes
- Native Qt styling for most elements (follows system theme)
- Green accent buttons for primary actions
- Matches sidebar color scheme

## Test Plan
- [x] Welcome dialog appears on startup with banner
- [x] "New Project" button opens new project dialog
- [x] "Open Project..." button opens file browser
- [x] Recent projects list populated after saving/opening projects
- [x] Double-click recent project to open
- [x] "Open Selected" button works with highlighted project
- [x] "Clear Recent" button clears history
- [x] "Show this screen on startup" checkbox persists preference
- [x] File → Open Recent menu shows recent files dynamically
- [x] Missing files shown as grayed out "(not found)"
- [x] Styling readable in dark mode
- [x] All 476 tests pass
- [x] Lint checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)