### PR TITLE
feat(US-B.3): Vertex coordinate and edge length annotations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,4 +166,4 @@ tests/
 | ------ | --- | ------------------------------------------ |
 | ✅     | B.1 | Rotate objects (free + 15° snap)           |
 | ✅     | B.2 | Edit polygon vertices (move, add, remove)  |
-|        | -   | Vertex coordinate annotations on selection |
+| ✅     | B.3 | Vertex coordinate annotations on selection |

--- a/src/open_garden_planner/ui/canvas/items/polygon_item.py
+++ b/src/open_garden_planner/ui/canvas/items/polygon_item.py
@@ -182,6 +182,7 @@ class PolygonItem(VertexEditMixin, RotationHandleMixin, ResizeHandlesMixin, Gard
 
         Shows/hides resize and rotation handles based on selection state.
         Exits vertex edit mode when deselected.
+        Updates annotations when position changes.
         """
         if change == QGraphicsItem.GraphicsItemChange.ItemSelectedChange:
             if value:  # Being selected
@@ -195,6 +196,8 @@ class PolygonItem(VertexEditMixin, RotationHandleMixin, ResizeHandlesMixin, Gard
                     self.exit_vertex_edit_mode()
                 self.hide_resize_handles()
                 self.hide_rotation_handle()
+        elif change == QGraphicsItem.GraphicsItemChange.ItemPositionHasChanged and self.is_vertex_edit_mode:
+            self._update_annotations()
 
         return super().itemChange(change, value)
 

--- a/src/open_garden_planner/ui/canvas/items/polyline_item.py
+++ b/src/open_garden_planner/ui/canvas/items/polyline_item.py
@@ -96,6 +96,7 @@ class PolylineItem(PolylineVertexEditMixin, RotationHandleMixin, GardenItemMixin
 
         Shows/hides rotation handle based on selection state.
         Exits vertex edit mode when deselected.
+        Updates annotations when position changes.
         """
         if change == QGraphicsItem.GraphicsItemChange.ItemSelectedChange:
             if value:  # Being selected
@@ -105,6 +106,8 @@ class PolylineItem(PolylineVertexEditMixin, RotationHandleMixin, GardenItemMixin
                 if self.is_vertex_edit_mode:
                     self.exit_vertex_edit_mode()
                 self.hide_rotation_handle()
+        elif change == QGraphicsItem.GraphicsItemChange.ItemPositionHasChanged and self.is_vertex_edit_mode:
+            self._update_annotations()
 
         return super().itemChange(change, value)
 

--- a/src/open_garden_planner/ui/canvas/items/rectangle_item.py
+++ b/src/open_garden_planner/ui/canvas/items/rectangle_item.py
@@ -186,6 +186,7 @@ class RectangleItem(RectVertexEditMixin, RotationHandleMixin, ResizeHandlesMixin
 
         Shows/hides resize and rotation handles based on selection state.
         Exits vertex edit mode when deselected.
+        Updates annotations when position changes.
         """
         if change == QGraphicsItem.GraphicsItemChange.ItemSelectedChange:
             if value:  # Being selected
@@ -199,6 +200,8 @@ class RectangleItem(RectVertexEditMixin, RotationHandleMixin, ResizeHandlesMixin
                     self.exit_vertex_edit_mode()
                 self.hide_resize_handles()
                 self.hide_rotation_handle()
+        elif change == QGraphicsItem.GraphicsItemChange.ItemPositionHasChanged and self.is_vertex_edit_mode:
+            self._update_rect_annotations()
 
         return super().itemChange(change, value)
 


### PR DESCRIPTION
## Summary
- **Coordinate annotations** at each vertex showing absolute `(x, y)` position in meters/cm
- **Edge length annotations** at each edge midpoint showing distance between vertices
- **Circle diameter annotation** with ⌀ symbol and center coordinates on selection
- All annotations update in **real-time** during move, resize, and vertex editing

## Technical Details
- New `AnnotationLabel` class in `resize_handle.py` — `QGraphicsItem` with rounded background, fixed screen size (`ItemIgnoresTransformations`)
- Helper functions `_format_coordinate()`, `_format_edge_length()`, `_edge_length()` for consistent formatting
- Annotations managed in all three vertex edit mixins (`VertexEditMixin`, `RectVertexEditMixin`, `PolylineVertexEditMixin`)
- Circle annotations managed directly in `CircleItem` (no vertex edit mode)
- `ItemPositionHasChanged` hook in all item types updates annotations during moves

## Test plan
- [x] 499 tests pass
- [x] Ruff lint clean
- [x] Manually tested: polygon vertex annotations (coordinates + edge lengths)
- [x] Manually tested: rectangle corner annotations
- [x] Manually tested: polyline vertex annotations
- [x] Manually tested: circle diameter and center annotations
- [x] Manually tested: annotations update when moving objects
- [x] Manually tested: annotations update when resizing
- [x] Manually tested: annotations update when editing vertices
- [x] Manually tested: annotations appear/disappear with vertex edit mode entry/exit

🤖 Generated with [Claude Code](https://claude.com/claude-code)