### PR TITLE
feat(US-5.8): Unify all tool icons with professional Tabler Icons design

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,7 +158,7 @@ tests/
 | ✅     | 5.5 | Light/dark mode switch                     |
 | ✅     | 5.6 | Welcome screen with recent projects        |
 | ✅     | 5.7 | Auto-save periodically                     |
-|        | 5.8 | Professional SVG icons for tools           |
+| ✅     | 5.8 | Professional SVG icons for tools           |
 
 ## Future Backlog
 

--- a/prd.md
+++ b/prd.md
@@ -692,7 +692,7 @@ open_garden_planner/
 | US-5.5 | As a user, I can switch between light and dark mode | Should |
 | ~~US-5.6~~ | ~~As a user, I see a welcome screen with recent projects~~ | ✅ Should |
 | ~~US-5.7~~ | ~~As a user, my work is auto-saved periodically~~ | ✅ Must |
-| US-5.8 | As a user, I have professional, consistent SVG icons for all drawing tools | Should |
+| ~~US-5.8~~ | ~~As a user, I have professional, consistent SVG icons for all drawing tools~~ | ✅ Should |
 
 **Technical Milestones**:
 - [x] PNG export with DPI options

--- a/src/open_garden_planner/resources/icons/tools/circle.svg
+++ b/src/open_garden_planner/resources/icons/tools/circle.svg
@@ -1,8 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64" fill="none">
-  <g stroke="#1F2937" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
-
-  <circle cx="32" cy="32" r="18" fill="#3B82F6"/>
-  <circle cx="32" cy="32" r="18" fill="none" stroke-dasharray="6 4"/>
-
+  <g stroke="#1F2937" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" transform="scale(2.6667)">
+    <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+    <path d="M3 12a9 9 0 1 0 18 0a9 9 0 1 0 -18 0" fill="#10B981"/>
   </g>
 </svg>

--- a/src/open_garden_planner/resources/icons/tools/driveway.svg
+++ b/src/open_garden_planner/resources/icons/tools/driveway.svg
@@ -1,8 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64" fill="none">
-  <g stroke="#1F2937" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
-
-  <path d="M22 54 L28 10 H36 L42 54 Z" fill="#9CA3AF"/>
-  <path d="M32 12 V52" stroke="white" stroke-dasharray="4 5"/>
-
+  <g stroke="#1F2937" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" transform="scale(2.6667)">
+    <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+    <path d="M5 20a2 2 0 1 0 4 0a2 2 0 0 0 -4 0" />
+    <path d="M15 20a2 2 0 1 0 4 0a2 2 0 0 0 -4 0" />
+    <path d="M5 20h-2v-6l2 -5h9l4 5h1a2 2 0 0 1 2 2v4h-2m-4 0h-6m-6 -6h15m-6 0v-5" fill="#64748B" opacity="0.3"/>
+    <path d="M3 6l9 -4l9 4" stroke="#A8A29E" stroke-width="3"/>
   </g>
 </svg>

--- a/src/open_garden_planner/resources/icons/tools/fence.svg
+++ b/src/open_garden_planner/resources/icons/tools/fence.svg
@@ -1,16 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64" fill="none">
-  <g stroke="#1F2937" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
-<path d="M12 24 L16 20 L20 24 V48 H12 Z" fill="#F59E0B"/>
-  <line x1="12" y1="34" x2="20" y2="34"/>
-  <path d="M20 24 L24 20 L28 24 V48 H20 Z" fill="#F59E0B"/>
-  <line x1="20" y1="34" x2="28" y2="34"/>
-  <path d="M28 24 L32 20 L36 24 V48 H28 Z" fill="#F59E0B"/>
-  <line x1="28" y1="34" x2="36" y2="34"/>
-  <path d="M36 24 L40 20 L44 24 V48 H36 Z" fill="#F59E0B"/>
-  <line x1="36" y1="34" x2="44" y2="34"/>
-  <path d="M44 24 L48 20 L52 24 V48 H44 Z" fill="#F59E0B"/>
-  <line x1="44" y1="34" x2="52" y2="34"/>
-  <path d="M52 24 L56 20 L60 24 V48 H52 Z" fill="#F59E0B"/>
-  <line x1="52" y1="34" x2="60" y2="34"/>
+  <g stroke="#1F2937" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" transform="scale(2.6667)">
+    <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+    <path d="M4 12v4h16v-4l-16 0" fill="#F59E0B"/>
+    <path d="M6 16v4h4v-4m0 -4v-6l-2 -2l-2 2v6" />
+    <path d="M14 16v4h4v-4m0 -4v-6l-2 -2l-2 2v6" />
   </g>
 </svg>

--- a/src/open_garden_planner/resources/icons/tools/flower.svg
+++ b/src/open_garden_planner/resources/icons/tools/flower.svg
@@ -1,8 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64" fill="none">
-  <g stroke="#1F2937" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
-
-  <ellipse cx="32" cy="24" rx="6" ry="10" fill="#EC4899" transform="rotate(0 32 32) translate(0, -8)"/><ellipse cx="32" cy="24" rx="6" ry="10" fill="#EC4899" transform="rotate(72 32 32) translate(0, -8)"/><ellipse cx="32" cy="24" rx="6" ry="10" fill="#EC4899" transform="rotate(144 32 32) translate(0, -8)"/><ellipse cx="32" cy="24" rx="6" ry="10" fill="#EC4899" transform="rotate(216 32 32) translate(0, -8)"/><ellipse cx="32" cy="24" rx="6" ry="10" fill="#EC4899" transform="rotate(288 32 32) translate(0, -8)"/>
-  <circle cx="32" cy="32" r="6" fill="#F59E0B"/>
-
+  <g stroke="#1F2937" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" transform="scale(2.6667)">
+    <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+    <path d="M9 12a3 3 0 1 0 6 0a3 3 0 1 0 -6 0" fill="#F59E0B"/>
+    <path d="M12 2a3 3 0 0 1 3 3c0 .562 -.259 1.442 -.776 2.64l-.724 1.36l1.76 -1.893c.499 -.6 .922 -1 1.27 -1.205a2.968 2.968 0 0 1 4.07 1.099a3.011 3.011 0 0 1 -1.09 4.098c-.374 .217 -.99 .396 -1.846 .535l-2.664 .366l2.4 .326c1 .145 1.698 .337 2.11 .576a3.011 3.011 0 0 1 1.09 4.098a2.968 2.968 0 0 1 -4.07 1.098c-.348 -.202 -.771 -.604 -1.27 -1.205l-1.76 -1.893l.724 1.36c.516 1.199 .776 2.079 .776 2.64a3 3 0 0 1 -6 0c0 -.562 .259 -1.442 .776 -2.64l.724 -1.36l-1.76 1.893c-.499 .601 -.922 1 -1.27 1.205a2.968 2.968 0 0 1 -4.07 -1.098a3.011 3.011 0 0 1 1.09 -4.098c.374 -.218 .99 -.396 1.846 -.536l2.664 -.366l-2.4 -.325c-1 -.145 -1.698 -.337 -2.11 -.576a3.011 3.011 0 0 1 -1.09 -4.099a2.968 2.968 0 0 1 4.07 -1.099c.348 .203 .771 .604 1.27 1.205l1.76 1.894c-1 -2.292 -1.5 -3.625 -1.5 -4a3 3 0 0 1 3 -3" fill="#EC4899"/>
   </g>
 </svg>

--- a/src/open_garden_planner/resources/icons/tools/greenhouse.svg
+++ b/src/open_garden_planner/resources/icons/tools/greenhouse.svg
@@ -1,10 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64" fill="none">
-  <g stroke="#1F2937" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
-
-  <path d="M12 30 L32 16 L52 30 V50 H12 Z" fill="#06B6D4" opacity="0.25"/>
-  <path d="M12 30 L32 16 L52 30 V50 H12 Z" fill="none"/>
-  <path d="M34 38 C34 34 40 30 44 30 C44 36 40 42 36 44 C34 44 34 40 34 38 Z" fill="#22C55E"/>
-  <line x1="34" y1="38" x2="44" y2="34"/>
-
+  <g stroke="#1F2937" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" transform="scale(2.6667)">
+    <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+    <path d="M20 11l-8 -8l-9 9h2v7a2 2 0 0 0 2 2h5" fill="#06B6D4" opacity="0.3"/>
+    <path d="M9 21v-6a2 2 0 0 1 2 -2h2c.325 0 .631 .077 .902 .215" />
+    <path d="M16 22s0 -2 3 -4" />
+    <path d="M19 21a3 3 0 0 1 0 -6h3v3a3 3 0 0 1 -3 3" fill="#22C55E"/>
   </g>
 </svg>

--- a/src/open_garden_planner/resources/icons/tools/house.svg
+++ b/src/open_garden_planner/resources/icons/tools/house.svg
@@ -1,9 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64" fill="none">
-  <g stroke="#1F2937" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
-
-  <path d="M12 28 L32 12 L52 28" fill="#EF4444"/>
-  <rect x="16" y="28" width="32" height="24" rx="4" fill="#EC4899"/>
-  <rect x="30" y="36" width="8" height="16" rx="2" fill="white"/>
-
+  <g stroke="#1F2937" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" transform="scale(2.6667)">
+    <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+    <path d="M5 12l-2 0l9 -9l9 9l-2 0" fill="#EF4444"/>
+    <path d="M5 12v7a2 2 0 0 0 2 2h10a2 2 0 0 0 2 -2v-7" fill="#EC4899"/>
+    <path d="M9 21v-6a2 2 0 0 1 2 -2h2a2 2 0 0 1 2 2v6" />
   </g>
 </svg>

--- a/src/open_garden_planner/resources/icons/tools/measure.svg
+++ b/src/open_garden_planner/resources/icons/tools/measure.svg
@@ -1,7 +1,14 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64" fill="none">
-<rect x='12' y='26' width='40' height='12' rx='2' fill='#F59E0B' stroke='#1F2937' stroke-width='2'/>
-<line x1='20' y1='26' x2='20' y2='38' stroke='#1F2937' stroke-width='2'/>
-<line x1='28' y1='26' x2='28' y2='38' stroke='#1F2937' stroke-width='2'/>
-<line x1='36' y1='26' x2='36' y2='38' stroke='#1F2937' stroke-width='2'/>
-<line x1='44' y1='26' x2='44' y2='38' stroke='#1F2937' stroke-width='2'/>
+  <g stroke="#1F2937" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" transform="scale(2.6667)">
+    <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+    <path d="M19.875 12c.621 0 1.125 .512 1.125 1.143v5.714c0 .631 -.504 1.143 -1.125 1.143h-15.875a1 1 0 0 1 -1 -1v-5.857c0 -.631 .504 -1.143 1.125 -1.143h15.75" fill="#F59E0B"/>
+    <path d="M9 12v2" />
+    <path d="M6 12v3" />
+    <path d="M12 12v3" />
+    <path d="M18 12v3" />
+    <path d="M15 12v2" />
+    <path d="M3 3v4" />
+    <path d="M3 5h18" />
+    <path d="M21 3v4" />
+  </g>
 </svg>

--- a/src/open_garden_planner/resources/icons/tools/path.svg
+++ b/src/open_garden_planner/resources/icons/tools/path.svg
@@ -1,6 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64" fill="none">
-  
-  <path d="M10 54 C18 46 22 42 28 40 C36 38 44 36 54 26" stroke="#A16207" stroke-width="6" stroke-linecap="round"/>
-  <path d="M10 54 C18 46 22 42 28 40 C36 38 44 36 54 26" stroke="white" stroke-width="1.8" stroke-dasharray="2 6" stroke-linecap="round"/>
-
+  <g stroke="#1F2937" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" transform="scale(2.6667)">
+    <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+    <path d="M4 19l4 -14" stroke="#A8A29E" stroke-width="3.5"/>
+    <path d="M16 5l4 14" stroke="#A8A29E" stroke-width="3.5"/>
+    <path d="M12 8v-2" />
+    <path d="M12 13v-2" />
+    <path d="M12 18v-2" />
+  </g>
 </svg>

--- a/src/open_garden_planner/resources/icons/tools/polygon.svg
+++ b/src/open_garden_planner/resources/icons/tools/polygon.svg
@@ -1,3 +1,6 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64" fill="none"><g stroke="#1F2937" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
-<polygon points='32,10 52,26 44,50 20,50 12,26' fill='#FB923C' />
-</g></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64" fill="none">
+  <g stroke="#1F2937" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" transform="scale(2.6667)">
+    <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+    <path d="M19.875 6.27a2.225 2.225 0 0 1 1.125 1.948v7.284c0 .809 -.443 1.555 -1.158 1.948l-6.75 4.27a2.269 2.269 0 0 1 -2.184 0l-6.75 -4.27a2.225 2.225 0 0 1 -1.158 -1.948v-7.285c0 -.809 .443 -1.554 1.158 -1.947l6.75 -3.98a2.33 2.33 0 0 1 2.25 0l6.75 3.98h-.033" fill="#A78BFA"/>
+  </g>
+</svg>

--- a/src/open_garden_planner/resources/icons/tools/pond.svg
+++ b/src/open_garden_planner/resources/icons/tools/pond.svg
@@ -1,9 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64" fill="none">
-  <g stroke="#1F2937" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
-
-  <path d="M18 40 C12 36 14 28 22 26 C26 24 30 24 34 26 C42 22 52 26 50 34 C48 42 38 46 30 46 C24 46 20 44 18 40 Z" fill="#3B82F6"/>
-  <path d="M26 34 C30 32 36 32 40 34" stroke="white"/>
-  <path d="M28 38 C32 36 36 36 38 38" stroke="white"/>
-
+  <g stroke="#1F2937" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" transform="scale(2.6667)">
+    <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+    <path d="M3 7c3 -2 6 -2 9 0s6 2 9 0" stroke="#3B82F6" stroke-width="3"/>
+    <path d="M3 17c3 -2 6 -2 9 0s6 2 9 0" stroke="#3B82F6" stroke-width="3"/>
+    <path d="M3 12c3 -2 6 -2 9 0s6 2 9 0" stroke="#06B6D4" stroke-width="3"/>
   </g>
 </svg>

--- a/src/open_garden_planner/resources/icons/tools/rectangle.svg
+++ b/src/open_garden_planner/resources/icons/tools/rectangle.svg
@@ -1,8 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64" fill="none">
-  <g stroke="#1F2937" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
-
-  <rect x="10" y="14" width="44" height="36" rx="6" fill="#06B6D4"/>
-  <rect x="10" y="14" width="44" height="36" rx="6" fill="none" stroke-dasharray="6 4"/>
-
+  <g stroke="#1F2937" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" transform="scale(2.6667)">
+    <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+    <path d="M3 5a2 2 0 0 1 2 -2h14a2 2 0 0 1 2 2v14a2 2 0 0 1 -2 2h-14a2 2 0 0 1 -2 -2v-14" fill="#06B6D4"/>
   </g>
 </svg>

--- a/src/open_garden_planner/resources/icons/tools/select.svg
+++ b/src/open_garden_planner/resources/icons/tools/select.svg
@@ -1,3 +1,6 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64" fill="none"><g stroke="#1F2937" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
-<path d='M18 10 L18 46 L26 38 L38 54 L42 50 L30 34 L38 26 Z' fill='#8B5CF6'/>
-</g></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64" fill="none">
+  <g stroke="#1F2937" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" transform="scale(2.6667)">
+    <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+    <path d="M7.904 17.563a1.2 1.2 0 0 0 2.228 .308l2.09 -3.093l4.907 4.907a1.067 1.067 0 0 0 1.509 0l1.047 -1.047a1.067 1.067 0 0 0 0 -1.509l-4.907 -4.907l3.113 -2.09a1.2 1.2 0 0 0 -.309 -2.228l-13.582 -3.904l3.904 13.563" fill="#8B5CF6"/>
+  </g>
+</svg>

--- a/src/open_garden_planner/resources/icons/tools/shed.svg
+++ b/src/open_garden_planner/resources/icons/tools/shed.svg
@@ -1,9 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64" fill="none">
-  <g stroke="#1F2937" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
-
-  <path d="M14 28 L48 20 L50 26 L16 34 Z" fill="#A16207"/>
-  <rect x="16" y="32" width="28" height="18" rx="3" fill="#FB923C"/>
-  <rect x="26" y="36" width="8" height="14" rx="2" fill="white"/>
-
+  <g stroke="#1F2937" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" transform="scale(2.6667)">
+    <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+    <path d="M3 21l18 0" />
+    <path d="M4 21v-11l2.5 -4.5l5.5 -2.5l5.5 2.5l2.5 4.5v11" fill="#FB923C"/>
+    <path d="M10 9a2 2 0 1 0 4 0a2 2 0 1 0 -4 0" />
+    <path d="M9 21v-5a1 1 0 0 1 1 -1h4a1 1 0 0 1 1 1v5" />
   </g>
 </svg>

--- a/src/open_garden_planner/resources/icons/tools/shrub.svg
+++ b/src/open_garden_planner/resources/icons/tools/shrub.svg
@@ -1,9 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64" fill="none">
-  <g stroke="#1F2937" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
-
-  <circle cx="24" cy="38" r="10" fill="#22C55E"/>
-  <circle cx="36" cy="40" r="12" fill="#84CC16"/>
-  <circle cx="44" cy="36" r="8" fill="#22C55E"/>
-
+  <g stroke="#1F2937" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" transform="scale(2.6667)">
+    <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+    <path d="M2 9a10 10 0 1 0 20 0" fill="#22C55E"/>
+    <path d="M12 19a10 10 0 0 1 10 -10" fill="#84CC16"/>
+    <path d="M2 9a10 10 0 0 1 10 10" fill="#10B981"/>
+    <path d="M12 4a9.7 9.7 0 0 1 2.99 7.5" />
+    <path d="M9.01 11.5a9.7 9.7 0 0 1 2.99 -7.5" />
   </g>
 </svg>

--- a/src/open_garden_planner/resources/icons/tools/terrace.svg
+++ b/src/open_garden_planner/resources/icons/tools/terrace.svg
@@ -1,8 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64" fill="none">
-  <g stroke="#1F2937" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
-
-  <rect x="10" y="26" width="44" height="24" rx="4" fill="#84CC16"/>
-  <path d="M10 34 H54 M10 42 H54 M26 26 V50 M38 26 V50"/>
-
+  <g stroke="#1F2937" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" transform="scale(2.6667)">
+    <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+    <path d="M3 21h7v-3a2 2 0 0 1 4 0v3h7" />
+    <path d="M6 21l0 -9" />
+    <path d="M18 21l0 -9" />
+    <path d="M6 12h12a3 3 0 0 0 3 -3a9 8 0 0 1 -9 -6a9 8 0 0 1 -9 6a3 3 0 0 0 3 3" fill="#D97706" opacity="0.4"/>
   </g>
 </svg>

--- a/src/open_garden_planner/resources/icons/tools/tree.svg
+++ b/src/open_garden_planner/resources/icons/tools/tree.svg
@@ -1,9 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64" fill="none">
-  <g stroke="#1F2937" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
-
-  <circle cx="34" cy="26" r="14" fill="#22C55E"/>
-  <circle cx="22" cy="28" r="10" fill="#84CC16"/>
-  <rect x="28" y="34" width="8" height="16" rx="2" fill="#A16207"/>
-
+  <g stroke="#1F2937" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" transform="scale(2.6667)">
+    <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+    <path d="M12 13l-2 -2" />
+    <path d="M12 12l2 -2" />
+    <path d="M12 21v-13" fill="#A16207"/>
+    <path d="M9.824 16a3 3 0 0 1 -2.743 -3.69a3 3 0 0 1 .304 -4.833a3 3 0 0 1 4.615 -3.707a3 3 0 0 1 4.614 3.707a3 3 0 0 1 .305 4.833a3 3 0 0 1 -2.919 3.695h-4l-.176 -.005" fill="#22C55E"/>
   </g>
 </svg>

--- a/src/open_garden_planner/resources/icons/tools/wall.svg
+++ b/src/open_garden_planner/resources/icons/tools/wall.svg
@@ -1,6 +1,14 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64" fill="none">
-  <g stroke="#1F2937" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
-<rect x="10" y="18" width="44" height="32" rx="3" fill="#EC4899" opacity="0.2"/>
-<rect x="10" y="20" width="10" height="6" rx="1" fill="#EF4444"/><rect x="22" y="20" width="10" height="6" rx="1" fill="#EF4444"/><rect x="34" y="20" width="10" height="6" rx="1" fill="#EF4444"/><rect x="46" y="20" width="10" height="6" rx="1" fill="#EF4444"/><rect x="16" y="28" width="10" height="6" rx="1" fill="#EF4444"/><rect x="28" y="28" width="10" height="6" rx="1" fill="#EF4444"/><rect x="40" y="28" width="10" height="6" rx="1" fill="#EF4444"/><rect x="52" y="28" width="10" height="6" rx="1" fill="#EF4444"/><rect x="10" y="36" width="10" height="6" rx="1" fill="#EF4444"/><rect x="22" y="36" width="10" height="6" rx="1" fill="#EF4444"/><rect x="34" y="36" width="10" height="6" rx="1" fill="#EF4444"/><rect x="46" y="36" width="10" height="6" rx="1" fill="#EF4444"/><rect x="16" y="44" width="10" height="6" rx="1" fill="#EF4444"/><rect x="28" y="44" width="10" height="6" rx="1" fill="#EF4444"/><rect x="40" y="44" width="10" height="6" rx="1" fill="#EF4444"/><rect x="52" y="44" width="10" height="6" rx="1" fill="#EF4444"/>
+  <g stroke="#1F2937" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" transform="scale(2.6667)">
+    <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+    <path d="M4 6a2 2 0 0 1 2 -2h12a2 2 0 0 1 2 2v12a2 2 0 0 1 -2 2h-12a2 2 0 0 1 -2 -2l0 -12" fill="#78716C" opacity="0.3"/>
+    <path d="M4 8h16" />
+    <path d="M20 12h-16" />
+    <path d="M4 16h16" />
+    <path d="M9 4v4" />
+    <path d="M14 8v4" />
+    <path d="M8 12v4" />
+    <path d="M16 12v4" />
+    <path d="M11 16v4" />
   </g>
 </svg>


### PR DESCRIPTION
## Summary
- Replaced all 17 tool icons with professional Tabler Icons
- Unified visual design with consistent sizing, stroke, and colors
- Each icon uses distinctive colors for easy identification

## Technical Details
- Standardized to 64x64px with scale(2.6667) transform
- Uniform stroke: #1F2937, width 2.5px
- Icons sourced from Tabler Icons library (MIT licensed)

## Icons Updated
Select, Measure, Rectangle, Polygon, Circle, Tree, Shrub, Flower, House, Shed, Greenhouse, Fence, Wall, Path, Driveway, Pond, Terrace

🤖 Generated with [Claude Code](https://claude.com/claude-code)