### PR TITLE
feat(US-B.1): Add object rotation with free drag and 15-degree snap

### DIFF
--- a/src/open_garden_planner/core/commands.py
+++ b/src/open_garden_planner/core/commands.py
@@ -359,3 +359,40 @@ class ResizeItemCommand(Command):
     def undo(self) -> None:
         """Restore the old geometry."""
         self._apply_func(self._item, self._old_geometry)
+
+
+class RotateItemCommand(Command):
+    """Command for rotating an item."""
+
+    def __init__(
+        self,
+        item: QGraphicsItem,
+        old_angle: float,
+        new_angle: float,
+        apply_func: Callable[[QGraphicsItem, float], None],
+    ) -> None:
+        """Initialize the rotate command.
+
+        Args:
+            item: The item being rotated
+            old_angle: Previous rotation angle in degrees
+            new_angle: New rotation angle in degrees
+            apply_func: Function to apply rotation to the item
+        """
+        self._item = item
+        self._old_angle = old_angle
+        self._new_angle = new_angle
+        self._apply_func = apply_func
+
+    @property
+    def description(self) -> str:
+        """Human-readable description."""
+        return "Rotate item"
+
+    def execute(self) -> None:
+        """Apply the new rotation."""
+        self._apply_func(self._item, self._new_angle)
+
+    def undo(self) -> None:
+        """Restore the old rotation."""
+        self._apply_func(self._item, self._old_angle)

--- a/src/open_garden_planner/core/project.py
+++ b/src/open_garden_planner/core/project.py
@@ -270,6 +270,9 @@ class ProjectManager(QObject):
             # Save stroke style
             if hasattr(item, "stroke_style") and item.stroke_style:
                 data["stroke_style"] = item.stroke_style.name
+            # Save rotation angle
+            if hasattr(item, "rotation_angle") and abs(item.rotation_angle) > 0.01:
+                data["rotation_angle"] = item.rotation_angle
             return data
         elif isinstance(item, CircleItem):
             data = {
@@ -302,6 +305,9 @@ class ProjectManager(QObject):
             # Save stroke style
             if hasattr(item, "stroke_style") and item.stroke_style:
                 data["stroke_style"] = item.stroke_style.name
+            # Save rotation angle
+            if hasattr(item, "rotation_angle") and abs(item.rotation_angle) > 0.01:
+                data["rotation_angle"] = item.rotation_angle
             return data
         elif isinstance(item, PolylineItem):
             data = {
@@ -320,6 +326,9 @@ class ProjectManager(QObject):
             stroke_color = item.pen().color()
             data["stroke_color"] = stroke_color.name(QColor.NameFormat.HexArgb)
             data["stroke_width"] = item.pen().widthF()
+            # Save rotation angle
+            if hasattr(item, "rotation_angle") and abs(item.rotation_angle) > 0.01:
+                data["rotation_angle"] = item.rotation_angle
             return data
         elif isinstance(item, PolygonItem):
             polygon = item.polygon()
@@ -358,6 +367,9 @@ class ProjectManager(QObject):
             # Save stroke style
             if hasattr(item, "stroke_style") and item.stroke_style:
                 data["stroke_style"] = item.stroke_style.name
+            # Save rotation angle
+            if hasattr(item, "rotation_angle") and abs(item.rotation_angle) > 0.01:
+                data["rotation_angle"] = item.rotation_angle
             return data
         return None
 
@@ -481,6 +493,9 @@ class ProjectManager(QObject):
                 if stroke_style:
                     pen.setStyle(stroke_style.to_qt_pen_style())
                 item.setPen(pen)
+            # Restore rotation angle
+            if "rotation_angle" in obj:
+                item._apply_rotation(obj["rotation_angle"])
             return item
         elif obj_type == "circle":
             item = CircleItem(
@@ -515,6 +530,9 @@ class ProjectManager(QObject):
                 if stroke_style:
                     pen.setStyle(stroke_style.to_qt_pen_style())
                 item.setPen(pen)
+            # Restore rotation angle
+            if "rotation_angle" in obj:
+                item._apply_rotation(obj["rotation_angle"])
             return item
         elif obj_type == "polyline":
             points = [QPointF(p["x"], p["y"]) for p in obj.get("points", [])]
@@ -532,6 +550,9 @@ class ProjectManager(QObject):
                     if "stroke_width" in obj:
                         pen.setWidthF(obj["stroke_width"])
                     item.setPen(pen)
+                # Restore rotation angle
+                if "rotation_angle" in obj:
+                    item._apply_rotation(obj["rotation_angle"])
                 return item
         elif obj_type == "polygon":
             points = [QPointF(p["x"], p["y"]) for p in obj.get("points", [])]
@@ -566,5 +587,8 @@ class ProjectManager(QObject):
                     if stroke_style:
                         pen.setStyle(stroke_style.to_qt_pen_style())
                     item.setPen(pen)
+                # Restore rotation angle
+                if "rotation_angle" in obj:
+                    item._apply_rotation(obj["rotation_angle"])
                 return item
         return None

--- a/src/open_garden_planner/ui/canvas/items/circle_item.py
+++ b/src/open_garden_planner/ui/canvas/items/circle_item.py
@@ -17,7 +17,7 @@ from open_garden_planner.core.fill_patterns import FillPattern, create_pattern_b
 from open_garden_planner.core.object_types import ObjectType, StrokeStyle, get_style
 
 from .garden_item import GardenItemMixin
-from .resize_handle import ResizeHandlesMixin
+from .resize_handle import ResizeHandlesMixin, RotationHandleMixin
 
 
 def _show_properties_dialog(item: QGraphicsEllipseItem) -> None:
@@ -92,11 +92,11 @@ def _show_properties_dialog(item: QGraphicsEllipseItem) -> None:
         item.setPen(pen)
 
 
-class CircleItem(ResizeHandlesMixin, GardenItemMixin, QGraphicsEllipseItem):
+class CircleItem(RotationHandleMixin, ResizeHandlesMixin, GardenItemMixin, QGraphicsEllipseItem):
     """A circle shape on the garden canvas.
 
     Supports property object types with appropriate styling.
-    Supports selection, movement, and resizing.
+    Supports selection, movement, resizing, and rotation.
     """
 
     def __init__(
@@ -147,8 +147,9 @@ class CircleItem(ResizeHandlesMixin, GardenItemMixin, QGraphicsEllipseItem):
         self._center = QPointF(center_x, center_y)
         self._radius = radius
 
-        # Initialize resize handles
+        # Initialize resize and rotation handles
         self.init_resize_handles()
+        self.init_rotation_handle()
 
         self._setup_styling()
         self._setup_flags()
@@ -197,13 +198,15 @@ class CircleItem(ResizeHandlesMixin, GardenItemMixin, QGraphicsEllipseItem):
     ) -> Any:
         """Handle item state changes.
 
-        Shows/hides resize handles based on selection state.
+        Shows/hides resize and rotation handles based on selection state.
         """
         if change == QGraphicsItem.GraphicsItemChange.ItemSelectedChange:
             if value:  # Being selected
                 self.show_resize_handles()
+                self.show_rotation_handle()
             else:  # Being deselected
                 self.hide_resize_handles()
+                self.hide_rotation_handle()
 
         return super().itemChange(change, value)
 
@@ -376,6 +379,44 @@ class CircleItem(ResizeHandlesMixin, GardenItemMixin, QGraphicsEllipseItem):
         )
 
         # Add to undo stack without executing (geometry already applied)
+        command_manager._undo_stack.append(command)
+        command_manager._redo_stack.clear()
+        command_manager.can_undo_changed.emit(True)
+        command_manager.can_redo_changed.emit(False)
+        command_manager.command_executed.emit(command.description)
+
+    def _on_rotation_end(self, initial_angle: float) -> None:
+        """Called when rotation operation completes. Registers undo command."""
+        scene = self.scene()
+        if scene is None or not hasattr(scene, 'get_command_manager'):
+            return
+
+        command_manager = scene.get_command_manager()
+        if command_manager is None:
+            return
+
+        # Get current angle
+        current_angle = self.rotation_angle
+
+        # Only register command if angle actually changed
+        if abs(initial_angle - current_angle) < 0.01:
+            return
+
+        from open_garden_planner.core.commands import RotateItemCommand
+
+        def apply_rotation(item: QGraphicsItem, angle: float) -> None:
+            """Apply rotation to the item."""
+            if isinstance(item, CircleItem):
+                item._apply_rotation(angle)
+
+        command = RotateItemCommand(
+            self,
+            initial_angle,
+            current_angle,
+            apply_rotation,
+        )
+
+        # Add to undo stack without executing (rotation already applied)
         command_manager._undo_stack.append(command)
         command_manager._redo_stack.clear()
         command_manager.can_undo_changed.emit(True)

--- a/src/open_garden_planner/ui/canvas/items/resize_handle.py
+++ b/src/open_garden_planner/ui/canvas/items/resize_handle.py
@@ -1,11 +1,14 @@
-"""Resize handles for scaling garden items."""
+"""Resize and rotation handles for scaling and rotating garden items."""
 
+import math
 from enum import Enum, auto
 from typing import TYPE_CHECKING
 
 from PyQt6.QtCore import QPointF, QRectF, Qt
 from PyQt6.QtGui import QBrush, QColor, QFont, QPainterPath, QPen
 from PyQt6.QtWidgets import (
+    QApplication,
+    QGraphicsEllipseItem,
     QGraphicsItem,
     QGraphicsPathItem,
     QGraphicsRectItem,
@@ -51,6 +54,13 @@ HANDLE_SIZE = 8.0  # pixels (cosmetic)
 HANDLE_COLOR = QColor(0, 120, 215)  # Blue
 HANDLE_HOVER_COLOR = QColor(0, 180, 255)  # Lighter blue
 HANDLE_BORDER_COLOR = QColor(255, 255, 255)  # White border
+
+# Rotation handle settings
+ROTATION_HANDLE_OFFSET = 25.0  # pixels above the top center
+ROTATION_HANDLE_SIZE = 10.0  # pixels (cosmetic)
+ROTATION_HANDLE_COLOR = QColor(46, 204, 113)  # Green
+ROTATION_HANDLE_HOVER_COLOR = QColor(88, 214, 141)  # Lighter green
+ROTATION_SNAP_ANGLE = 15.0  # degrees for snapping when Shift is held
 
 
 class DimensionDisplay(QGraphicsItem):
@@ -373,6 +383,261 @@ class ResizeHandle(QGraphicsRectItem):
             )
 
 
+class AngleDisplay(QGraphicsItem):
+    """Display widget showing rotation angle during rotation operation.
+
+    Shows the angle in degrees in a tooltip-like box near the cursor.
+    """
+
+    def __init__(self, parent: QGraphicsItem | None = None) -> None:
+        """Initialize angle display."""
+        super().__init__(parent)
+
+        # Create background box
+        self._background = QGraphicsPathItem(self)
+        self._background.setPen(QPen(QColor(46, 125, 50), 1))
+        self._background.setBrush(QBrush(QColor(232, 245, 233, 230)))
+
+        # Create text item
+        self._text = QGraphicsSimpleTextItem(self)
+        font = QFont("Segoe UI", 9)
+        self._text.setFont(font)
+        self._text.setBrush(QBrush(QColor(0, 0, 0)))
+
+        # Make it render at fixed screen size
+        self.setFlag(QGraphicsItem.GraphicsItemFlag.ItemIgnoresTransformations)
+        self.setZValue(2000)  # Above everything
+
+        self.hide()
+
+    def boundingRect(self) -> QRectF:
+        """Return bounding rectangle."""
+        return self.childrenBoundingRect()
+
+    def paint(self, painter, option, widget=None) -> None:
+        """Paint method (required by QGraphicsItem)."""
+        pass
+
+    def update_angle(self, angle: float, pos: QPointF) -> None:
+        """Update the displayed angle.
+
+        Args:
+            angle: Angle in degrees
+            pos: Position in scene coordinates to display near
+        """
+        # Normalize angle to 0-360
+        display_angle = angle % 360
+        if display_angle < 0:
+            display_angle += 360
+
+        # Set text
+        text = f"{display_angle:.1f}°"
+        self._text.setText(text)
+
+        # Update background size based on text
+        text_rect = self._text.boundingRect()
+        padding = 6
+        bg_rect = text_rect.adjusted(-padding, -padding, padding, padding)
+
+        path = QPainterPath()
+        path.addRoundedRect(bg_rect, 4, 4)
+        self._background.setPath(path)
+
+        # Position text within background
+        self._text.setPos(bg_rect.left() + padding, bg_rect.top() + padding)
+
+        # Position the display near the cursor
+        self.setPos(pos.x() + 15, pos.y() + 15)
+
+        # Show the display
+        self.show()
+
+    def hide_display(self) -> None:
+        """Hide the angle display."""
+        self.hide()
+
+
+class RotationHandle(QGraphicsEllipseItem):
+    """A circular handle for rotating items.
+
+    Displayed above the item's top center when selected.
+    Dragging rotates the item around its center.
+    """
+
+    def __init__(self, parent: "ParentItem") -> None:
+        """Initialize the rotation handle.
+
+        Args:
+            parent: The parent item this handle belongs to
+        """
+        super().__init__(parent)
+        self._parent_item = parent
+        self._is_dragging = False
+        self._drag_start_pos: QPointF | None = None
+        self._initial_angle: float = 0.0
+        self._center: QPointF = QPointF(0, 0)
+
+        self._setup_appearance()
+        self._setup_flags()
+
+    def _setup_appearance(self) -> None:
+        """Configure the visual appearance of the handle."""
+        # Set size - circular handle
+        half_size = ROTATION_HANDLE_SIZE / 2.0
+        self.setRect(-half_size, -half_size, ROTATION_HANDLE_SIZE, ROTATION_HANDLE_SIZE)
+
+        # Style
+        self.setPen(QPen(HANDLE_BORDER_COLOR, 1.0))
+        self.setBrush(QBrush(ROTATION_HANDLE_COLOR))
+
+        # Make handle render at fixed screen size regardless of zoom
+        self.setFlag(QGraphicsEllipseItem.GraphicsItemFlag.ItemIgnoresTransformations)
+
+    def _setup_flags(self) -> None:
+        """Configure interaction flags."""
+        self.setAcceptHoverEvents(True)
+        self.setCursor(Qt.CursorShape.CrossCursor)
+        # Z-value above parent and resize handles
+        self.setZValue(1001)
+
+    def update_position(self) -> None:
+        """Update handle position above the parent's bounding rect center-top."""
+        if self._parent_item is None:
+            return
+
+        rect = self._parent_item.boundingRect()
+
+        # Position above the top center
+        # Since we use ItemIgnoresTransformations, we need to account for view scale
+        view = None
+        if self._parent_item.scene():
+            views = self._parent_item.scene().views()
+            if views:
+                view = views[0]
+
+        # Calculate offset in scene coordinates
+        offset = ROTATION_HANDLE_OFFSET
+        if view:
+            # Adjust offset based on view transform
+            scale = view.transform().m11()
+            if scale > 0:
+                offset = ROTATION_HANDLE_OFFSET / scale
+
+        pos = QPointF(rect.center().x(), rect.top() - offset)
+        self.setPos(pos)
+
+    def hoverEnterEvent(self, event: QGraphicsSceneHoverEvent) -> None:
+        """Highlight handle on hover."""
+        self.setBrush(QBrush(ROTATION_HANDLE_HOVER_COLOR))
+        super().hoverEnterEvent(event)
+
+    def hoverLeaveEvent(self, event: QGraphicsSceneHoverEvent) -> None:
+        """Remove highlight when hover ends."""
+        self.setBrush(QBrush(ROTATION_HANDLE_COLOR))
+        super().hoverLeaveEvent(event)
+
+    def mousePressEvent(self, event: QGraphicsSceneMouseEvent) -> None:
+        """Start rotation operation."""
+        if event.button() == Qt.MouseButton.LeftButton:
+            self._is_dragging = True
+            self._drag_start_pos = event.scenePos()
+
+            # Store initial rotation angle and calculate center
+            if self._parent_item is not None:
+                rect = self._parent_item.boundingRect()
+                # Get center in scene coordinates
+                self._center = self._parent_item.mapToScene(rect.center())
+
+                # Get initial rotation angle of the item
+                if hasattr(self._parent_item, 'rotation_angle'):
+                    self._initial_angle = self._parent_item.rotation_angle
+                else:
+                    self._initial_angle = self._parent_item.rotation()
+
+                # Notify parent that rotation is starting
+                if hasattr(self._parent_item, '_on_rotation_start'):
+                    self._parent_item._on_rotation_start()
+
+            event.accept()
+        else:
+            super().mousePressEvent(event)
+
+    def mouseMoveEvent(self, event: QGraphicsSceneMouseEvent) -> None:
+        """Handle rotation during drag."""
+        if not self._is_dragging or self._drag_start_pos is None:
+            super().mouseMoveEvent(event)
+            return
+
+        if self._parent_item is None:
+            return
+
+        current_pos = event.scenePos()
+
+        # Calculate angles from center to start and current positions
+        start_angle = math.atan2(
+            self._drag_start_pos.y() - self._center.y(),
+            self._drag_start_pos.x() - self._center.x()
+        )
+        current_angle = math.atan2(
+            current_pos.y() - self._center.y(),
+            current_pos.x() - self._center.x()
+        )
+
+        # Calculate delta in degrees
+        delta_degrees = math.degrees(current_angle - start_angle)
+        new_angle = self._initial_angle + delta_degrees
+
+        # Check if Shift is held for 15° snapping
+        modifiers = QApplication.keyboardModifiers()
+        if modifiers & Qt.KeyboardModifier.ShiftModifier:
+            new_angle = round(new_angle / ROTATION_SNAP_ANGLE) * ROTATION_SNAP_ANGLE
+
+        # Apply the rotation
+        self._apply_rotation(new_angle, current_pos)
+
+        event.accept()
+
+    def mouseReleaseEvent(self, event: QGraphicsSceneMouseEvent) -> None:
+        """Complete rotation operation."""
+        if event.button() == Qt.MouseButton.LeftButton and self._is_dragging:
+            self._is_dragging = False
+
+            # Hide angle display
+            if (self._parent_item is not None and
+                hasattr(self._parent_item, '_angle_display') and
+                self._parent_item._angle_display is not None):
+                self._parent_item._angle_display.hide_display()
+
+            # Notify parent that rotation is complete
+            if self._parent_item is not None and hasattr(self._parent_item, '_on_rotation_end'):
+                self._parent_item._on_rotation_end(self._initial_angle)
+
+            self._drag_start_pos = None
+
+            event.accept()
+        else:
+            super().mouseReleaseEvent(event)
+
+    def _apply_rotation(self, angle: float, cursor_pos: QPointF) -> None:
+        """Apply the rotation transformation.
+
+        Args:
+            angle: New rotation angle in degrees
+            cursor_pos: Current cursor position for angle display
+        """
+        if self._parent_item is None:
+            return
+
+        # Update angle display
+        if (hasattr(self._parent_item, '_angle_display') and
+            self._parent_item._angle_display is not None):
+            self._parent_item._angle_display.update_angle(angle, cursor_pos)
+
+        # Apply rotation to parent
+        if hasattr(self._parent_item, '_apply_rotation'):
+            self._parent_item._apply_rotation(angle)
+
+
 class ResizeHandlesMixin:
     """Mixin that adds resize handle functionality to garden items.
 
@@ -495,3 +760,135 @@ class ResizeHandlesMixin:
             pos_y: New scene y position
         """
         pass
+
+
+class RotationHandleMixin:
+    """Mixin that adds rotation handle functionality to garden items.
+
+    This mixin provides methods to create, show, hide, and manage
+    the rotation handle for any item type.
+    """
+
+    _rotation_handle: RotationHandle | None
+    _rotation_initial_angle: float
+    _rotation_angle: float
+    _angle_display: AngleDisplay | None
+
+    def init_rotation_handle(self) -> None:
+        """Initialize rotation handle (call in subclass __init__)."""
+        self._rotation_handle = None
+        self._rotation_initial_angle = 0.0
+        self._rotation_angle = 0.0
+        self._angle_display = None
+
+    @property
+    def rotation_angle(self) -> float:
+        """Get the current rotation angle in degrees."""
+        return self._rotation_angle
+
+    @rotation_angle.setter
+    def rotation_angle(self, value: float) -> None:
+        """Set the rotation angle in degrees."""
+        self._rotation_angle = value
+
+    def create_rotation_handle(self) -> None:
+        """Create the rotation handle as a child item."""
+        if not hasattr(self, '_rotation_handle'):
+            self._rotation_handle = None
+
+        # Remove existing handle
+        self.remove_rotation_handle()
+
+        # Create handle
+        self._rotation_handle = RotationHandle(self)  # type: ignore[arg-type]
+        self._rotation_handle.update_position()
+
+        # Create angle display if it doesn't exist
+        if not hasattr(self, '_angle_display') or self._angle_display is None:
+            scene = getattr(self, 'scene', lambda: None)()
+            if scene is not None:
+                self._angle_display = AngleDisplay()
+                scene.addItem(self._angle_display)
+                self._angle_display.hide()
+
+    def remove_rotation_handle(self) -> None:
+        """Remove the rotation handle."""
+        if not hasattr(self, '_rotation_handle') or self._rotation_handle is None:
+            return
+
+        if self._rotation_handle.scene() is not None:
+            self._rotation_handle.scene().removeItem(self._rotation_handle)
+        self._rotation_handle = None
+
+        # Remove angle display
+        if hasattr(self, '_angle_display') and self._angle_display is not None:
+            if self._angle_display.scene() is not None:
+                self._angle_display.scene().removeItem(self._angle_display)
+            self._angle_display = None
+
+    def update_rotation_handle(self) -> None:
+        """Update position of the rotation handle."""
+        if not hasattr(self, '_rotation_handle') or self._rotation_handle is None:
+            return
+
+        self._rotation_handle.update_position()
+
+    def show_rotation_handle(self) -> None:
+        """Show the rotation handle."""
+        if not hasattr(self, '_rotation_handle') or self._rotation_handle is None:
+            self.create_rotation_handle()
+
+        if self._rotation_handle is not None:
+            self._rotation_handle.show()
+
+    def hide_rotation_handle(self) -> None:
+        """Hide the rotation handle."""
+        if not hasattr(self, '_rotation_handle') or self._rotation_handle is None:
+            return
+
+        self._rotation_handle.hide()
+
+    def _on_rotation_start(self) -> None:
+        """Called when a rotation operation starts."""
+        # Store initial angle for undo
+        self._rotation_initial_angle = self._rotation_angle
+
+    def _on_rotation_end(self, initial_angle: float) -> None:
+        """Called when a rotation operation completes.
+
+        Override in subclass to register undo command.
+
+        Args:
+            initial_angle: The angle before rotation started
+        """
+        pass
+
+    def _apply_rotation(self, angle: float) -> None:
+        """Apply a rotation transformation.
+
+        Args:
+            angle: New rotation angle in degrees
+        """
+        self._rotation_angle = angle
+
+        # Apply the rotation transform to the item
+        if hasattr(self, 'setRotation'):
+            # Get the center of the bounding rect for rotation pivot
+            if hasattr(self, 'boundingRect'):
+                rect = self.boundingRect()  # type: ignore[attr-defined]
+                center = rect.center()
+
+                # Set transform origin to center
+                if hasattr(self, 'setTransformOriginPoint'):
+                    self.setTransformOriginPoint(center)  # type: ignore[attr-defined]
+
+            self.setRotation(angle)  # type: ignore[attr-defined]
+
+        # Update handles
+        if hasattr(self, 'update_resize_handles'):
+            self.update_resize_handles()  # type: ignore[attr-defined]
+        self.update_rotation_handle()
+
+        # Update label position
+        if hasattr(self, '_position_label'):
+            self._position_label()  # type: ignore[attr-defined]


### PR DESCRIPTION
## Summary
- Add rotation support for all canvas object types (rectangles, polygons, circles, polylines)
- Green circular rotation handle appears above selected objects when in selection mode
- Hold Shift while dragging to snap rotation to 15-degree increments
- Live angle display shows current rotation during drag operation

## Technical Details
- **resize_handle.py**: Added `RotationHandle`, `AngleDisplay`, and `RotationHandleMixin` classes
- **commands.py**: Added `RotateItemCommand` for full undo/redo support
- **rectangle_item.py, polygon_item.py, circle_item.py, polyline_item.py**: Integrated rotation mixin
- **project.py**: Added rotation angle serialization for save/load

## Test Plan
- [ ] Select any object and verify green rotation handle appears above it
- [ ] Drag rotation handle and verify object rotates around its center
- [ ] Hold Shift while rotating and verify 15-degree snap behavior
- [ ] Verify angle display shows during rotation
- [ ] Test undo/redo of rotation operations
- [ ] Save project with rotated objects, reload, and verify rotation is preserved

:robot: Generated with [Claude Code](https://claude.com/claude-code)