### PR TITLE
feat(US-6.6): Add toggleable object labels on canvas

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -183,7 +183,7 @@ tests/
 | ✅ | 6.3  | Drop shadows on all objects (toggleable)          |
 | ✅ | 6.4  | Visual scale bar on canvas                        |
 | ✅ | 6.5  | Visual thumbnail gallery sidebar                  |
-|        | 6.6  | Toggleable object labels on canvas                |
+| ✅ | 6.6  | Toggleable object labels on canvas                |
 |        | 6.7  | Branded green theme (light/dark)                  |
 |        | 6.8  | Outdoor furniture objects                         |
 |        | 6.9  | Garden infrastructure objects                     |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -131,7 +131,7 @@
 | US-6.3 | Drop shadows on all objects (toggleable) | Must | ✅ Done |
 | US-6.4 | Visual scale bar on canvas | Must | ✅ Done |
 | US-6.5 | Visual thumbnail gallery sidebar | Must | ✅ Done |
-| US-6.6 | Toggleable object labels on canvas | Should | |
+| US-6.6 | Toggleable object labels on canvas | Should | ✅ Done |
 | US-6.7 | Branded green theme (light/dark variants) | Should | |
 | US-6.8 | Outdoor furniture objects | Must | |
 | US-6.9 | Garden infrastructure objects | Must | |

--- a/src/open_garden_planner/app/application.py
+++ b/src/open_garden_planner/app/application.py
@@ -325,6 +325,14 @@ class GardenPlannerApp(QMainWindow):
         self._scale_bar_action.triggered.connect(self._on_toggle_scale_bar)
         menu.addAction(self._scale_bar_action)
 
+        # Toggle Labels
+        self._labels_action = QAction("Show &Labels", self)
+        self._labels_action.setCheckable(True)
+        self._labels_action.setChecked(True)  # Updated from settings in _setup_central_widget
+        self._labels_action.setStatusTip("Toggle object labels on the canvas")
+        self._labels_action.triggered.connect(self._on_toggle_labels)
+        menu.addAction(self._labels_action)
+
         menu.addSeparator()
 
         # Theme submenu
@@ -487,9 +495,10 @@ class GardenPlannerApp(QMainWindow):
         # Initial selection display
         self.update_selection(0, [])
 
-        # Initialize shadow and scale bar state from settings
+        # Initialize shadow, scale bar, and labels state from settings
         QTimer.singleShot(0, self._init_shadows_from_settings)
         QTimer.singleShot(0, self._init_scale_bar_from_settings)
+        QTimer.singleShot(0, self._init_labels_from_settings)
 
     def _setup_sidebar(self) -> None:
         """Set up the right sidebar with collapsible panels."""
@@ -1188,6 +1197,21 @@ class GardenPlannerApp(QMainWindow):
 
         self.canvas_view.set_scale_bar_visible(checked)
         get_settings().show_scale_bar = checked
+
+    def _init_labels_from_settings(self) -> None:
+        """Initialize labels state from persisted settings."""
+        from open_garden_planner.app.settings import get_settings
+
+        enabled = get_settings().show_labels
+        self._labels_action.setChecked(enabled)
+        self.canvas_scene.set_labels_visible(enabled)
+
+    def _on_toggle_labels(self, checked: bool) -> None:
+        """Handle toggle labels action."""
+        from open_garden_planner.app.settings import get_settings
+
+        self.canvas_scene.set_labels_visible(checked)
+        get_settings().show_labels = checked
 
     def _on_toggle_grid(self, checked: bool) -> None:
         """Handle toggle grid action."""

--- a/src/open_garden_planner/app/settings.py
+++ b/src/open_garden_planner/app/settings.py
@@ -27,12 +27,14 @@ class AppSettings:
     KEY_THEME_MODE = "appearance/theme_mode"
     KEY_SHOW_SHADOWS = "appearance/show_shadows"
     KEY_SHOW_SCALE_BAR = "appearance/show_scale_bar"
+    KEY_SHOW_LABELS = "appearance/show_labels"
 
     # Default values
     DEFAULT_AUTOSAVE_ENABLED = True
     DEFAULT_SHOW_WELCOME = True
     DEFAULT_SHOW_SHADOWS = True
     DEFAULT_SHOW_SCALE_BAR = True
+    DEFAULT_SHOW_LABELS = True
     DEFAULT_AUTOSAVE_INTERVAL_MINUTES = 5
     MIN_AUTOSAVE_INTERVAL_MINUTES = 1
     MAX_AUTOSAVE_INTERVAL_MINUTES = 30
@@ -200,6 +202,20 @@ class AppSettings:
     def show_scale_bar(self, show: bool) -> None:
         """Set whether to show the scale bar on the canvas."""
         self._settings.setValue(self.KEY_SHOW_SCALE_BAR, show)
+
+    @property
+    def show_labels(self) -> bool:
+        """Whether to show object labels on the canvas."""
+        return self._settings.value(
+            self.KEY_SHOW_LABELS,
+            self.DEFAULT_SHOW_LABELS,
+            type=bool,
+        )
+
+    @show_labels.setter
+    def show_labels(self, show: bool) -> None:
+        """Set whether to show object labels on the canvas."""
+        self._settings.setValue(self.KEY_SHOW_LABELS, show)
 
     def sync(self) -> None:
         """Force settings to be written to storage."""

--- a/src/open_garden_planner/core/project.py
+++ b/src/open_garden_planner/core/project.py
@@ -254,6 +254,8 @@ class ProjectManager(QObject):
                 data["metadata"] = item.metadata
             if hasattr(item, "layer_id") and item.layer_id:
                 data["layer_id"] = str(item.layer_id)
+            if hasattr(item, "label_visible") and not item.label_visible:
+                data["label_visible"] = False
             # Save custom fill and stroke colors (with alpha)
             # Use stored fill_color if available (for textured brushes), otherwise get from brush
             if hasattr(item, "fill_color") and item.fill_color:
@@ -289,6 +291,8 @@ class ProjectManager(QObject):
                 data["metadata"] = item.metadata
             if hasattr(item, "layer_id") and item.layer_id:
                 data["layer_id"] = str(item.layer_id)
+            if hasattr(item, "label_visible") and not item.label_visible:
+                data["label_visible"] = False
             # Save custom fill and stroke colors (with alpha)
             # Use stored fill_color if available (for textured brushes), otherwise get from brush
             if hasattr(item, "fill_color") and item.fill_color:
@@ -327,6 +331,8 @@ class ProjectManager(QObject):
                 data["metadata"] = item.metadata
             if hasattr(item, "layer_id") and item.layer_id:
                 data["layer_id"] = str(item.layer_id)
+            if hasattr(item, "label_visible") and not item.label_visible:
+                data["label_visible"] = False
             # Save custom stroke color (polylines don't have fill, with alpha)
             stroke_color = item.pen().color()
             data["stroke_color"] = stroke_color.name(QColor.NameFormat.HexArgb)
@@ -356,6 +362,8 @@ class ProjectManager(QObject):
                 data["metadata"] = item.metadata
             if hasattr(item, "layer_id") and item.layer_id:
                 data["layer_id"] = str(item.layer_id)
+            if hasattr(item, "label_visible") and not item.label_visible:
+                data["label_visible"] = False
             # Save custom fill and stroke colors (with alpha)
             # Use stored fill_color if available (for textured brushes), otherwise get from brush
             if hasattr(item, "fill_color") and item.fill_color:
@@ -441,6 +449,7 @@ class ProjectManager(QObject):
 
         name = obj.get("name", "")
         metadata = obj.get("metadata", {})
+        label_visible = obj.get("label_visible", True)
         fill_pattern = None
         if "fill_pattern" in obj:
             try:
@@ -498,6 +507,9 @@ class ProjectManager(QObject):
                 if stroke_style:
                     pen.setStyle(stroke_style.to_qt_pen_style())
                 item.setPen(pen)
+            # Restore label visibility
+            if not label_visible:
+                item.label_visible = False
             # Restore rotation angle
             if "rotation_angle" in obj:
                 item._apply_rotation(obj["rotation_angle"])
@@ -535,6 +547,9 @@ class ProjectManager(QObject):
                 if stroke_style:
                     pen.setStyle(stroke_style.to_qt_pen_style())
                 item.setPen(pen)
+            # Restore label visibility
+            if not label_visible:
+                item.label_visible = False
             # Restore rotation angle
             if "rotation_angle" in obj:
                 item._apply_rotation(obj["rotation_angle"])
@@ -564,6 +579,9 @@ class ProjectManager(QObject):
                     if "stroke_width" in obj:
                         pen.setWidthF(obj["stroke_width"])
                     item.setPen(pen)
+                # Restore label visibility
+                if not label_visible:
+                    item.label_visible = False
                 # Restore rotation angle
                 if "rotation_angle" in obj:
                     item._apply_rotation(obj["rotation_angle"])
@@ -601,6 +619,9 @@ class ProjectManager(QObject):
                     if stroke_style:
                         pen.setStyle(stroke_style.to_qt_pen_style())
                     item.setPen(pen)
+                # Restore label visibility
+                if not label_visible:
+                    item.label_visible = False
                 # Restore rotation angle
                 if "rotation_angle" in obj:
                     item._apply_rotation(obj["rotation_angle"])

--- a/src/open_garden_planner/ui/canvas/canvas_scene.py
+++ b/src/open_garden_planner/ui/canvas/canvas_scene.py
@@ -70,6 +70,9 @@ class CanvasScene(QGraphicsScene):
         # Shadow state
         self._shadows_enabled = True
 
+        # Labels state
+        self._labels_enabled = True
+
         # Layer management
         self._layers: list[Layer] = create_default_layers()
         self._active_layer: Layer | None = self._layers[0] if self._layers else None  # Default to first layer
@@ -150,8 +153,28 @@ class CanvasScene(QGraphicsScene):
         effect.setOffset(self.SHADOW_OFFSET_X, self.SHADOW_OFFSET_Y)
         item.setGraphicsEffect(effect)
 
+    # Label management
+
+    @property
+    def labels_enabled(self) -> bool:
+        """Whether labels are shown on objects."""
+        return self._labels_enabled
+
+    def set_labels_visible(self, visible: bool) -> None:
+        """Enable or disable labels on all garden objects.
+
+        Args:
+            visible: Whether labels should be shown
+        """
+        self._labels_enabled = visible
+        from open_garden_planner.ui.canvas.items.garden_item import GardenItemMixin
+
+        for item in self.items():
+            if isinstance(item, GardenItemMixin):
+                item.set_global_labels_visible(visible)
+
     def addItem(self, item: QGraphicsItem) -> None:
-        """Add an item to the scene, applying shadow if enabled.
+        """Add an item to the scene, applying shadow and label state.
 
         Args:
             item: The graphics item to add
@@ -159,6 +182,10 @@ class CanvasScene(QGraphicsScene):
         super().addItem(item)
         if self._shadows_enabled and self._is_shadow_eligible(item):
             self._apply_shadow_effect(item)
+        # Sync global label state to newly added items
+        from open_garden_planner.ui.canvas.items.garden_item import GardenItemMixin
+        if isinstance(item, GardenItemMixin):
+            item.set_global_labels_visible(self._labels_enabled)
 
     @property
     def width_cm(self) -> float:


### PR DESCRIPTION
## Summary
- Global label toggle via View > Show Labels (persisted in settings)
- Per-object label toggle via checkbox in Properties panel
- Labels only show user-set custom names (no auto-labelling)
- Labels readable at any zoom level
- Serialized in .ogp project files with backward compatibility

## Technical Details
- `garden_item.py`: Added `_label_visible`, `_global_labels_visible`, `set_global_labels_visible()`, updated `_update_label()` logic
- `canvas_scene.py`: Added `set_labels_visible()` global toggle, syncs state to new items via `addItem()`
- `settings.py`: Added `show_labels` persistent setting
- `application.py`: Added "Show Labels" action in View menu with init from settings
- `properties_panel.py`: Added "Show label on canvas" checkbox with undo support
- `project.py`: Serializes `label_visible: false` when disabled (defaults true for backward compat)

## Test plan
- [x] All 669 tests pass
- [x] Ruff lint clean
- [x] Manual: draw objects, set custom names, labels appear
- [x] Manual: View > Show Labels toggles all labels
- [x] Manual: Per-object checkbox hides/shows individual labels
- [x] Manual: Labels readable at all zoom levels

🤖 Generated with [Claude Code](https://claude.com/claude-code)