### PR TITLE
feat(US-6.2): Illustrated SVG plant rendering

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,6 +121,7 @@ src/open_garden_planner/
 │   ├── project.py                # Save/load, ProjectManager
 │   ├── object_types.py           # ObjectType enum, default styles
 │   ├── fill_patterns.py          # Texture/pattern rendering
+│   ├── plant_renderer.py         # Plant SVG loading, caching, rendering
 │   ├── geometry/                 # Point, Polygon, Rectangle primitives
 │   └── tools/                    # Drawing tools
 │       ├── base_tool.py          # ToolType enum, BaseTool ABC
@@ -178,7 +179,7 @@ tests/
 | Status | US   | Description                                       |
 | ------ | ---- | ------------------------------------------------- |
 | :white_check_mark: | 6.1  | Rich tileable PNG textures for all materials      |
-|        | 6.2  | Illustrated SVG plant rendering (hybrid approach) |
+| :white_check_mark: | 6.2  | Illustrated SVG plant rendering (hybrid approach) |
 |        | 6.3  | Drop shadows on all objects (toggleable)          |
 |        | 6.4  | Visual scale bar on canvas                        |
 |        | 6.5  | Visual thumbnail gallery sidebar                  |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -127,7 +127,7 @@
 | ID | User Story | Priority | Status |
 |----|------------|----------|--------|
 | US-6.1 | Rich tileable textures for all materials | Must | :white_check_mark: Done |
-| US-6.2 | Illustrated SVG plant rendering (hybrid approach) | Must | |
+| US-6.2 | Illustrated SVG plant rendering (hybrid approach) | Must | :white_check_mark: Done |
 | US-6.3 | Drop shadows on all objects (toggleable) | Must | |
 | US-6.4 | Visual scale bar on canvas | Must | |
 | US-6.5 | Visual thumbnail gallery sidebar | Must | |

--- a/src/open_garden_planner/core/plant_renderer.py
+++ b/src/open_garden_planner/core/plant_renderer.py
@@ -1,0 +1,332 @@
+"""Plant SVG rendering system.
+
+Loads illustrated top-down SVG plant shapes and renders them
+as cached QPixmaps for display on the garden canvas. Supports
+category-based shapes (15 categories) and species-specific
+illustrations (8+ popular species).
+"""
+
+import hashlib
+from enum import Enum, auto
+from pathlib import Path
+
+from PyQt6.QtCore import QRectF, Qt
+from PyQt6.QtGui import QColor, QImage, QPainter, QPixmap
+from PyQt6.QtSvg import QSvgRenderer
+
+from .object_types import ObjectType
+
+# Directory containing plant SVG files
+_PLANTS_DIR = Path(__file__).parent.parent / "resources" / "plants"
+_CATEGORIES_DIR = _PLANTS_DIR / "categories"
+_SPECIES_DIR = _PLANTS_DIR / "species"
+
+
+class PlantCategory(Enum):
+    """Categories of plant shapes for SVG mapping."""
+
+    ROUND_DECIDUOUS = auto()
+    COLUMNAR_TREE = auto()
+    WEEPING_TREE = auto()
+    CONIFER = auto()
+    SPREADING_SHRUB = auto()
+    COMPACT_SHRUB = auto()
+    ORNAMENTAL_GRASS = auto()
+    FLOWERING_PERENNIAL = auto()
+    GROUND_COVER = auto()
+    CLIMBING_PLANT = auto()
+    HEDGE_SECTION = auto()
+    VEGETABLE = auto()
+    HERB = auto()
+    FRUIT_TREE = auto()
+    PALM = auto()
+
+
+# Map PlantCategory to SVG filename (without extension)
+_CATEGORY_FILES: dict[PlantCategory, str] = {
+    PlantCategory.ROUND_DECIDUOUS: "round_deciduous",
+    PlantCategory.COLUMNAR_TREE: "columnar_tree",
+    PlantCategory.WEEPING_TREE: "weeping_tree",
+    PlantCategory.CONIFER: "conifer",
+    PlantCategory.SPREADING_SHRUB: "spreading_shrub",
+    PlantCategory.COMPACT_SHRUB: "compact_shrub",
+    PlantCategory.ORNAMENTAL_GRASS: "ornamental_grass",
+    PlantCategory.FLOWERING_PERENNIAL: "flowering_perennial",
+    PlantCategory.GROUND_COVER: "ground_cover",
+    PlantCategory.CLIMBING_PLANT: "climbing_plant",
+    PlantCategory.HEDGE_SECTION: "hedge_section",
+    PlantCategory.VEGETABLE: "vegetable",
+    PlantCategory.HERB: "herb",
+    PlantCategory.FRUIT_TREE: "fruit_tree",
+    PlantCategory.PALM: "palm",
+}
+
+# Map species names (lowercase) to SVG filename (without extension)
+_SPECIES_FILES: dict[str, str] = {
+    "rose": "rose",
+    "rosa": "rose",
+    "lavender": "lavender",
+    "lavandula": "lavender",
+    "apple": "apple_tree",
+    "apple tree": "apple_tree",
+    "malus": "apple_tree",
+    "cherry": "cherry_tree",
+    "cherry tree": "cherry_tree",
+    "prunus": "cherry_tree",
+    "sunflower": "sunflower",
+    "helianthus": "sunflower",
+    "tomato": "tomato",
+    "solanum lycopersicum": "tomato",
+    "boxwood": "boxwood",
+    "buxus": "boxwood",
+    "box": "boxwood",
+    "rhododendron": "rhododendron",
+    "azalea": "rhododendron",
+}
+
+# Default category mapping for ObjectType
+_OBJECT_TYPE_DEFAULT_CATEGORY: dict[ObjectType, PlantCategory] = {
+    ObjectType.TREE: PlantCategory.ROUND_DECIDUOUS,
+    ObjectType.SHRUB: PlantCategory.SPREADING_SHRUB,
+    ObjectType.PERENNIAL: PlantCategory.FLOWERING_PERENNIAL,
+}
+
+# Cache for QSvgRenderer instances (path -> renderer)
+_renderer_cache: dict[str, QSvgRenderer] = {}
+
+# Cache for rendered pixmaps (cache_key -> QPixmap)
+_pixmap_cache: dict[str, QPixmap] = {}
+
+# Maximum pixmap cache entries before eviction
+_PIXMAP_CACHE_MAX = 300
+
+
+def _get_renderer(svg_path: Path) -> QSvgRenderer | None:
+    """Load or retrieve cached QSvgRenderer for an SVG file.
+
+    Args:
+        svg_path: Path to the SVG file
+
+    Returns:
+        QSvgRenderer instance, or None if file not found/invalid
+    """
+    key = str(svg_path)
+    if key in _renderer_cache:
+        return _renderer_cache[key]
+
+    if not svg_path.exists():
+        return None
+
+    renderer = QSvgRenderer(str(svg_path))
+    if not renderer.isValid():
+        return None
+
+    _renderer_cache[key] = renderer
+    return renderer
+
+
+def _resolve_svg_path(
+    object_type: ObjectType,
+    species: str = "",
+    category: PlantCategory | None = None,
+) -> Path | None:
+    """Resolve the SVG file path for a plant.
+
+    Priority:
+    1. Species-specific SVG (if species name matches)
+    2. Category SVG (if category specified)
+    3. Default category based on ObjectType
+
+    Args:
+        object_type: The plant's ObjectType (TREE, SHRUB, PERENNIAL)
+        species: Species name (optional)
+        category: Plant category (optional)
+
+    Returns:
+        Path to SVG file, or None if not a plant type
+    """
+    if object_type not in _OBJECT_TYPE_DEFAULT_CATEGORY:
+        return None
+
+    # 1. Try species-specific SVG
+    if species:
+        species_lower = species.lower().strip()
+        # Check direct match first
+        if species_lower in _SPECIES_FILES:
+            path = _SPECIES_DIR / f"{_SPECIES_FILES[species_lower]}.svg"
+            if path.exists():
+                return path
+        # Check partial match (species name contains a known key)
+        for key, filename in _SPECIES_FILES.items():
+            if key in species_lower or species_lower in key:
+                path = _SPECIES_DIR / f"{filename}.svg"
+                if path.exists():
+                    return path
+
+    # 2. Try category SVG
+    if category is not None:
+        filename = _CATEGORY_FILES.get(category)
+        if filename:
+            path = _CATEGORIES_DIR / f"{filename}.svg"
+            if path.exists():
+                return path
+
+    # 3. Fall back to default category based on ObjectType
+    default_category = _OBJECT_TYPE_DEFAULT_CATEGORY.get(object_type)
+    if default_category:
+        filename = _CATEGORY_FILES.get(default_category)
+        if filename:
+            path = _CATEGORIES_DIR / f"{filename}.svg"
+            if path.exists():
+                return path
+
+    return None
+
+
+def _stable_random_for_item(item_id: str, seed_offset: int = 0) -> float:
+    """Generate a stable pseudo-random value from an item ID.
+
+    This ensures the same item always gets the same random variation,
+    so plants don't change appearance on re-render.
+
+    Args:
+        item_id: Unique item identifier string
+        seed_offset: Offset to generate different random values for the same item
+
+    Returns:
+        Float between 0.0 and 1.0
+    """
+    h = hashlib.md5(f"{item_id}:{seed_offset}".encode()).hexdigest()
+    return int(h[:8], 16) / 0xFFFFFFFF
+
+
+def render_plant_pixmap(
+    object_type: ObjectType,
+    diameter: float,
+    item_id: str = "",
+    species: str = "",
+    category: PlantCategory | None = None,
+    tint_color: QColor | None = None,
+) -> QPixmap | None:
+    """Render a plant SVG to a QPixmap at the specified size.
+
+    Uses caching for performance. Applies slight random rotation
+    based on item_id for natural variation.
+
+    Args:
+        object_type: The plant's ObjectType
+        diameter: Target diameter in pixels
+        item_id: Unique item ID for stable randomization
+        species: Species name for SVG lookup
+        category: Plant category for SVG lookup
+        tint_color: Optional color tint to apply
+
+    Returns:
+        QPixmap with rendered plant, or None if no SVG available
+    """
+    svg_path = _resolve_svg_path(object_type, species, category)
+    if svg_path is None:
+        return None
+
+    renderer = _get_renderer(svg_path)
+    if renderer is None:
+        return None
+
+    # Calculate render size (use integer pixels)
+    size = max(int(diameter), 4)
+
+    # Generate stable random rotation for this specific item
+    rotation = 0.0
+    if item_id:
+        rotation = _stable_random_for_item(item_id, seed_offset=0) * 360.0
+
+    # Build cache key
+    tint_key = tint_color.rgba() if tint_color else 0
+    cache_key = f"{svg_path}:{size}:{int(rotation)}:{tint_key}"
+
+    if cache_key in _pixmap_cache:
+        return _pixmap_cache[cache_key]
+
+    # Evict cache if too large
+    if len(_pixmap_cache) >= _PIXMAP_CACHE_MAX:
+        _pixmap_cache.clear()
+
+    # Render SVG to QImage (for compositing)
+    image = QImage(size, size, QImage.Format.Format_ARGB32_Premultiplied)
+    image.fill(Qt.GlobalColor.transparent)
+
+    painter = QPainter(image)
+    painter.setRenderHint(QPainter.RenderHint.Antialiasing)
+    painter.setRenderHint(QPainter.RenderHint.SmoothPixmapTransform)
+
+    # Apply rotation around center
+    if abs(rotation) > 0.5:
+        center = size / 2.0
+        painter.translate(center, center)
+        painter.rotate(rotation)
+        painter.translate(-center, -center)
+
+    # Render SVG into the full area
+    renderer.render(painter, QRectF(0, 0, size, size))
+
+    # Apply color tint if specified
+    if tint_color is not None and tint_color.alpha() > 0:
+        painter.setCompositionMode(QPainter.CompositionMode.CompositionMode_SourceAtop)
+        tint = QColor(tint_color.red(), tint_color.green(), tint_color.blue(), 60)
+        painter.fillRect(0, 0, size, size, tint)
+
+    painter.end()
+
+    pixmap = QPixmap.fromImage(image)
+    _pixmap_cache[cache_key] = pixmap
+    return pixmap
+
+
+def is_plant_type(object_type: ObjectType | None) -> bool:
+    """Check if an ObjectType is a plant type.
+
+    Args:
+        object_type: The object type to check
+
+    Returns:
+        True if this is a plant type (TREE, SHRUB, PERENNIAL)
+    """
+    if object_type is None:
+        return False
+    return object_type in _OBJECT_TYPE_DEFAULT_CATEGORY
+
+
+def get_default_category(object_type: ObjectType) -> PlantCategory | None:
+    """Get the default plant category for an ObjectType.
+
+    Args:
+        object_type: The object type
+
+    Returns:
+        Default PlantCategory, or None if not a plant type
+    """
+    return _OBJECT_TYPE_DEFAULT_CATEGORY.get(object_type)
+
+
+def get_all_categories() -> list[PlantCategory]:
+    """Get all available plant categories.
+
+    Returns:
+        List of all PlantCategory values
+    """
+    return list(PlantCategory)
+
+
+def get_species_names() -> list[str]:
+    """Get all recognized species names with unique SVGs.
+
+    Returns:
+        Sorted list of species names
+    """
+    return sorted(set(_SPECIES_FILES.keys()))
+
+
+def clear_plant_cache() -> None:
+    """Clear all cached renderers and pixmaps."""
+    _renderer_cache.clear()
+    _pixmap_cache.clear()

--- a/src/open_garden_planner/core/project.py
+++ b/src/open_garden_planner/core/project.py
@@ -308,6 +308,11 @@ class ProjectManager(QObject):
             # Save rotation angle
             if hasattr(item, "rotation_angle") and abs(item.rotation_angle) > 0.01:
                 data["rotation_angle"] = item.rotation_angle
+            # Save plant category and species (for plant types)
+            if hasattr(item, "plant_category") and item.plant_category is not None:
+                data["plant_category"] = item.plant_category.name
+            if hasattr(item, "plant_species") and item.plant_species:
+                data["plant_species"] = item.plant_species
             return data
         elif isinstance(item, PolylineItem):
             data = {
@@ -533,6 +538,15 @@ class ProjectManager(QObject):
             # Restore rotation angle
             if "rotation_angle" in obj:
                 item._apply_rotation(obj["rotation_angle"])
+            # Restore plant category and species
+            if "plant_category" in obj:
+                import contextlib
+
+                from open_garden_planner.core.plant_renderer import PlantCategory
+                with contextlib.suppress(KeyError):
+                    item.plant_category = PlantCategory[obj["plant_category"]]
+            if "plant_species" in obj:
+                item.plant_species = obj["plant_species"]
             return item
         elif obj_type == "polyline":
             points = [QPointF(p["x"], p["y"]) for p in obj.get("points", [])]

--- a/src/open_garden_planner/resources/plants/categories/climbing_plant.svg
+++ b/src/open_garden_planner/resources/plants/categories/climbing_plant.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <!-- Climbing plant - elongated trailing/vine-like shape from above -->
+  <defs>
+    <radialGradient id="climb_fill" cx="50%" cy="50%" r="55%">
+      <stop offset="0%" stop-color="#5aaa35"/>
+      <stop offset="70%" stop-color="#4a9428"/>
+      <stop offset="100%" stop-color="#3a8020"/>
+    </radialGradient>
+  </defs>
+  <!-- Main vine mass (irregular elongated) -->
+  <path d="M25 30 C22 22 32 14 42 16 C50 18 58 14 66 18 C76 22 82 32 78 42 C82 48 80 56 74 62 C70 68 62 74 54 76 C48 78 40 80 34 76 C26 72 20 62 18 52 C16 44 20 36 25 30Z" fill="url(#climb_fill)" opacity="0.8"/>
+  <!-- Trailing vine tendrils -->
+  <path d="M74 62 C80 68 84 78 80 86" stroke="#4a9428" stroke-width="2.5" fill="none" opacity="0.6"/>
+  <path d="M54 76 C56 82 52 90 48 94" stroke="#4a9428" stroke-width="2" fill="none" opacity="0.55"/>
+  <path d="M34 76 C30 82 26 88 22 90" stroke="#4a9428" stroke-width="2" fill="none" opacity="0.5"/>
+  <path d="M25 30 C20 24 16 16 14 10" stroke="#4a9428" stroke-width="2" fill="none" opacity="0.5"/>
+  <!-- Leaf shapes along vine -->
+  <ellipse cx="40" cy="30" rx="8" ry="6" fill="#62b240" opacity="0.55"/>
+  <ellipse cx="62" cy="32" rx="7" ry="6" fill="#5aaa38" opacity="0.5"/>
+  <ellipse cx="70" cy="50" rx="7" ry="6" fill="#62b240" opacity="0.5"/>
+  <ellipse cx="55" cy="62" rx="8" ry="6" fill="#5aaa38" opacity="0.45"/>
+  <ellipse cx="35" cy="58" rx="7" ry="6" fill="#62b240" opacity="0.45"/>
+  <!-- Small flower accents -->
+  <circle cx="44" cy="24" r="2.5" fill="#a080c0" opacity="0.6"/>
+  <circle cx="66" cy="40" r="2" fill="#a080c0" opacity="0.55"/>
+  <circle cx="48" cy="68" r="2.5" fill="#a080c0" opacity="0.5"/>
+</svg>

--- a/src/open_garden_planner/resources/plants/categories/columnar_tree.svg
+++ b/src/open_garden_planner/resources/plants/categories/columnar_tree.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <!-- Columnar tree - narrow upright oval from above -->
+  <defs>
+    <radialGradient id="col_canopy" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#4a8c3f"/>
+      <stop offset="70%" stop-color="#3a7530"/>
+      <stop offset="100%" stop-color="#2a5f22"/>
+    </radialGradient>
+  </defs>
+  <!-- Narrow oval canopy -->
+  <ellipse cx="50" cy="50" rx="22" ry="42" fill="url(#col_canopy)" opacity="0.9"/>
+  <!-- Vertical leaf detail -->
+  <ellipse cx="45" cy="35" rx="10" ry="18" fill="#55a044" opacity="0.5"/>
+  <ellipse cx="55" cy="55" rx="10" ry="16" fill="#4d9438" opacity="0.5"/>
+  <ellipse cx="50" cy="45" rx="8" ry="14" fill="#62b050" opacity="0.4"/>
+  <!-- Trunk shadow -->
+  <circle cx="50" cy="50" r="4" fill="#3a2a1a" opacity="0.35"/>
+  <!-- Highlights -->
+  <ellipse cx="46" cy="38" rx="4" ry="7" fill="#7cc46a" opacity="0.3"/>
+</svg>

--- a/src/open_garden_planner/resources/plants/categories/compact_shrub.svg
+++ b/src/open_garden_planner/resources/plants/categories/compact_shrub.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <!-- Compact shrub - small, dense, rounded shape -->
+  <defs>
+    <radialGradient id="compact_fill" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#5ea035"/>
+      <stop offset="70%" stop-color="#4d8c2c"/>
+      <stop offset="100%" stop-color="#3d7822"/>
+    </radialGradient>
+  </defs>
+  <!-- Dense round base -->
+  <ellipse cx="50" cy="50" rx="32" ry="30" fill="url(#compact_fill)" opacity="0.9"/>
+  <!-- Tight leaf clusters -->
+  <circle cx="42" cy="42" r="12" fill="#68ac3e" opacity="0.55"/>
+  <circle cx="58" cy="44" r="11" fill="#62a438" opacity="0.5"/>
+  <circle cx="50" cy="58" r="11" fill="#68ac3e" opacity="0.45"/>
+  <circle cx="38" cy="55" r="9" fill="#62a438" opacity="0.4"/>
+  <circle cx="60" cy="56" r="9" fill="#68ac3e" opacity="0.4"/>
+  <!-- Highlight spots -->
+  <circle cx="44" cy="44" r="4" fill="#82c450" opacity="0.35"/>
+  <circle cx="56" cy="50" r="3" fill="#82c450" opacity="0.3"/>
+</svg>

--- a/src/open_garden_planner/resources/plants/categories/conifer.svg
+++ b/src/open_garden_planner/resources/plants/categories/conifer.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <!-- Conifer/pine tree - star-shaped from above with radiating branches -->
+  <defs>
+    <radialGradient id="pine_canopy" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#2d6b3a"/>
+      <stop offset="60%" stop-color="#1f5c2e"/>
+      <stop offset="100%" stop-color="#164d24"/>
+    </radialGradient>
+  </defs>
+  <!-- Radiating branch structure -->
+  <path d="M50 8 L56 38 L88 30 L62 50 L90 62 L58 58 L68 90 L50 62 L32 90 L42 58 L10 62 L38 50 L12 30 L44 38Z" fill="url(#pine_canopy)" opacity="0.85"/>
+  <!-- Secondary branch layer -->
+  <path d="M50 18 L54 40 L76 34 L58 50 L78 58 L56 56 L62 78 L50 58 L38 78 L44 56 L22 58 L42 50 L24 34 L46 40Z" fill="#2d7b3e" opacity="0.6"/>
+  <!-- Inner canopy -->
+  <circle cx="50" cy="50" r="16" fill="#358544" opacity="0.7"/>
+  <!-- Trunk center -->
+  <circle cx="50" cy="50" r="4" fill="#4a3520" opacity="0.5"/>
+  <!-- Needle texture highlights -->
+  <circle cx="44" cy="44" r="3" fill="#4a9a55" opacity="0.3"/>
+  <circle cx="56" cy="46" r="3" fill="#4a9a55" opacity="0.25"/>
+</svg>

--- a/src/open_garden_planner/resources/plants/categories/flowering_perennial.svg
+++ b/src/open_garden_planner/resources/plants/categories/flowering_perennial.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <!-- Flowering perennial - leafy mound with flower dots -->
+  <defs>
+    <radialGradient id="peren_fill" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#5ea838"/>
+      <stop offset="70%" stop-color="#4d9430"/>
+      <stop offset="100%" stop-color="#3d8025"/>
+    </radialGradient>
+  </defs>
+  <!-- Leafy base mound -->
+  <path d="M14 50 C12 30 24 12 42 10 C52 8 60 14 66 10 C82 8 94 26 92 46 C94 60 86 76 74 84 C62 92 40 92 26 84 C12 76 8 62 14 50Z" fill="url(#peren_fill)" opacity="0.85"/>
+  <!-- Leaf clusters -->
+  <circle cx="34" cy="32" r="15" fill="#68b040" opacity="0.5"/>
+  <circle cx="66" cy="34" r="14" fill="#60a83a" opacity="0.45"/>
+  <circle cx="50" cy="62" r="15" fill="#68b040" opacity="0.45"/>
+  <circle cx="28" cy="56" r="13" fill="#60a83a" opacity="0.4"/>
+  <circle cx="72" cy="56" r="12" fill="#68b040" opacity="0.4"/>
+  <circle cx="50" cy="40" r="11" fill="#60a83a" opacity="0.35"/>
+  <!-- Flower dots -->
+  <circle cx="38" cy="26" r="5" fill="#e86090" opacity="0.8"/>
+  <circle cx="64" cy="30" r="4.5" fill="#e86090" opacity="0.75"/>
+  <circle cx="58" cy="52" r="4" fill="#e86090" opacity="0.7"/>
+  <circle cx="30" cy="46" r="4.5" fill="#e86090" opacity="0.75"/>
+  <circle cx="50" cy="72" r="4" fill="#e86090" opacity="0.7"/>
+  <circle cx="74" cy="52" r="3.5" fill="#e86090" opacity="0.65"/>
+  <circle cx="22" cy="36" r="3.5" fill="#e86090" opacity="0.6"/>
+  <!-- Flower centers -->
+  <circle cx="38" cy="26" r="2" fill="#f0c040" opacity="0.8"/>
+  <circle cx="64" cy="30" r="1.8" fill="#f0c040" opacity="0.75"/>
+  <circle cx="58" cy="52" r="1.5" fill="#f0c040" opacity="0.7"/>
+  <circle cx="30" cy="46" r="1.8" fill="#f0c040" opacity="0.75"/>
+  <circle cx="50" cy="72" r="1.5" fill="#f0c040" opacity="0.7"/>
+</svg>

--- a/src/open_garden_planner/resources/plants/categories/fruit_tree.svg
+++ b/src/open_garden_planner/resources/plants/categories/fruit_tree.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <!-- Fruit tree - round canopy with fruit dots -->
+  <defs>
+    <radialGradient id="fruit_canopy" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#4a8c3f"/>
+      <stop offset="60%" stop-color="#3d7a34"/>
+      <stop offset="100%" stop-color="#2d6425"/>
+    </radialGradient>
+  </defs>
+  <!-- Main canopy (similar to round deciduous) -->
+  <ellipse cx="50" cy="50" rx="42" ry="40" fill="url(#fruit_canopy)" opacity="0.9"/>
+  <!-- Leaf clusters -->
+  <circle cx="36" cy="36" r="16" fill="#55a044" opacity="0.6"/>
+  <circle cx="62" cy="34" r="14" fill="#4d9438" opacity="0.55"/>
+  <circle cx="56" cy="62" r="15" fill="#508f3c" opacity="0.5"/>
+  <circle cx="32" cy="58" r="13" fill="#55a044" opacity="0.5"/>
+  <circle cx="50" cy="44" r="12" fill="#5da846" opacity="0.45"/>
+  <!-- Trunk shadow -->
+  <circle cx="50" cy="50" r="5" fill="#3a2a1a" opacity="0.35"/>
+  <!-- Fruit dots (red apples/cherries) -->
+  <circle cx="38" cy="30" r="3.5" fill="#d44040" opacity="0.8"/>
+  <circle cx="65" cy="38" r="3" fill="#d44040" opacity="0.75"/>
+  <circle cx="58" cy="58" r="3.5" fill="#d44040" opacity="0.7"/>
+  <circle cx="30" cy="52" r="3" fill="#d44040" opacity="0.75"/>
+  <circle cx="48" cy="70" r="3" fill="#d44040" opacity="0.65"/>
+  <circle cx="70" cy="52" r="2.5" fill="#d44040" opacity="0.6"/>
+  <circle cx="42" cy="42" r="2.5" fill="#d44040" opacity="0.7"/>
+  <!-- Highlight on leaves -->
+  <circle cx="40" cy="38" r="5" fill="#7cc46a" opacity="0.3"/>
+  <circle cx="60" cy="48" r="4" fill="#7cc46a" opacity="0.25"/>
+</svg>

--- a/src/open_garden_planner/resources/plants/categories/ground_cover.svg
+++ b/src/open_garden_planner/resources/plants/categories/ground_cover.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <!-- Ground cover - low, spreading, mat-like pattern -->
+  <defs>
+    <radialGradient id="gc_fill" cx="50%" cy="50%" r="55%">
+      <stop offset="0%" stop-color="#6aac38"/>
+      <stop offset="70%" stop-color="#5a9830"/>
+      <stop offset="100%" stop-color="#4a8428"/>
+    </radialGradient>
+  </defs>
+  <!-- Irregular spreading base -->
+  <path d="M15 48 C12 36 22 22 38 18 C48 14 56 16 66 14 C80 12 92 26 90 42 C92 54 86 66 78 74 C68 82 58 88 44 86 C32 84 20 78 14 66 C10 58 12 52 15 48Z" fill="url(#gc_fill)" opacity="0.75"/>
+  <!-- Small leaf rosettes scattered -->
+  <circle cx="30" cy="35" r="8" fill="#72b440" opacity="0.55"/>
+  <circle cx="50" cy="28" r="7" fill="#6aac38" opacity="0.5"/>
+  <circle cx="70" cy="35" r="8" fill="#72b440" opacity="0.5"/>
+  <circle cx="38" cy="52" r="7" fill="#6aac38" opacity="0.5"/>
+  <circle cx="58" cy="50" r="8" fill="#72b440" opacity="0.45"/>
+  <circle cx="75" cy="55" r="7" fill="#6aac38" opacity="0.45"/>
+  <circle cx="28" cy="65" r="7" fill="#72b440" opacity="0.45"/>
+  <circle cx="50" cy="68" r="8" fill="#6aac38" opacity="0.4"/>
+  <circle cx="68" cy="70" r="7" fill="#72b440" opacity="0.4"/>
+  <!-- Tiny flower dots -->
+  <circle cx="35" cy="38" r="2" fill="#c8a0d8" opacity="0.6"/>
+  <circle cx="55" cy="32" r="1.8" fill="#c8a0d8" opacity="0.55"/>
+  <circle cx="65" cy="55" r="2" fill="#c8a0d8" opacity="0.5"/>
+  <circle cx="45" cy="62" r="1.8" fill="#c8a0d8" opacity="0.55"/>
+</svg>

--- a/src/open_garden_planner/resources/plants/categories/hedge_section.svg
+++ b/src/open_garden_planner/resources/plants/categories/hedge_section.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <!-- Hedge section - rectangular trimmed shape from above -->
+  <defs>
+    <linearGradient id="hedge_fill" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#4a8c30"/>
+      <stop offset="50%" stop-color="#3d7a28"/>
+      <stop offset="100%" stop-color="#326820"/>
+    </linearGradient>
+  </defs>
+  <!-- Trimmed rectangular hedge mass -->
+  <rect x="10" y="25" width="80" height="50" rx="6" ry="6" fill="#3d7a28" opacity="0.9"/>
+  <!-- Surface texture - tight leaf clusters -->
+  <circle cx="22" cy="38" r="7" fill="#508c35" opacity="0.5"/>
+  <circle cx="36" cy="42" r="8" fill="#4a8430" opacity="0.45"/>
+  <circle cx="50" cy="38" r="7" fill="#508c35" opacity="0.5"/>
+  <circle cx="64" cy="42" r="8" fill="#4a8430" opacity="0.45"/>
+  <circle cx="78" cy="38" r="7" fill="#508c35" opacity="0.5"/>
+  <circle cx="28" cy="56" r="7" fill="#4a8430" opacity="0.45"/>
+  <circle cx="42" cy="58" r="8" fill="#508c35" opacity="0.45"/>
+  <circle cx="58" cy="56" r="7" fill="#4a8430" opacity="0.45"/>
+  <circle cx="72" cy="58" r="8" fill="#508c35" opacity="0.45"/>
+  <!-- Highlight spots on top -->
+  <circle cx="30" cy="40" r="3" fill="#60a040" opacity="0.35"/>
+  <circle cx="55" cy="42" r="3" fill="#60a040" opacity="0.3"/>
+  <circle cx="70" cy="40" r="3" fill="#60a040" opacity="0.3"/>
+  <!-- Subtle shadow edge at bottom -->
+  <rect x="10" y="65" width="80" height="10" rx="4" ry="4" fill="#2a5a18" opacity="0.25"/>
+</svg>

--- a/src/open_garden_planner/resources/plants/categories/herb.svg
+++ b/src/open_garden_planner/resources/plants/categories/herb.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <!-- Herb plant - small bushy aromatic plant with fine leaves -->
+  <defs>
+    <radialGradient id="herb_fill" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#6cb838"/>
+      <stop offset="70%" stop-color="#5aa42e"/>
+      <stop offset="100%" stop-color="#4a9024"/>
+    </radialGradient>
+  </defs>
+  <!-- Small bushy base -->
+  <ellipse cx="50" cy="50" rx="30" ry="28" fill="url(#herb_fill)" opacity="0.8"/>
+  <!-- Fine leaf sprigs radiating -->
+  <ellipse cx="50" cy="24" rx="5" ry="12" fill="#62b034" opacity="0.6"/>
+  <ellipse cx="50" cy="76" rx="5" ry="12" fill="#62b034" opacity="0.55"/>
+  <ellipse cx="24" cy="50" rx="12" ry="5" fill="#62b034" opacity="0.6"/>
+  <ellipse cx="76" cy="50" rx="12" ry="5" fill="#62b034" opacity="0.55"/>
+  <ellipse cx="30" cy="32" rx="4" ry="10" fill="#5aa82e" opacity="0.5" transform="rotate(-45 30 32)"/>
+  <ellipse cx="70" cy="32" rx="4" ry="10" fill="#5aa82e" opacity="0.45" transform="rotate(45 70 32)"/>
+  <ellipse cx="32" cy="68" rx="4" ry="10" fill="#5aa82e" opacity="0.45" transform="rotate(45 32 68)"/>
+  <ellipse cx="68" cy="68" rx="4" ry="10" fill="#5aa82e" opacity="0.4" transform="rotate(-45 68 68)"/>
+  <!-- Leaf cluster bumps -->
+  <circle cx="42" cy="42" r="8" fill="#72c042" opacity="0.45"/>
+  <circle cx="58" cy="44" r="7" fill="#6abc3c" opacity="0.4"/>
+  <circle cx="50" cy="56" r="7" fill="#72c042" opacity="0.4"/>
+  <!-- Center -->
+  <circle cx="50" cy="50" r="4" fill="#80cc50" opacity="0.4"/>
+</svg>

--- a/src/open_garden_planner/resources/plants/categories/ornamental_grass.svg
+++ b/src/open_garden_planner/resources/plants/categories/ornamental_grass.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <!-- Ornamental grass - radiating blade-like leaves from center -->
+  <defs>
+    <radialGradient id="grass_center" cx="50%" cy="50%" r="30%">
+      <stop offset="0%" stop-color="#8ab848"/>
+      <stop offset="100%" stop-color="#6a9830"/>
+    </radialGradient>
+  </defs>
+  <!-- Radiating grass blades -->
+  <path d="M50 50 L52 8 Q50 20 48 8Z" fill="#7aaa3c" opacity="0.7"/>
+  <path d="M50 50 L68 12 Q58 22 62 10Z" fill="#82b244" opacity="0.65"/>
+  <path d="M50 50 L88 28 Q74 34 86 22Z" fill="#7aaa3c" opacity="0.7"/>
+  <path d="M50 50 L92 50 Q80 48 92 44Z" fill="#72a236" opacity="0.65"/>
+  <path d="M50 50 L86 72 Q76 64 88 68Z" fill="#7aaa3c" opacity="0.7"/>
+  <path d="M50 50 L68 90 Q62 78 72 88Z" fill="#82b244" opacity="0.65"/>
+  <path d="M50 50 L48 92 Q50 80 52 92Z" fill="#7aaa3c" opacity="0.7"/>
+  <path d="M50 50 L30 88 Q38 78 28 86Z" fill="#72a236" opacity="0.65"/>
+  <path d="M50 50 L12 72 Q22 64 10 70Z" fill="#7aaa3c" opacity="0.7"/>
+  <path d="M50 50 L8 48 Q20 48 8 52Z" fill="#82b244" opacity="0.65"/>
+  <path d="M50 50 L14 26 Q24 34 12 30Z" fill="#7aaa3c" opacity="0.7"/>
+  <path d="M50 50 L34 10 Q40 22 30 14Z" fill="#72a236" opacity="0.65"/>
+  <!-- Secondary thinner blades -->
+  <path d="M50 50 L58 14 Q54 26 60 16Z" fill="#90c450" opacity="0.45"/>
+  <path d="M50 50 L84 38 Q72 40 82 34Z" fill="#90c450" opacity="0.4"/>
+  <path d="M50 50 L78 78 Q68 70 76 76Z" fill="#90c450" opacity="0.45"/>
+  <path d="M50 50 L38 86 Q42 74 36 84Z" fill="#90c450" opacity="0.4"/>
+  <path d="M50 50 L14 58 Q26 54 16 60Z" fill="#90c450" opacity="0.45"/>
+  <path d="M50 50 L24 18 Q32 26 22 20Z" fill="#90c450" opacity="0.4"/>
+  <!-- Center clump -->
+  <circle cx="50" cy="50" r="8" fill="url(#grass_center)" opacity="0.9"/>
+</svg>

--- a/src/open_garden_planner/resources/plants/categories/palm.svg
+++ b/src/open_garden_planner/resources/plants/categories/palm.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <!-- Palm tree - star/fan-shaped fronds from above -->
+  <defs>
+    <radialGradient id="palm_center" cx="50%" cy="50%" r="20%">
+      <stop offset="0%" stop-color="#8a7040"/>
+      <stop offset="100%" stop-color="#6a5530"/>
+    </radialGradient>
+  </defs>
+  <!-- Palm fronds radiating outward -->
+  <path d="M50 50 L42 6 Q50 22 58 6Z" fill="#3a8a28" opacity="0.75"/>
+  <path d="M50 50 L82 14 Q66 28 86 10Z" fill="#429230" opacity="0.7"/>
+  <path d="M50 50 L94 42 Q78 46 96 38Z" fill="#3a8a28" opacity="0.75"/>
+  <path d="M50 50 L90 72 Q76 64 92 68Z" fill="#429230" opacity="0.7"/>
+  <path d="M50 50 L62 94 Q54 78 66 92Z" fill="#3a8a28" opacity="0.7"/>
+  <path d="M50 50 L20 88 Q32 76 18 86Z" fill="#429230" opacity="0.65"/>
+  <path d="M50 50 L6 58 Q22 54 4 62Z" fill="#3a8a28" opacity="0.75"/>
+  <path d="M50 50 L10 28 Q24 36 8 32Z" fill="#429230" opacity="0.7"/>
+  <!-- Wider frond shapes overlaid -->
+  <path d="M50 50 Q44 30 42 6 Q50 28 58 6 Q56 30 50 50Z" fill="#4a9a35" opacity="0.45"/>
+  <path d="M50 50 Q62 36 82 14 Q64 34 86 10 Q68 38 50 50Z" fill="#4a9a35" opacity="0.4"/>
+  <path d="M50 50 Q58 44 94 42 Q60 48 96 38 Q62 50 50 50Z" fill="#4a9a35" opacity="0.45"/>
+  <path d="M50 50 Q58 58 90 72 Q60 62 92 68 Q62 60 50 50Z" fill="#4a9a35" opacity="0.4"/>
+  <path d="M50 50 Q54 62 62 94 Q52 64 66 92 Q56 62 50 50Z" fill="#4a9a35" opacity="0.4"/>
+  <path d="M50 50 Q42 60 20 88 Q40 62 18 86 Q38 58 50 50Z" fill="#4a9a35" opacity="0.35"/>
+  <path d="M50 50 Q40 54 6 58 Q38 52 4 62 Q36 50 50 50Z" fill="#4a9a35" opacity="0.45"/>
+  <path d="M50 50 Q40 40 10 28 Q38 38 8 32 Q36 38 50 50Z" fill="#4a9a35" opacity="0.4"/>
+  <!-- Trunk center -->
+  <circle cx="50" cy="50" r="7" fill="url(#palm_center)" opacity="0.9"/>
+  <circle cx="50" cy="50" r="4" fill="#7a6540" opacity="0.6"/>
+</svg>

--- a/src/open_garden_planner/resources/plants/categories/round_deciduous.svg
+++ b/src/open_garden_planner/resources/plants/categories/round_deciduous.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <!-- Round deciduous tree - top-down view with organic leaf clusters -->
+  <defs>
+    <radialGradient id="canopy" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#4a8c3f"/>
+      <stop offset="60%" stop-color="#3d7a34"/>
+      <stop offset="100%" stop-color="#2d6425"/>
+    </radialGradient>
+  </defs>
+  <!-- Main canopy -->
+  <ellipse cx="50" cy="50" rx="44" ry="42" fill="url(#canopy)" opacity="0.9"/>
+  <!-- Leaf cluster details -->
+  <circle cx="35" cy="35" r="18" fill="#55a044" opacity="0.7"/>
+  <circle cx="62" cy="32" r="16" fill="#4d9438" opacity="0.65"/>
+  <circle cx="55" cy="60" r="17" fill="#508f3c" opacity="0.6"/>
+  <circle cx="30" cy="58" r="15" fill="#59a848" opacity="0.55"/>
+  <circle cx="50" cy="42" r="14" fill="#62b050" opacity="0.5"/>
+  <circle cx="68" cy="55" r="12" fill="#4a8c3f" opacity="0.5"/>
+  <circle cx="40" cy="70" r="11" fill="#55a044" opacity="0.45"/>
+  <!-- Trunk shadow at center -->
+  <circle cx="50" cy="50" r="5" fill="#3a2a1a" opacity="0.4"/>
+  <!-- Highlight spots -->
+  <circle cx="38" cy="38" r="6" fill="#7cc46a" opacity="0.35"/>
+  <circle cx="60" cy="45" r="5" fill="#7cc46a" opacity="0.3"/>
+</svg>

--- a/src/open_garden_planner/resources/plants/categories/spreading_shrub.svg
+++ b/src/open_garden_planner/resources/plants/categories/spreading_shrub.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <!-- Spreading shrub - wide irregular organic shape -->
+  <defs>
+    <radialGradient id="shrub_fill" cx="50%" cy="50%" r="55%">
+      <stop offset="0%" stop-color="#6ba832"/>
+      <stop offset="60%" stop-color="#5a9428"/>
+      <stop offset="100%" stop-color="#4a8020"/>
+    </radialGradient>
+  </defs>
+  <!-- Wide irregular base shape -->
+  <path d="M18 45 C16 32 28 18 42 16 C52 14 58 18 65 16 C78 14 90 28 88 42 C90 52 86 62 80 70 C72 80 60 86 48 86 C36 86 24 80 18 70 C12 60 14 52 18 45Z" fill="url(#shrub_fill)" opacity="0.85"/>
+  <!-- Leaf cluster bumps -->
+  <circle cx="35" cy="30" r="14" fill="#72b43a" opacity="0.55"/>
+  <circle cx="60" cy="28" r="12" fill="#6aac34" opacity="0.5"/>
+  <circle cx="72" cy="50" r="13" fill="#72b43a" opacity="0.5"/>
+  <circle cx="55" cy="68" r="14" fill="#6aac34" opacity="0.45"/>
+  <circle cx="32" cy="60" r="12" fill="#72b43a" opacity="0.45"/>
+  <circle cx="48" cy="45" r="10" fill="#7ec048" opacity="0.4"/>
+  <!-- Small detail highlights -->
+  <circle cx="38" cy="32" r="4" fill="#90d060" opacity="0.35"/>
+  <circle cx="62" cy="48" r="3" fill="#90d060" opacity="0.3"/>
+  <circle cx="45" cy="62" r="3" fill="#90d060" opacity="0.3"/>
+</svg>

--- a/src/open_garden_planner/resources/plants/categories/vegetable.svg
+++ b/src/open_garden_planner/resources/plants/categories/vegetable.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <!-- Vegetable plant - leafy rosette pattern -->
+  <defs>
+    <radialGradient id="veg_fill" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#68b438"/>
+      <stop offset="70%" stop-color="#58a02e"/>
+      <stop offset="100%" stop-color="#488c24"/>
+    </radialGradient>
+  </defs>
+  <!-- Large leaves radiating from center -->
+  <ellipse cx="50" cy="25" rx="12" ry="20" fill="#58a830" opacity="0.7"/>
+  <ellipse cx="50" cy="75" rx="12" ry="20" fill="#58a830" opacity="0.65"/>
+  <ellipse cx="25" cy="50" rx="20" ry="12" fill="#58a830" opacity="0.7"/>
+  <ellipse cx="75" cy="50" rx="20" ry="12" fill="#58a830" opacity="0.65"/>
+  <!-- Diagonal leaves -->
+  <ellipse cx="30" cy="30" rx="10" ry="16" fill="#50a028" opacity="0.6" transform="rotate(-45 30 30)"/>
+  <ellipse cx="70" cy="30" rx="10" ry="16" fill="#50a028" opacity="0.55" transform="rotate(45 70 30)"/>
+  <ellipse cx="30" cy="70" rx="10" ry="16" fill="#50a028" opacity="0.55" transform="rotate(45 30 70)"/>
+  <ellipse cx="70" cy="70" rx="10" ry="16" fill="#50a028" opacity="0.5" transform="rotate(-45 70 70)"/>
+  <!-- Inner rosette -->
+  <circle cx="50" cy="50" r="14" fill="url(#veg_fill)" opacity="0.8"/>
+  <!-- Leaf vein details (subtle) -->
+  <line x1="50" y1="50" x2="50" y2="12" stroke="#488c24" stroke-width="1" opacity="0.3"/>
+  <line x1="50" y1="50" x2="50" y2="88" stroke="#488c24" stroke-width="1" opacity="0.3"/>
+  <line x1="50" y1="50" x2="12" y2="50" stroke="#488c24" stroke-width="1" opacity="0.3"/>
+  <line x1="50" y1="50" x2="88" y2="50" stroke="#488c24" stroke-width="1" opacity="0.3"/>
+  <!-- Center highlight -->
+  <circle cx="50" cy="50" r="5" fill="#7cc44a" opacity="0.5"/>
+</svg>

--- a/src/open_garden_planner/resources/plants/categories/weeping_tree.svg
+++ b/src/open_garden_planner/resources/plants/categories/weeping_tree.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <!-- Weeping tree - round with drooping fringe edges -->
+  <defs>
+    <radialGradient id="weep_canopy" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#5a9a4f"/>
+      <stop offset="50%" stop-color="#4a8840"/>
+      <stop offset="100%" stop-color="#3a7530"/>
+    </radialGradient>
+  </defs>
+  <!-- Drooping outer fringe (irregular edge) -->
+  <path d="M50 6 C62 8 78 18 85 30 C90 40 92 48 88 60 C85 72 78 82 68 88 C58 94 46 95 36 90 C24 84 14 74 10 60 C6 48 8 36 14 26 C22 14 36 7 50 6Z" fill="#3a7530" opacity="0.5"/>
+  <!-- Main canopy -->
+  <ellipse cx="50" cy="50" rx="36" ry="36" fill="url(#weep_canopy)" opacity="0.9"/>
+  <!-- Drooping branch tips around the edge -->
+  <ellipse cx="22" cy="42" rx="8" ry="4" fill="#4a8840" opacity="0.6" transform="rotate(-30 22 42)"/>
+  <ellipse cx="30" cy="75" rx="7" ry="4" fill="#4a8840" opacity="0.6" transform="rotate(20 30 75)"/>
+  <ellipse cx="72" cy="38" rx="7" ry="4" fill="#4a8840" opacity="0.6" transform="rotate(25 72 38)"/>
+  <ellipse cx="75" cy="62" rx="8" ry="4" fill="#4a8840" opacity="0.6" transform="rotate(-15 75 62)"/>
+  <ellipse cx="50" cy="18" rx="6" ry="4" fill="#4a8840" opacity="0.55"/>
+  <ellipse cx="50" cy="82" rx="7" ry="4" fill="#4a8840" opacity="0.55"/>
+  <!-- Leaf clusters -->
+  <circle cx="42" cy="40" r="12" fill="#62b050" opacity="0.45"/>
+  <circle cx="58" cy="55" r="11" fill="#59a848" opacity="0.4"/>
+  <!-- Trunk shadow -->
+  <circle cx="50" cy="50" r="5" fill="#3a2a1a" opacity="0.4"/>
+  <!-- Highlights -->
+  <circle cx="40" cy="42" r="5" fill="#7cc46a" opacity="0.3"/>
+</svg>

--- a/src/open_garden_planner/resources/plants/species/apple_tree.svg
+++ b/src/open_garden_planner/resources/plants/species/apple_tree.svg
@@ -1,0 +1,36 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <!-- Apple tree - broad round canopy with red apple fruits -->
+  <defs>
+    <radialGradient id="apple_canopy" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#4a8c3f"/>
+      <stop offset="55%" stop-color="#3d7a34"/>
+      <stop offset="100%" stop-color="#2d6425"/>
+    </radialGradient>
+  </defs>
+  <!-- Broad irregular canopy -->
+  <path d="M16 48 C12 32 24 16 40 12 C50 10 56 14 64 12 C80 10 92 26 90 44 C92 56 86 68 76 76 C64 84 38 86 26 78 C14 68 12 58 16 48Z" fill="url(#apple_canopy)" opacity="0.88"/>
+  <!-- Leaf clusters giving organic shape -->
+  <circle cx="34" cy="32" r="16" fill="#55a044" opacity="0.6"/>
+  <circle cx="62" cy="28" r="14" fill="#4d9438" opacity="0.55"/>
+  <circle cx="72" cy="50" r="14" fill="#50944a" opacity="0.5"/>
+  <circle cx="56" cy="65" r="15" fill="#55a044" opacity="0.5"/>
+  <circle cx="30" cy="60" r="13" fill="#508f3c" opacity="0.5"/>
+  <circle cx="48" cy="42" r="12" fill="#5da846" opacity="0.45"/>
+  <!-- Trunk shadow -->
+  <circle cx="50" cy="48" r="5" fill="#3a2a1a" opacity="0.35"/>
+  <!-- Red apples -->
+  <circle cx="36" cy="26" r="3.5" fill="#cc3030" opacity="0.85"/>
+  <circle cx="68" cy="34" r="3" fill="#cc3030" opacity="0.8"/>
+  <circle cx="60" cy="56" r="3.5" fill="#cc3030" opacity="0.75"/>
+  <circle cx="32" cy="52" r="3" fill="#cc3030" opacity="0.8"/>
+  <circle cx="50" cy="72" r="3" fill="#cc3030" opacity="0.7"/>
+  <circle cx="76" cy="54" r="2.5" fill="#cc3030" opacity="0.65"/>
+  <circle cx="44" cy="38" r="2.5" fill="#cc3030" opacity="0.75"/>
+  <circle cx="22" cy="42" r="2.5" fill="#cc3030" opacity="0.7"/>
+  <!-- Apple highlights -->
+  <circle cx="35" cy="25" r="1.2" fill="#ff6060" opacity="0.5"/>
+  <circle cx="67" cy="33" r="1" fill="#ff6060" opacity="0.45"/>
+  <!-- Canopy highlights -->
+  <circle cx="38" cy="34" r="5" fill="#7cc46a" opacity="0.3"/>
+  <circle cx="58" cy="44" r="4" fill="#7cc46a" opacity="0.25"/>
+</svg>

--- a/src/open_garden_planner/resources/plants/species/boxwood.svg
+++ b/src/open_garden_planner/resources/plants/species/boxwood.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <!-- Boxwood - dense, tightly clipped round shrub -->
+  <defs>
+    <radialGradient id="box_fill" cx="45%" cy="45%" r="55%">
+      <stop offset="0%" stop-color="#3d7a2a"/>
+      <stop offset="60%" stop-color="#326822"/>
+      <stop offset="100%" stop-color="#285a1a"/>
+    </radialGradient>
+  </defs>
+  <!-- Dense round clipped shape (slightly irregular for natural look) -->
+  <path d="M18 48 C16 34 26 20 40 18 C50 16 56 18 64 18 C78 18 86 32 86 46 C86 58 80 70 70 76 C60 82 42 82 30 76 C20 70 16 58 18 48Z" fill="url(#box_fill)" opacity="0.92"/>
+  <!-- Very tight small leaf texture -->
+  <circle cx="30" cy="34" r="8" fill="#468832" opacity="0.45"/>
+  <circle cx="46" cy="30" r="7" fill="#3e8028" opacity="0.4"/>
+  <circle cx="62" cy="32" r="8" fill="#468832" opacity="0.42"/>
+  <circle cx="76" cy="44" r="7" fill="#3e8028" opacity="0.4"/>
+  <circle cx="72" cy="60" r="8" fill="#468832" opacity="0.38"/>
+  <circle cx="56" cy="66" r="7" fill="#3e8028" opacity="0.38"/>
+  <circle cx="38" cy="64" r="8" fill="#468832" opacity="0.38"/>
+  <circle cx="24" cy="52" r="7" fill="#3e8028" opacity="0.4"/>
+  <circle cx="50" cy="48" r="9" fill="#468832" opacity="0.35"/>
+  <!-- Clipped edge definition -->
+  <circle cx="36" cy="44" r="6" fill="#509038" opacity="0.3"/>
+  <circle cx="58" cy="46" r="6" fill="#509038" opacity="0.28"/>
+  <circle cx="48" cy="36" r="5" fill="#509038" opacity="0.28"/>
+  <!-- Light highlight on top surface -->
+  <ellipse cx="44" cy="40" rx="14" ry="10" fill="#58a040" opacity="0.2"/>
+</svg>

--- a/src/open_garden_planner/resources/plants/species/cherry_tree.svg
+++ b/src/open_garden_planner/resources/plants/species/cherry_tree.svg
@@ -1,0 +1,37 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <!-- Cherry tree - round canopy with pink blossoms -->
+  <defs>
+    <radialGradient id="cherry_canopy" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#4a8a3d"/>
+      <stop offset="55%" stop-color="#3c7832"/>
+      <stop offset="100%" stop-color="#2c6424"/>
+    </radialGradient>
+  </defs>
+  <!-- Organic round canopy -->
+  <path d="M18 46 C14 30 26 16 42 14 C52 12 58 16 66 14 C80 12 90 28 88 44 C90 58 84 70 74 78 C62 86 40 86 28 78 C16 70 14 58 18 46Z" fill="url(#cherry_canopy)" opacity="0.85"/>
+  <!-- Leaf clusters -->
+  <circle cx="36" cy="34" r="15" fill="#52a042" opacity="0.55"/>
+  <circle cx="62" cy="30" r="13" fill="#4a9438" opacity="0.5"/>
+  <circle cx="70" cy="52" r="13" fill="#52a042" opacity="0.5"/>
+  <circle cx="54" cy="64" r="14" fill="#4a9438" opacity="0.45"/>
+  <circle cx="32" cy="58" r="12" fill="#52a042" opacity="0.45"/>
+  <circle cx="50" cy="44" r="11" fill="#5aa844" opacity="0.4"/>
+  <!-- Trunk -->
+  <circle cx="50" cy="48" r="5" fill="#3a2a1a" opacity="0.35"/>
+  <!-- Cherry blossoms (pink/white) -->
+  <circle cx="34" cy="28" r="4" fill="#ffa0b8" opacity="0.8"/>
+  <circle cx="56" cy="24" r="3.5" fill="#ffb0c4" opacity="0.75"/>
+  <circle cx="72" cy="36" r="3.5" fill="#ffa0b8" opacity="0.7"/>
+  <circle cx="66" cy="58" r="3" fill="#ffb0c4" opacity="0.7"/>
+  <circle cx="44" cy="68" r="3.5" fill="#ffa0b8" opacity="0.65"/>
+  <circle cx="28" cy="50" r="3" fill="#ffb0c4" opacity="0.7"/>
+  <circle cx="48" cy="36" r="3" fill="#ffa0b8" opacity="0.65"/>
+  <circle cx="78" cy="48" r="2.5" fill="#ffb0c4" opacity="0.6"/>
+  <!-- Blossom centers -->
+  <circle cx="34" cy="28" r="1.5" fill="#fff0f4" opacity="0.7"/>
+  <circle cx="56" cy="24" r="1.2" fill="#fff0f4" opacity="0.65"/>
+  <circle cx="72" cy="36" r="1.2" fill="#fff0f4" opacity="0.6"/>
+  <circle cx="44" cy="68" r="1.2" fill="#fff0f4" opacity="0.55"/>
+  <!-- Highlight -->
+  <circle cx="40" cy="36" r="5" fill="#7cc46a" opacity="0.25"/>
+</svg>

--- a/src/open_garden_planner/resources/plants/species/lavender.svg
+++ b/src/open_garden_planner/resources/plants/species/lavender.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <!-- Lavender - compact grey-green mound with purple flower spikes -->
+  <defs>
+    <radialGradient id="lav_base" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#7a9a70"/>
+      <stop offset="70%" stop-color="#688a60"/>
+      <stop offset="100%" stop-color="#587a52"/>
+    </radialGradient>
+  </defs>
+  <!-- Grey-green foliage mound -->
+  <path d="M24 48 C22 34 32 22 44 20 C54 18 60 22 66 20 C78 18 86 32 84 46 C86 56 80 66 72 72 C62 78 40 80 30 74 C22 68 20 56 24 48Z" fill="url(#lav_base)" opacity="0.8"/>
+  <!-- Fine silvery-green leaves -->
+  <ellipse cx="38" cy="38" rx="10" ry="8" fill="#88a880" opacity="0.5"/>
+  <ellipse cx="58" cy="36" rx="9" ry="8" fill="#80a078" opacity="0.45"/>
+  <ellipse cx="50" cy="55" rx="10" ry="8" fill="#88a880" opacity="0.45"/>
+  <ellipse cx="34" cy="58" rx="9" ry="7" fill="#80a078" opacity="0.4"/>
+  <ellipse cx="66" cy="52" rx="8" ry="7" fill="#88a880" opacity="0.4"/>
+  <!-- Lavender flower spikes (purple) -->
+  <ellipse cx="35" cy="28" rx="3" ry="8" fill="#8860b8" opacity="0.8"/>
+  <ellipse cx="50" cy="24" rx="2.5" ry="7" fill="#9068c0" opacity="0.75"/>
+  <ellipse cx="64" cy="26" rx="3" ry="8" fill="#8860b8" opacity="0.75"/>
+  <ellipse cx="28" cy="42" rx="2.5" ry="7" fill="#9068c0" opacity="0.7" transform="rotate(-20 28 42)"/>
+  <ellipse cx="74" cy="40" rx="2.5" ry="7" fill="#8860b8" opacity="0.7" transform="rotate(20 74 40)"/>
+  <ellipse cx="42" cy="20" rx="2" ry="6" fill="#9870c8" opacity="0.65"/>
+  <ellipse cx="58" cy="22" rx="2" ry="6" fill="#9870c8" opacity="0.6"/>
+  <!-- Flower spike tips (lighter) -->
+  <ellipse cx="35" cy="22" rx="2" ry="3" fill="#a880d0" opacity="0.6"/>
+  <ellipse cx="50" cy="19" rx="1.5" ry="2.5" fill="#a880d0" opacity="0.55"/>
+  <ellipse cx="64" cy="20" rx="2" ry="3" fill="#a880d0" opacity="0.55"/>
+</svg>

--- a/src/open_garden_planner/resources/plants/species/rhododendron.svg
+++ b/src/open_garden_planner/resources/plants/species/rhododendron.svg
@@ -1,0 +1,42 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <!-- Rhododendron - large glossy-leaved shrub with flower clusters -->
+  <defs>
+    <radialGradient id="rhodo_fill" cx="50%" cy="50%" r="55%">
+      <stop offset="0%" stop-color="#2d6a28"/>
+      <stop offset="70%" stop-color="#225820"/>
+      <stop offset="100%" stop-color="#1a4818"/>
+    </radialGradient>
+  </defs>
+  <!-- Large spreading base -->
+  <path d="M14 46 C10 30 22 16 38 12 C50 10 58 14 68 12 C84 10 94 28 92 44 C94 58 88 72 76 80 C64 88 38 88 24 80 C12 72 10 58 14 46Z" fill="url(#rhodo_fill)" opacity="0.88"/>
+  <!-- Large glossy leaves -->
+  <ellipse cx="32" cy="30" rx="14" ry="9" fill="#388032" opacity="0.6" transform="rotate(-15 32 30)"/>
+  <ellipse cx="66" cy="28" rx="13" ry="8" fill="#307828" opacity="0.55" transform="rotate(15 66 28)"/>
+  <ellipse cx="78" cy="50" rx="12" ry="8" fill="#388032" opacity="0.55" transform="rotate(40 78 50)"/>
+  <ellipse cx="62" cy="70" rx="14" ry="9" fill="#307828" opacity="0.5" transform="rotate(-10 62 70)"/>
+  <ellipse cx="32" cy="66" rx="13" ry="8" fill="#388032" opacity="0.5" transform="rotate(10 32 66)"/>
+  <ellipse cx="18" cy="48" rx="11" ry="8" fill="#307828" opacity="0.5" transform="rotate(-40 18 48)"/>
+  <ellipse cx="50" cy="48" rx="12" ry="8" fill="#388032" opacity="0.45"/>
+  <!-- Flower clusters (rhododendron blooms - pink/magenta) -->
+  <!-- Cluster 1 -->
+  <circle cx="38" cy="34" r="3" fill="#d050a0" opacity="0.8"/>
+  <circle cx="34" cy="30" r="2.5" fill="#d858a8" opacity="0.75"/>
+  <circle cx="42" cy="30" r="2.5" fill="#d050a0" opacity="0.75"/>
+  <circle cx="38" cy="26" r="2.5" fill="#d858a8" opacity="0.7"/>
+  <circle cx="38" cy="30" r="1.5" fill="#e880c0" opacity="0.6"/>
+  <!-- Cluster 2 -->
+  <circle cx="62" cy="42" r="3" fill="#d050a0" opacity="0.75"/>
+  <circle cx="58" cy="38" r="2.5" fill="#d858a8" opacity="0.7"/>
+  <circle cx="66" cy="38" r="2.5" fill="#d050a0" opacity="0.7"/>
+  <circle cx="62" cy="38" r="1.5" fill="#e880c0" opacity="0.55"/>
+  <!-- Cluster 3 -->
+  <circle cx="48" cy="62" r="2.5" fill="#d050a0" opacity="0.7"/>
+  <circle cx="44" cy="58" r="2" fill="#d858a8" opacity="0.65"/>
+  <circle cx="52" cy="58" r="2" fill="#d050a0" opacity="0.65"/>
+  <!-- Cluster 4 (small) -->
+  <circle cx="74" cy="58" r="2" fill="#d050a0" opacity="0.6"/>
+  <circle cx="70" cy="56" r="1.5" fill="#d858a8" opacity="0.55"/>
+  <!-- Leaf shine highlights -->
+  <ellipse cx="34" cy="36" rx="4" ry="2" fill="#48a040" opacity="0.25"/>
+  <ellipse cx="60" cy="50" rx="4" ry="2" fill="#48a040" opacity="0.2"/>
+</svg>

--- a/src/open_garden_planner/resources/plants/species/rose.svg
+++ b/src/open_garden_planner/resources/plants/species/rose.svg
@@ -1,0 +1,41 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <!-- Rose bush - top-down view with rose blooms and thorny foliage -->
+  <defs>
+    <radialGradient id="rose_leaf" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#3d7a28"/>
+      <stop offset="100%" stop-color="#2d6420"/>
+    </radialGradient>
+  </defs>
+  <!-- Irregular foliage base -->
+  <path d="M22 42 C18 30 28 18 42 16 C52 14 60 18 68 18 C80 20 88 32 86 46 C88 58 80 70 70 76 C60 82 42 84 32 78 C20 70 18 56 22 42Z" fill="url(#rose_leaf)" opacity="0.8"/>
+  <!-- Serrated leaf clusters -->
+  <ellipse cx="35" cy="35" rx="12" ry="10" fill="#468830" opacity="0.6"/>
+  <ellipse cx="60" cy="32" rx="10" ry="10" fill="#3e8028" opacity="0.55"/>
+  <ellipse cx="68" cy="55" rx="10" ry="10" fill="#468830" opacity="0.5"/>
+  <ellipse cx="48" cy="65" rx="11" ry="9" fill="#3e8028" opacity="0.5"/>
+  <ellipse cx="30" cy="58" rx="10" ry="9" fill="#468830" opacity="0.5"/>
+  <!-- Rose blooms - multi-layered petals -->
+  <!-- Rose 1 (large) -->
+  <circle cx="42" cy="36" r="8" fill="#e83060" opacity="0.85"/>
+  <circle cx="42" cy="36" r="5.5" fill="#f04070" opacity="0.8"/>
+  <circle cx="42" cy="36" r="3" fill="#f85880" opacity="0.75"/>
+  <circle cx="42" cy="36" r="1.5" fill="#ffa0b0" opacity="0.7"/>
+  <!-- Rose 2 -->
+  <circle cx="62" cy="48" r="7" fill="#e83060" opacity="0.8"/>
+  <circle cx="62" cy="48" r="5" fill="#f04070" opacity="0.75"/>
+  <circle cx="62" cy="48" r="2.5" fill="#f85880" opacity="0.7"/>
+  <circle cx="62" cy="48" r="1.2" fill="#ffa0b0" opacity="0.65"/>
+  <!-- Rose 3 -->
+  <circle cx="38" cy="60" r="6.5" fill="#e83060" opacity="0.75"/>
+  <circle cx="38" cy="60" r="4.5" fill="#f04070" opacity="0.7"/>
+  <circle cx="38" cy="60" r="2.2" fill="#f85880" opacity="0.65"/>
+  <!-- Rose 4 (bud) -->
+  <circle cx="58" cy="66" r="4" fill="#e83060" opacity="0.7"/>
+  <circle cx="58" cy="66" r="2" fill="#f04070" opacity="0.65"/>
+  <!-- Rose 5 (small) -->
+  <circle cx="72" cy="38" r="5" fill="#e83060" opacity="0.7"/>
+  <circle cx="72" cy="38" r="3" fill="#f04070" opacity="0.65"/>
+  <!-- Leaf highlights -->
+  <circle cx="50" cy="28" r="3" fill="#58a038" opacity="0.4"/>
+  <circle cx="28" cy="48" r="3" fill="#58a038" opacity="0.35"/>
+</svg>

--- a/src/open_garden_planner/resources/plants/species/sunflower.svg
+++ b/src/open_garden_planner/resources/plants/species/sunflower.svg
@@ -1,0 +1,42 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <!-- Sunflower - large flower head from above with radiating petals -->
+  <defs>
+    <radialGradient id="sun_center" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#6a4a20"/>
+      <stop offset="50%" stop-color="#5a3a18"/>
+      <stop offset="100%" stop-color="#4a2a10"/>
+    </radialGradient>
+  </defs>
+  <!-- Large leaves at base -->
+  <ellipse cx="28" cy="70" rx="14" ry="8" fill="#4a8830" opacity="0.5" transform="rotate(-30 28 70)"/>
+  <ellipse cx="72" cy="68" rx="14" ry="8" fill="#4a8830" opacity="0.45" transform="rotate(30 72 68)"/>
+  <ellipse cx="22" cy="42" rx="12" ry="7" fill="#4a8830" opacity="0.45" transform="rotate(-60 22 42)"/>
+  <ellipse cx="78" cy="40" rx="12" ry="7" fill="#4a8830" opacity="0.4" transform="rotate(60 78 40)"/>
+  <!-- Yellow petals radiating from center -->
+  <ellipse cx="50" cy="18" rx="6" ry="16" fill="#f0c020" opacity="0.85"/>
+  <ellipse cx="68" cy="22" rx="6" ry="16" fill="#e8b818" opacity="0.8" transform="rotate(30 68 22)"/>
+  <ellipse cx="80" cy="36" rx="6" ry="16" fill="#f0c020" opacity="0.8" transform="rotate(60 80 36)"/>
+  <ellipse cx="82" cy="54" rx="6" ry="16" fill="#e8b818" opacity="0.75" transform="rotate(90 82 54)"/>
+  <ellipse cx="74" cy="70" rx="6" ry="16" fill="#f0c020" opacity="0.75" transform="rotate(120 74 70)"/>
+  <ellipse cx="58" cy="80" rx="6" ry="16" fill="#e8b818" opacity="0.7" transform="rotate(150 58 80)"/>
+  <ellipse cx="42" cy="80" rx="6" ry="16" fill="#f0c020" opacity="0.7" transform="rotate(210 42 80)"/>
+  <ellipse cx="26" cy="70" rx="6" ry="16" fill="#e8b818" opacity="0.75" transform="rotate(240 26 70)"/>
+  <ellipse cx="18" cy="54" rx="6" ry="16" fill="#f0c020" opacity="0.75" transform="rotate(270 18 54)"/>
+  <ellipse cx="20" cy="36" rx="6" ry="16" fill="#e8b818" opacity="0.8" transform="rotate(300 20 36)"/>
+  <ellipse cx="32" cy="22" rx="6" ry="16" fill="#f0c020" opacity="0.8" transform="rotate(330 32 22)"/>
+  <!-- Inner petals layer -->
+  <ellipse cx="50" cy="26" rx="4" ry="10" fill="#f8d040" opacity="0.6"/>
+  <ellipse cx="72" cy="42" rx="4" ry="10" fill="#f8d040" opacity="0.55" transform="rotate(70 72 42)"/>
+  <ellipse cx="62" cy="72" rx="4" ry="10" fill="#f8d040" opacity="0.5" transform="rotate(140 62 72)"/>
+  <ellipse cx="38" cy="72" rx="4" ry="10" fill="#f8d040" opacity="0.5" transform="rotate(220 38 72)"/>
+  <ellipse cx="28" cy="42" rx="4" ry="10" fill="#f8d040" opacity="0.55" transform="rotate(290 28 42)"/>
+  <!-- Large brown center disc -->
+  <circle cx="50" cy="50" r="16" fill="url(#sun_center)" opacity="0.9"/>
+  <!-- Seed pattern in center -->
+  <circle cx="46" cy="46" r="1.5" fill="#7a5a28" opacity="0.5"/>
+  <circle cx="54" cy="46" r="1.5" fill="#7a5a28" opacity="0.5"/>
+  <circle cx="50" cy="42" r="1.5" fill="#7a5a28" opacity="0.5"/>
+  <circle cx="50" cy="54" r="1.5" fill="#7a5a28" opacity="0.5"/>
+  <circle cx="44" cy="52" r="1.5" fill="#7a5a28" opacity="0.5"/>
+  <circle cx="56" cy="52" r="1.5" fill="#7a5a28" opacity="0.5"/>
+</svg>

--- a/src/open_garden_planner/resources/plants/species/tomato.svg
+++ b/src/open_garden_planner/resources/plants/species/tomato.svg
@@ -1,0 +1,35 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <!-- Tomato plant - bushy spreading foliage with tomato fruits -->
+  <defs>
+    <radialGradient id="tomato_leaf" cx="50%" cy="50%" r="55%">
+      <stop offset="0%" stop-color="#508c2e"/>
+      <stop offset="70%" stop-color="#407824"/>
+      <stop offset="100%" stop-color="#30641c"/>
+    </radialGradient>
+  </defs>
+  <!-- Bushy foliage base -->
+  <path d="M20 44 C16 30 28 18 42 16 C52 14 58 18 68 16 C82 14 92 30 88 46 C90 58 84 70 74 78 C62 86 40 86 28 78 C18 70 16 56 20 44Z" fill="url(#tomato_leaf)" opacity="0.8"/>
+  <!-- Compound leaf clusters -->
+  <ellipse cx="35" cy="32" rx="14" ry="10" fill="#58942e" opacity="0.55"/>
+  <ellipse cx="62" cy="30" rx="12" ry="10" fill="#508c28" opacity="0.5"/>
+  <ellipse cx="72" cy="52" rx="12" ry="10" fill="#58942e" opacity="0.5"/>
+  <ellipse cx="55" cy="66" rx="14" ry="10" fill="#508c28" opacity="0.45"/>
+  <ellipse cx="30" cy="60" rx="12" ry="9" fill="#58942e" opacity="0.45"/>
+  <ellipse cx="48" cy="44" rx="10" ry="8" fill="#60a034" opacity="0.4"/>
+  <!-- Leaf vein hints -->
+  <line x1="35" y1="32" x2="22" y2="24" stroke="#30641c" stroke-width="0.8" opacity="0.3"/>
+  <line x1="62" y1="30" x2="76" y2="22" stroke="#30641c" stroke-width="0.8" opacity="0.3"/>
+  <!-- Tomato fruits -->
+  <circle cx="40" cy="40" r="5" fill="#e03828" opacity="0.85"/>
+  <circle cx="65" cy="45" r="4.5" fill="#e04030" opacity="0.8"/>
+  <circle cx="50" cy="60" r="5" fill="#e03828" opacity="0.75"/>
+  <circle cx="30" cy="50" r="4" fill="#d83020" opacity="0.8"/>
+  <circle cx="72" cy="62" r="3.5" fill="#e04030" opacity="0.7"/>
+  <!-- Green unripe tomatoes -->
+  <circle cx="58" cy="32" r="3" fill="#78a838" opacity="0.7"/>
+  <circle cx="38" cy="68" r="3" fill="#78a838" opacity="0.65"/>
+  <!-- Tomato highlights -->
+  <circle cx="39" cy="39" r="1.8" fill="#f06050" opacity="0.5"/>
+  <circle cx="64" cy="44" r="1.5" fill="#f06050" opacity="0.45"/>
+  <circle cx="49" cy="59" r="1.8" fill="#f06050" opacity="0.4"/>
+</svg>

--- a/tests/unit/test_plant_renderer.py
+++ b/tests/unit/test_plant_renderer.py
@@ -1,0 +1,310 @@
+"""Unit tests for plant SVG rendering system (US-6.2)."""
+
+from pathlib import Path
+
+import pytest
+from PyQt6.QtGui import QColor, QPixmap
+
+from open_garden_planner.core.object_types import ObjectType
+from open_garden_planner.core.plant_renderer import (
+    PlantCategory,
+    _CATEGORIES_DIR,
+    _SPECIES_DIR,
+    _resolve_svg_path,
+    _stable_random_for_item,
+    clear_plant_cache,
+    get_all_categories,
+    get_default_category,
+    get_species_names,
+    is_plant_type,
+    render_plant_pixmap,
+)
+
+
+class TestPlantCategoryEnum:
+    """Tests for PlantCategory enum members."""
+
+    def test_all_15_categories_exist(self, qtbot: object) -> None:  # noqa: ARG002
+        expected = [
+            "ROUND_DECIDUOUS", "COLUMNAR_TREE", "WEEPING_TREE", "CONIFER",
+            "SPREADING_SHRUB", "COMPACT_SHRUB", "ORNAMENTAL_GRASS",
+            "FLOWERING_PERENNIAL", "GROUND_COVER", "CLIMBING_PLANT",
+            "HEDGE_SECTION", "VEGETABLE", "HERB", "FRUIT_TREE", "PALM",
+        ]
+        for name in expected:
+            assert hasattr(PlantCategory, name), f"Missing category: {name}"
+
+    def test_category_count(self, qtbot: object) -> None:  # noqa: ARG002
+        assert len(PlantCategory) == 15
+
+
+class TestPlantSVGFiles:
+    """Tests for plant SVG file existence."""
+
+    @pytest.mark.parametrize(
+        "filename",
+        [
+            "round_deciduous", "columnar_tree", "weeping_tree", "conifer",
+            "spreading_shrub", "compact_shrub", "ornamental_grass",
+            "flowering_perennial", "ground_cover", "climbing_plant",
+            "hedge_section", "vegetable", "herb", "fruit_tree", "palm",
+        ],
+    )
+    def test_category_svg_exists(self, filename: str) -> None:
+        path = _CATEGORIES_DIR / f"{filename}.svg"
+        assert path.exists(), f"Category SVG missing: {filename}.svg"
+        assert path.is_file()
+        assert path.stat().st_size > 0
+
+    @pytest.mark.parametrize(
+        "filename",
+        [
+            "rose", "lavender", "apple_tree", "cherry_tree",
+            "sunflower", "tomato", "boxwood", "rhododendron",
+        ],
+    )
+    def test_species_svg_exists(self, filename: str) -> None:
+        path = _SPECIES_DIR / f"{filename}.svg"
+        assert path.exists(), f"Species SVG missing: {filename}.svg"
+        assert path.is_file()
+        assert path.stat().st_size > 0
+
+    @pytest.mark.parametrize(
+        "filename",
+        [
+            "round_deciduous", "columnar_tree", "conifer", "spreading_shrub",
+            "flowering_perennial", "rose", "lavender", "sunflower",
+        ],
+    )
+    def test_svg_has_valid_header(self, filename: str) -> None:
+        # Check categories first, then species
+        path = _CATEGORIES_DIR / f"{filename}.svg"
+        if not path.exists():
+            path = _SPECIES_DIR / f"{filename}.svg"
+        content = path.read_text(encoding="utf-8")
+        assert "<svg" in content, f"{filename}.svg is not valid SVG"
+        assert "</svg>" in content
+
+
+class TestIsPlantType:
+    """Tests for is_plant_type helper."""
+
+    def test_tree_is_plant(self, qtbot: object) -> None:  # noqa: ARG002
+        assert is_plant_type(ObjectType.TREE) is True
+
+    def test_shrub_is_plant(self, qtbot: object) -> None:  # noqa: ARG002
+        assert is_plant_type(ObjectType.SHRUB) is True
+
+    def test_perennial_is_plant(self, qtbot: object) -> None:  # noqa: ARG002
+        assert is_plant_type(ObjectType.PERENNIAL) is True
+
+    def test_house_is_not_plant(self, qtbot: object) -> None:  # noqa: ARG002
+        assert is_plant_type(ObjectType.HOUSE) is False
+
+    def test_generic_circle_is_not_plant(self, qtbot: object) -> None:  # noqa: ARG002
+        assert is_plant_type(ObjectType.GENERIC_CIRCLE) is False
+
+    def test_none_is_not_plant(self, qtbot: object) -> None:  # noqa: ARG002
+        assert is_plant_type(None) is False
+
+
+class TestDefaultCategory:
+    """Tests for ObjectType to PlantCategory mapping."""
+
+    def test_tree_default_is_round_deciduous(self, qtbot: object) -> None:  # noqa: ARG002
+        assert get_default_category(ObjectType.TREE) == PlantCategory.ROUND_DECIDUOUS
+
+    def test_shrub_default_is_spreading_shrub(self, qtbot: object) -> None:  # noqa: ARG002
+        assert get_default_category(ObjectType.SHRUB) == PlantCategory.SPREADING_SHRUB
+
+    def test_perennial_default_is_flowering_perennial(self, qtbot: object) -> None:  # noqa: ARG002
+        assert get_default_category(ObjectType.PERENNIAL) == PlantCategory.FLOWERING_PERENNIAL
+
+    def test_non_plant_returns_none(self, qtbot: object) -> None:  # noqa: ARG002
+        assert get_default_category(ObjectType.HOUSE) is None
+
+
+class TestResolveSvgPath:
+    """Tests for SVG path resolution logic."""
+
+    def test_tree_default_resolves(self, qtbot: object) -> None:  # noqa: ARG002
+        path = _resolve_svg_path(ObjectType.TREE)
+        assert path is not None
+        assert path.name == "round_deciduous.svg"
+
+    def test_species_takes_priority(self, qtbot: object) -> None:  # noqa: ARG002
+        path = _resolve_svg_path(ObjectType.SHRUB, species="rose")
+        assert path is not None
+        assert path.name == "rose.svg"
+
+    def test_category_takes_priority_over_default(self, qtbot: object) -> None:  # noqa: ARG002
+        path = _resolve_svg_path(ObjectType.TREE, category=PlantCategory.CONIFER)
+        assert path is not None
+        assert path.name == "conifer.svg"
+
+    def test_species_partial_match(self, qtbot: object) -> None:  # noqa: ARG002
+        path = _resolve_svg_path(ObjectType.TREE, species="Cherry Blossom")
+        assert path is not None
+        assert path.name == "cherry_tree.svg"
+
+    def test_non_plant_returns_none(self, qtbot: object) -> None:  # noqa: ARG002
+        path = _resolve_svg_path(ObjectType.HOUSE)
+        assert path is None
+
+    def test_unknown_species_falls_back_to_category(self, qtbot: object) -> None:  # noqa: ARG002
+        path = _resolve_svg_path(
+            ObjectType.TREE, species="Unknown Plant XYZ",
+            category=PlantCategory.CONIFER,
+        )
+        assert path is not None
+        assert path.name == "conifer.svg"
+
+    def test_unknown_species_falls_back_to_default(self, qtbot: object) -> None:  # noqa: ARG002
+        path = _resolve_svg_path(ObjectType.TREE, species="Unknown Plant XYZ")
+        assert path is not None
+        assert path.name == "round_deciduous.svg"
+
+
+class TestStableRandom:
+    """Tests for stable randomization."""
+
+    def test_same_id_gives_same_result(self, qtbot: object) -> None:  # noqa: ARG002
+        r1 = _stable_random_for_item("test-id-123")
+        r2 = _stable_random_for_item("test-id-123")
+        assert r1 == r2
+
+    def test_different_ids_give_different_results(self, qtbot: object) -> None:  # noqa: ARG002
+        r1 = _stable_random_for_item("id-a")
+        r2 = _stable_random_for_item("id-b")
+        assert r1 != r2
+
+    def test_different_offsets_give_different_results(self, qtbot: object) -> None:  # noqa: ARG002
+        r1 = _stable_random_for_item("same-id", seed_offset=0)
+        r2 = _stable_random_for_item("same-id", seed_offset=1)
+        assert r1 != r2
+
+    def test_result_in_range(self, qtbot: object) -> None:  # noqa: ARG002
+        r = _stable_random_for_item("any-id")
+        assert 0.0 <= r <= 1.0
+
+
+class TestRenderPlantPixmap:
+    """Tests for SVG to QPixmap rendering."""
+
+    @pytest.fixture(autouse=True)
+    def clear_caches(self) -> None:
+        clear_plant_cache()
+        yield  # type: ignore[misc]
+        clear_plant_cache()
+
+    def test_render_tree_returns_pixmap(self, qtbot: object) -> None:  # noqa: ARG002
+        pixmap = render_plant_pixmap(ObjectType.TREE, diameter=100.0)
+        assert pixmap is not None
+        assert isinstance(pixmap, QPixmap)
+        assert not pixmap.isNull()
+        assert pixmap.width() == 100
+        assert pixmap.height() == 100
+
+    def test_render_shrub_returns_pixmap(self, qtbot: object) -> None:  # noqa: ARG002
+        pixmap = render_plant_pixmap(ObjectType.SHRUB, diameter=80.0)
+        assert pixmap is not None
+        assert not pixmap.isNull()
+
+    def test_render_perennial_returns_pixmap(self, qtbot: object) -> None:  # noqa: ARG002
+        pixmap = render_plant_pixmap(ObjectType.PERENNIAL, diameter=60.0)
+        assert pixmap is not None
+        assert not pixmap.isNull()
+
+    def test_render_non_plant_returns_none(self, qtbot: object) -> None:  # noqa: ARG002
+        pixmap = render_plant_pixmap(ObjectType.HOUSE, diameter=100.0)
+        assert pixmap is None
+
+    def test_render_with_species(self, qtbot: object) -> None:  # noqa: ARG002
+        pixmap = render_plant_pixmap(
+            ObjectType.SHRUB, diameter=100.0, species="rose",
+        )
+        assert pixmap is not None
+        assert not pixmap.isNull()
+
+    def test_render_with_category(self, qtbot: object) -> None:  # noqa: ARG002
+        pixmap = render_plant_pixmap(
+            ObjectType.TREE, diameter=100.0,
+            category=PlantCategory.CONIFER,
+        )
+        assert pixmap is not None
+        assert not pixmap.isNull()
+
+    def test_render_with_tint(self, qtbot: object) -> None:  # noqa: ARG002
+        pixmap = render_plant_pixmap(
+            ObjectType.TREE, diameter=100.0,
+            tint_color=QColor(200, 100, 50, 100),
+        )
+        assert pixmap is not None
+        assert not pixmap.isNull()
+
+    def test_caching_returns_same_pixmap(self, qtbot: object) -> None:  # noqa: ARG002
+        p1 = render_plant_pixmap(
+            ObjectType.TREE, diameter=100.0, item_id="test-cache",
+        )
+        p2 = render_plant_pixmap(
+            ObjectType.TREE, diameter=100.0, item_id="test-cache",
+        )
+        assert p1 is p2  # Same object from cache
+
+    def test_different_sizes_different_pixmaps(self, qtbot: object) -> None:  # noqa: ARG002
+        p1 = render_plant_pixmap(ObjectType.TREE, diameter=50.0, item_id="id1")
+        p2 = render_plant_pixmap(ObjectType.TREE, diameter=100.0, item_id="id1")
+        assert p1 is not None
+        assert p2 is not None
+        assert p1.width() != p2.width()
+
+    def test_minimum_size_clamped(self, qtbot: object) -> None:  # noqa: ARG002
+        pixmap = render_plant_pixmap(ObjectType.TREE, diameter=1.0)
+        assert pixmap is not None
+        assert pixmap.width() >= 4
+
+    def test_render_all_categories(self, qtbot: object) -> None:  # noqa: ARG002
+        """Verify every category SVG renders without error."""
+        for cat in PlantCategory:
+            pixmap = render_plant_pixmap(
+                ObjectType.TREE, diameter=64.0, category=cat,
+            )
+            assert pixmap is not None, f"Failed to render category: {cat.name}"
+            assert not pixmap.isNull()
+
+    def test_render_all_species(self, qtbot: object) -> None:  # noqa: ARG002
+        """Verify all species SVGs render without error."""
+        species_list = [
+            "rose", "lavender", "apple", "cherry",
+            "sunflower", "tomato", "boxwood", "rhododendron",
+        ]
+        for species in species_list:
+            pixmap = render_plant_pixmap(
+                ObjectType.TREE, diameter=64.0, species=species,
+            )
+            assert pixmap is not None, f"Failed to render species: {species}"
+            assert not pixmap.isNull()
+
+
+class TestHelperFunctions:
+    """Tests for utility functions."""
+
+    def test_get_all_categories(self, qtbot: object) -> None:  # noqa: ARG002
+        cats = get_all_categories()
+        assert len(cats) == 15
+        assert PlantCategory.ROUND_DECIDUOUS in cats
+
+    def test_get_species_names(self, qtbot: object) -> None:  # noqa: ARG002
+        names = get_species_names()
+        assert len(names) > 0
+        assert "rose" in names
+        assert "lavender" in names
+
+    def test_clear_plant_cache(self, qtbot: object) -> None:  # noqa: ARG002
+        # Load something into cache
+        render_plant_pixmap(ObjectType.TREE, diameter=64.0)
+        # Clear should not raise
+        clear_plant_cache()
+        # Loading again should still work
+        pixmap = render_plant_pixmap(ObjectType.TREE, diameter=64.0)
+        assert pixmap is not None


### PR DESCRIPTION
## Summary
- Replace flat colored circles with organic, illustrated top-down SVG plant shapes for Tree, Shrub, and Perennial types
- 15 category-based SVGs (round deciduous, columnar tree, conifer, spreading shrub, etc.) + 8 species-specific SVGs (rose, lavender, apple tree, cherry tree, sunflower, tomato, boxwood, rhododendron)
- New `plant_renderer.py` module with PlantCategory enum, SVG resolution priority (species → category → ObjectType default), QPixmap caching, and stable per-item random rotation

## Technical Details
- `CircleItem.paint()` override renders SVG pixmap for plant types, 1.15x scale for organic edge fill
- `boundingRect()` expanded for plant overflow area
- Serialization support for `plant_category` and `plant_species` in project files
- Backwards compatible: existing plant objects automatically map to default SVG shapes

## Test plan
- [x] 69 unit tests for plant_renderer module (SVG loading, caching, mapping, rendering)
- [x] Full test suite: 631 tests passing
- [x] Ruff lint clean
- [x] Manual testing: Tree, Shrub, Perennial render with illustrated SVGs on canvas

🤖 Generated with [Claude Code](https://claude.com/claude-code)