### PR TITLE
feat(US-6.4): Add visual scale bar on canvas

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,7 +181,7 @@ tests/
 | :white_check_mark: | 6.1  | Rich tileable PNG textures for all materials      |
 | :white_check_mark: | 6.2  | Illustrated SVG plant rendering (hybrid approach) |
 | :white_check_mark: | 6.3  | Drop shadows on all objects (toggleable)          |
-|        | 6.4  | Visual scale bar on canvas                        |
+| :white_check_mark: | 6.4  | Visual scale bar on canvas                        |
 |        | 6.5  | Visual thumbnail gallery sidebar                  |
 |        | 6.6  | Toggleable object labels on canvas                |
 |        | 6.7  | Branded green theme (light/dark)                  |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -129,7 +129,7 @@
 | US-6.1 | Rich tileable textures for all materials | Must | :white_check_mark: Done |
 | US-6.2 | Illustrated SVG plant rendering (hybrid approach) | Must | :white_check_mark: Done |
 | US-6.3 | Drop shadows on all objects (toggleable) | Must | :white_check_mark: Done |
-| US-6.4 | Visual scale bar on canvas | Must | |
+| US-6.4 | Visual scale bar on canvas | Must | :white_check_mark: Done |
 | US-6.5 | Visual thumbnail gallery sidebar | Must | |
 | US-6.6 | Toggleable object labels on canvas | Should | |
 | US-6.7 | Branded green theme (light/dark variants) | Should | |

--- a/src/open_garden_planner/app/application.py
+++ b/src/open_garden_planner/app/application.py
@@ -317,6 +317,14 @@ class GardenPlannerApp(QMainWindow):
         self._shadows_action.triggered.connect(self._on_toggle_shadows)
         menu.addAction(self._shadows_action)
 
+        # Toggle Scale Bar
+        self._scale_bar_action = QAction("Show Scale &Bar", self)
+        self._scale_bar_action.setCheckable(True)
+        self._scale_bar_action.setChecked(True)  # Updated from settings in _setup_central_widget
+        self._scale_bar_action.setStatusTip("Toggle the scale bar overlay on the canvas")
+        self._scale_bar_action.triggered.connect(self._on_toggle_scale_bar)
+        menu.addAction(self._scale_bar_action)
+
         menu.addSeparator()
 
         # Theme submenu
@@ -472,8 +480,9 @@ class GardenPlannerApp(QMainWindow):
         # Initial selection display
         self.update_selection(0, [])
 
-        # Initialize shadow state from settings
+        # Initialize shadow and scale bar state from settings
         QTimer.singleShot(0, self._init_shadows_from_settings)
+        QTimer.singleShot(0, self._init_scale_bar_from_settings)
 
     def _setup_sidebar(self) -> None:
         """Set up the right sidebar with collapsible panels."""
@@ -1157,6 +1166,21 @@ class GardenPlannerApp(QMainWindow):
 
         self.canvas_scene.set_shadows_enabled(checked)
         get_settings().show_shadows = checked
+
+    def _init_scale_bar_from_settings(self) -> None:
+        """Initialize scale bar state from persisted settings."""
+        from open_garden_planner.app.settings import get_settings
+
+        enabled = get_settings().show_scale_bar
+        self._scale_bar_action.setChecked(enabled)
+        self.canvas_view.set_scale_bar_visible(enabled)
+
+    def _on_toggle_scale_bar(self, checked: bool) -> None:
+        """Handle toggle scale bar action."""
+        from open_garden_planner.app.settings import get_settings
+
+        self.canvas_view.set_scale_bar_visible(checked)
+        get_settings().show_scale_bar = checked
 
     def _on_toggle_grid(self, checked: bool) -> None:
         """Handle toggle grid action."""

--- a/src/open_garden_planner/app/settings.py
+++ b/src/open_garden_planner/app/settings.py
@@ -26,11 +26,13 @@ class AppSettings:
     KEY_SHOW_WELCOME = "startup/show_welcome"
     KEY_THEME_MODE = "appearance/theme_mode"
     KEY_SHOW_SHADOWS = "appearance/show_shadows"
+    KEY_SHOW_SCALE_BAR = "appearance/show_scale_bar"
 
     # Default values
     DEFAULT_AUTOSAVE_ENABLED = True
     DEFAULT_SHOW_WELCOME = True
     DEFAULT_SHOW_SHADOWS = True
+    DEFAULT_SHOW_SCALE_BAR = True
     DEFAULT_AUTOSAVE_INTERVAL_MINUTES = 5
     MIN_AUTOSAVE_INTERVAL_MINUTES = 1
     MAX_AUTOSAVE_INTERVAL_MINUTES = 30
@@ -184,6 +186,20 @@ class AppSettings:
     def show_shadows(self, show: bool) -> None:
         """Set whether to show drop shadows on canvas objects."""
         self._settings.setValue(self.KEY_SHOW_SHADOWS, show)
+
+    @property
+    def show_scale_bar(self) -> bool:
+        """Whether to show the scale bar on the canvas."""
+        return self._settings.value(
+            self.KEY_SHOW_SCALE_BAR,
+            self.DEFAULT_SHOW_SCALE_BAR,
+            type=bool,
+        )
+
+    @show_scale_bar.setter
+    def show_scale_bar(self, show: bool) -> None:
+        """Set whether to show the scale bar on the canvas."""
+        self._settings.setValue(self.KEY_SHOW_SCALE_BAR, show)
 
     def sync(self) -> None:
         """Force settings to be written to storage."""

--- a/tests/unit/test_scale_bar.py
+++ b/tests/unit/test_scale_bar.py
@@ -1,0 +1,86 @@
+"""Tests for US-6.4: Visual scale bar on canvas."""
+
+import pytest
+
+from open_garden_planner.ui.canvas.canvas_scene import CanvasScene
+from open_garden_planner.ui.canvas.canvas_view import CanvasView
+
+
+class TestScaleBarVisibility:
+    """Tests for scale bar toggle."""
+
+    def test_scale_bar_visible_by_default(self, qtbot) -> None:
+        scene = CanvasScene()
+        view = CanvasView(scene)
+        qtbot.addWidget(view)
+        assert view.scale_bar_visible is True
+
+    def test_set_scale_bar_visible_false(self, qtbot) -> None:
+        scene = CanvasScene()
+        view = CanvasView(scene)
+        qtbot.addWidget(view)
+        view.set_scale_bar_visible(False)
+        assert view.scale_bar_visible is False
+
+    def test_set_scale_bar_visible_true(self, qtbot) -> None:
+        scene = CanvasScene()
+        view = CanvasView(scene)
+        qtbot.addWidget(view)
+        view.set_scale_bar_visible(False)
+        view.set_scale_bar_visible(True)
+        assert view.scale_bar_visible is True
+
+
+class TestScaleBarDistanceFormat:
+    """Tests for distance label formatting."""
+
+    def test_format_centimeters(self, qtbot) -> None:
+        assert CanvasView._format_distance(1) == "1 cm"
+        assert CanvasView._format_distance(5) == "5 cm"
+        assert CanvasView._format_distance(50) == "50 cm"
+
+    def test_format_meters(self, qtbot) -> None:
+        assert CanvasView._format_distance(100) == "1 m"
+        assert CanvasView._format_distance(200) == "2 m"
+        assert CanvasView._format_distance(500) == "5 m"
+        assert CanvasView._format_distance(1000) == "10 m"
+
+    def test_format_kilometers(self, qtbot) -> None:
+        assert CanvasView._format_distance(100000) == "1 km"
+        assert CanvasView._format_distance(500000) == "5 km"
+
+    def test_format_no_trailing_zeros(self, qtbot) -> None:
+        # %g format strips trailing zeros
+        assert CanvasView._format_distance(100) == "1 m"
+        assert CanvasView._format_distance(250) == "2.5 m"
+
+
+class TestScaleBarDistancePicking:
+    """Tests for the scale bar round distance selection."""
+
+    def test_picks_from_nice_distances(self, qtbot) -> None:
+        scene = CanvasScene()
+        view = CanvasView(scene)
+        qtbot.addWidget(view)
+        # At default zoom (1.0), target ~150px => 150cm = 1.5m
+        # Closest nice distance should be 100cm or 200cm
+        dist = view._pick_scale_bar_distance()
+        assert dist in CanvasView._SCALE_BAR_NICE_DISTANCES
+
+    def test_zoomed_in_picks_smaller_distance(self, qtbot) -> None:
+        scene = CanvasScene()
+        view = CanvasView(scene)
+        qtbot.addWidget(view)
+        view.set_zoom(10.0)  # Very zoomed in
+        dist = view._pick_scale_bar_distance()
+        # At zoom=10, 150px = 15cm, so should pick small distance
+        assert dist <= 50
+
+    def test_zoomed_out_picks_larger_distance(self, qtbot) -> None:
+        scene = CanvasScene()
+        view = CanvasView(scene)
+        qtbot.addWidget(view)
+        view.set_zoom(0.05)  # Very zoomed out
+        dist = view._pick_scale_bar_distance()
+        # At zoom=0.05, 150px = 3000cm = 30m, should pick large distance
+        assert dist >= 1000


### PR DESCRIPTION
## Summary
- Google Maps-style scale bar overlay in the bottom-right corner of the canvas
- Auto-adjusts to round distances (cm/m/km) as zoom level changes
- White outline behind dark lines/text for legibility over any background
- Toggleable via View > Show Scale Bar, setting persisted via QSettings

## Technical Details
- Painted as viewport overlay in `CanvasView.paintEvent()` (stays fixed regardless of pan/zoom)
- Two-pass rendering: white outline pass + dark foreground pass
- Distance selection algorithm picks from 1-2-5 series for clean labels
- 10 unit tests covering visibility toggle, distance formatting, and zoom-based distance picking

## Test plan
- [x] Scale bar visible by default in bottom-right corner
- [x] Bar and label auto-adjust when zooming in/out
- [x] Toggle via View > Show Scale Bar hides/shows it
- [x] Setting persists across app restarts
- [x] Legible over both light and dark backgrounds
- [x] All 653 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)