### PR TITLE
feat(US-6.11): Add fullscreen preview mode (F11)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,7 +188,7 @@ tests/
 |        | 6.8  | Outdoor furniture objects                         |
 |        | 6.9  | Garden infrastructure objects                     |
 |        | 6.10 | Object snapping & alignment tools                 |
-|        | 6.11 | Fullscreen preview mode (F11)                     |
+| ✅ | 6.11 | Fullscreen preview mode (F11)                     |
 |        | 6.12 | Internationalization (EN + DE, Qt Linguist)       |
 |        | 6.13 | Print support with scaling                        |
 |        | 6.14 | Windows installer (NSIS) + .ogp file association  |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -136,7 +136,7 @@
 | US-6.8 | Outdoor furniture objects | Must | |
 | US-6.9 | Garden infrastructure objects | Must | |
 | US-6.10 | Object snapping & alignment tools | Should | |
-| US-6.11 | Fullscreen preview mode (F11) | Should | |
+| US-6.11 | Fullscreen preview mode (F11) | Should | ✅ Done |
 | US-6.12 | Internationalization (EN + DE, Qt Linguist) | Must | |
 | US-6.13 | Print support with scaling | Should | |
 | US-6.14 | Windows installer (NSIS) + .ogp file association | Must | |
@@ -330,7 +330,7 @@
 - [ ] Infrastructure SVG assets + object types
 - [ ] Snap-to-object with visual guides
 - [ ] Alignment/distribution tools
-- [ ] Fullscreen preview mode
+- [x] Fullscreen preview mode
 - [ ] Qt Linguist i18n + German translation
 - [ ] Print support (QPrinter)
 - [ ] PyInstaller + NSIS installer

--- a/src/open_garden_planner/ui/dialogs/shortcuts_dialog.py
+++ b/src/open_garden_planner/ui/dialogs/shortcuts_dialog.py
@@ -67,6 +67,8 @@ class ShortcutsDialog(QDialog):
             ("Ctrl+0", "Fit to Window"),
             ("G", "Toggle Grid"),
             ("S", "Toggle Snap to Grid"),
+            ("F11", "Fullscreen Preview"),
+            ("Escape", "Exit Fullscreen Preview"),
             ("Scroll Wheel", "Zoom"),
             ("Middle Mouse Drag", "Pan"),
         ])

--- a/tests/ui/test_main_window.py
+++ b/tests/ui/test_main_window.py
@@ -210,6 +210,192 @@ class TestMainWindow:
         assert save_action.shortcut().toString() == "Ctrl+S"
 
 
+class TestPreviewMode:
+    """Tests for fullscreen preview mode (US-6.11)."""
+
+    def test_preview_action_exists(self, qtbot) -> None:
+        """Test that Fullscreen Preview action exists in View menu."""
+        window = GardenPlannerApp()
+        qtbot.addWidget(window)
+        view_menu = None
+        for action in window.menuBar().actions():
+            if action.text() == "&View":
+                view_menu = action.menu()
+                break
+
+        action_texts = [a.text() for a in view_menu.actions()]
+        assert any("Fullscreen Preview" in text for text in action_texts)
+
+    def test_preview_action_is_checkable(self, qtbot) -> None:
+        """Test that the preview action is checkable."""
+        window = GardenPlannerApp()
+        qtbot.addWidget(window)
+        assert window._preview_action.isCheckable()
+        assert not window._preview_action.isChecked()
+
+    def test_preview_action_shortcut(self, qtbot) -> None:
+        """Test that F11 shortcut is assigned to preview action."""
+        window = GardenPlannerApp()
+        qtbot.addWidget(window)
+        assert window._preview_action.shortcut().toString() == "F11"
+
+    def test_preview_mode_initial_state(self, qtbot) -> None:
+        """Test that preview mode is off by default."""
+        window = GardenPlannerApp()
+        qtbot.addWidget(window)
+        assert not window._preview_mode
+
+    def test_enter_preview_mode_hides_sidebar(self, qtbot) -> None:
+        """Test that entering preview mode hides the sidebar."""
+        window = GardenPlannerApp()
+        qtbot.addWidget(window)
+        window._enter_preview_mode()
+        assert not window.sidebar.isVisible()
+
+    def test_enter_preview_mode_hides_toolbar(self, qtbot) -> None:
+        """Test that entering preview mode hides the toolbar."""
+        window = GardenPlannerApp()
+        qtbot.addWidget(window)
+        window._enter_preview_mode()
+        assert not window.main_toolbar.isVisible()
+
+    def test_enter_preview_mode_hides_statusbar(self, qtbot) -> None:
+        """Test that entering preview mode hides the status bar."""
+        window = GardenPlannerApp()
+        qtbot.addWidget(window)
+        window._enter_preview_mode()
+        assert not window.statusBar().isVisible()
+
+    def test_enter_preview_mode_hides_menubar(self, qtbot) -> None:
+        """Test that entering preview mode hides the menu bar."""
+        window = GardenPlannerApp()
+        qtbot.addWidget(window)
+        window._enter_preview_mode()
+        assert not window.menuBar().isVisible()
+
+    def test_enter_preview_mode_hides_grid(self, qtbot) -> None:
+        """Test that entering preview mode hides the grid."""
+        window = GardenPlannerApp()
+        qtbot.addWidget(window)
+        # Enable grid first
+        window.canvas_view.set_grid_visible(True)
+        window._enter_preview_mode()
+        assert not window.canvas_view.grid_visible
+
+    def test_enter_preview_mode_hides_scale_bar(self, qtbot) -> None:
+        """Test that entering preview mode hides the scale bar."""
+        window = GardenPlannerApp()
+        qtbot.addWidget(window)
+        window._enter_preview_mode()
+        assert not window.canvas_view.scale_bar_visible
+
+    def test_enter_preview_mode_hides_labels(self, qtbot) -> None:
+        """Test that entering preview mode hides labels."""
+        window = GardenPlannerApp()
+        qtbot.addWidget(window)
+        window._enter_preview_mode()
+        assert not window.canvas_scene.labels_enabled
+
+    def test_enter_preview_mode_sets_flag(self, qtbot) -> None:
+        """Test that entering preview mode sets the flag."""
+        window = GardenPlannerApp()
+        qtbot.addWidget(window)
+        window._enter_preview_mode()
+        assert window._preview_mode
+
+    def test_exit_preview_mode_restores_sidebar(self, qtbot) -> None:
+        """Test that exiting preview mode restores the sidebar."""
+        window = GardenPlannerApp()
+        qtbot.addWidget(window)
+        window._enter_preview_mode()
+        window._exit_preview_mode()
+        assert window.sidebar.isVisible()
+
+    def test_exit_preview_mode_restores_toolbar(self, qtbot) -> None:
+        """Test that exiting preview mode restores the toolbar."""
+        window = GardenPlannerApp()
+        qtbot.addWidget(window)
+        window._enter_preview_mode()
+        window._exit_preview_mode()
+        assert window.main_toolbar.isVisible()
+
+    def test_exit_preview_mode_restores_statusbar(self, qtbot) -> None:
+        """Test that exiting preview mode restores the status bar."""
+        window = GardenPlannerApp()
+        qtbot.addWidget(window)
+        window._enter_preview_mode()
+        window._exit_preview_mode()
+        assert window.statusBar().isVisible()
+
+    def test_exit_preview_mode_restores_menubar(self, qtbot) -> None:
+        """Test that exiting preview mode restores the menu bar."""
+        window = GardenPlannerApp()
+        qtbot.addWidget(window)
+        window._enter_preview_mode()
+        window._exit_preview_mode()
+        assert window.menuBar().isVisible()
+
+    def test_exit_preview_mode_restores_grid_state(self, qtbot) -> None:
+        """Test that exiting preview mode restores the grid state."""
+        window = GardenPlannerApp()
+        qtbot.addWidget(window)
+        # Enable grid before entering preview
+        window.canvas_view.set_grid_visible(True)
+        window._enter_preview_mode()
+        window._exit_preview_mode()
+        assert window.canvas_view.grid_visible
+
+    def test_exit_preview_mode_restores_scale_bar_state(self, qtbot) -> None:
+        """Test that exiting preview mode restores scale bar state."""
+        window = GardenPlannerApp()
+        qtbot.addWidget(window)
+        window._enter_preview_mode()
+        window._exit_preview_mode()
+        assert window.canvas_view.scale_bar_visible
+
+    def test_exit_preview_mode_restores_labels_state(self, qtbot) -> None:
+        """Test that exiting preview mode restores labels state."""
+        window = GardenPlannerApp()
+        qtbot.addWidget(window)
+        window._enter_preview_mode()
+        window._exit_preview_mode()
+        assert window.canvas_scene.labels_enabled
+
+    def test_exit_preview_mode_clears_flag(self, qtbot) -> None:
+        """Test that exiting preview mode clears the flag."""
+        window = GardenPlannerApp()
+        qtbot.addWidget(window)
+        window._enter_preview_mode()
+        window._exit_preview_mode()
+        assert not window._preview_mode
+
+    def test_exit_preview_mode_unchecks_action(self, qtbot) -> None:
+        """Test that exiting preview mode unchecks the menu action."""
+        window = GardenPlannerApp()
+        qtbot.addWidget(window)
+        window._preview_action.setChecked(True)
+        window._enter_preview_mode()
+        window._exit_preview_mode()
+        assert not window._preview_action.isChecked()
+
+    def test_double_enter_is_idempotent(self, qtbot) -> None:
+        """Test that entering preview mode twice doesn't cause issues."""
+        window = GardenPlannerApp()
+        qtbot.addWidget(window)
+        window._enter_preview_mode()
+        window._enter_preview_mode()  # Should be no-op
+        assert window._preview_mode
+        window._exit_preview_mode()
+        assert not window._preview_mode
+
+    def test_double_exit_is_idempotent(self, qtbot) -> None:
+        """Test that exiting preview mode twice doesn't cause issues."""
+        window = GardenPlannerApp()
+        qtbot.addWidget(window)
+        window._exit_preview_mode()  # Should be no-op when not in preview
+        assert not window._preview_mode
+
+
 class TestApplicationIcon:
     """Tests for application icon functionality (US-1.8)."""
 


### PR DESCRIPTION
## Summary
- F11 toggles fullscreen preview mode that hides all UI chrome (menu bar, toolbar, status bar, sidebar)
- Canvas overlays (grid, scale bar, labels) are hidden; all objects deselected
- Escape or F11 exits back to design mode, restoring all previous overlay states
- View menu entry with checkable action and F11 shortcut
- Keyboard shortcuts dialog updated with F11/Escape entries

## Technical Details
- `keyPressEvent` override on `GardenPlannerApp` handles F11 toggle directly (since menu bar is hidden in preview mode, the QAction shortcut alone wouldn't work for exit)
- Pre-preview state (grid, scale bar, labels, window maximized) saved and restored on exit
- Idempotent enter/exit guards prevent double-toggle issues

## Test plan
- [x] 22 new tests in `TestPreviewMode` covering enter/exit, state save/restore, idempotency
- [x] All 692 tests pass
- [x] Ruff lint clean
- [x] Manual testing: F11 enter, F11 exit, Escape exit all work

🤖 Generated with [Claude Code](https://claude.com/claude-code)