### PR TITLE
feat(US-6.9): Add garden infrastructure objects with SVG rendering

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,6 +150,8 @@ src/open_garden_planner/
     ├── textures/                 # Tileable PNG textures (Phase 6)
     ├── plants/                   # Plant SVG illustrations (Phase 6)
     └── objects/                  # Object SVG illustrations (Phase 6)
+        ├── furniture/            # Outdoor furniture SVGs
+        └── infrastructure/       # Garden infrastructure SVGs
 
 docs/                             # arc42 architecture documentation
 ├── 01-introduction-and-goals/    # Vision, goals, users
@@ -187,7 +189,7 @@ tests/
 | ✅ | 6.6  | Toggleable object labels on canvas                |
 | ✅ | 6.7  | Branded green theme (light/dark)                  |
 | ✅ | 6.8  | Outdoor furniture objects                         |
-|        | 6.9  | Garden infrastructure objects                     |
+| ✅ | 6.9  | Garden infrastructure objects                     |
 |        | 6.10 | Object snapping & alignment tools                 |
 | ✅ | 6.11 | Fullscreen preview mode (F11)                     |
 |        | 6.12 | Internationalization (EN + DE, Qt Linguist)       |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -134,7 +134,7 @@
 | US-6.6 | Toggleable object labels on canvas | Should | ✅ Done |
 | US-6.7 | Branded green theme (light/dark variants) | Should | ✅ Done |
 | US-6.8 | Outdoor furniture objects | Must | ✅ Done |
-| US-6.9 | Garden infrastructure objects | Must | |
+| US-6.9 | Garden infrastructure objects | Must | ✅ Done |
 | US-6.10 | Object snapping & alignment tools | Should | |
 | US-6.11 | Fullscreen preview mode (F11) | Should | ✅ Done |
 | US-6.12 | Internationalization (EN + DE, Qt Linguist) | Must | |
@@ -327,7 +327,7 @@
 - [ ] Object label rendering
 - [x] Branded green theme
 - [ ] Furniture SVG assets + object types
-- [ ] Infrastructure SVG assets + object types
+- [x] Infrastructure SVG assets + object types
 - [ ] Snap-to-object with visual guides
 - [ ] Alignment/distribution tools
 - [x] Fullscreen preview mode

--- a/src/open_garden_planner/core/furniture_renderer.py
+++ b/src/open_garden_planner/core/furniture_renderer.py
@@ -14,6 +14,7 @@ from .object_types import ObjectType
 
 # Directories containing SVG files
 _FURNITURE_DIR = Path(__file__).parent.parent / "resources" / "objects" / "furniture"
+_INFRASTRUCTURE_DIR = Path(__file__).parent.parent / "resources" / "objects" / "infrastructure"
 _PLANTS_CATEGORIES_DIR = Path(__file__).parent.parent / "resources" / "plants" / "categories"
 
 # Map ObjectType to (directory, filename_without_extension)
@@ -29,14 +30,36 @@ _FURNITURE_FILES: dict[ObjectType, str] = {
     ObjectType.PLANTER_POT: "planter_pot",
 }
 
+# Map ObjectType to SVG filename for infrastructure objects
+_INFRASTRUCTURE_FILES: dict[ObjectType, str] = {
+    ObjectType.RAISED_BED: "raised_bed",
+    ObjectType.COMPOST_BIN: "compost_bin",
+    ObjectType.COLD_FRAME: "cold_frame",
+    ObjectType.RAIN_BARREL: "rain_barrel",
+    ObjectType.WATER_TAP: "water_tap",
+    ObjectType.TOOL_SHED: "tool_shed",
+}
+
 # SVG types whose files live outside _FURNITURE_DIR
 _SVG_DIR_OVERRIDES: dict[ObjectType, Path] = {
     ObjectType.HEDGE_SECTION: _PLANTS_CATEGORIES_DIR,
+    ObjectType.RAISED_BED: _INFRASTRUCTURE_DIR,
+    ObjectType.COMPOST_BIN: _INFRASTRUCTURE_DIR,
+    ObjectType.COLD_FRAME: _INFRASTRUCTURE_DIR,
+    ObjectType.RAIN_BARREL: _INFRASTRUCTURE_DIR,
+    ObjectType.WATER_TAP: _INFRASTRUCTURE_DIR,
+    ObjectType.TOOL_SHED: _INFRASTRUCTURE_DIR,
 }
 
 # Map ObjectType to SVG filename for non-furniture SVG-rendered objects
 _OBJECT_SVG_FILES: dict[ObjectType, str] = {
     ObjectType.HEDGE_SECTION: "hedge_section",
+    ObjectType.RAISED_BED: "raised_bed",
+    ObjectType.COMPOST_BIN: "compost_bin",
+    ObjectType.COLD_FRAME: "cold_frame",
+    ObjectType.RAIN_BARREL: "rain_barrel",
+    ObjectType.WATER_TAP: "water_tap",
+    ObjectType.TOOL_SHED: "tool_shed",
 }
 
 # Default dimensions in cm (width, height) for each furniture type
@@ -50,6 +73,13 @@ FURNITURE_DEFAULT_DIMENSIONS: dict[ObjectType, tuple[float, float]] = {
     ObjectType.BBQ_GRILL: (80.0, 60.0),
     ObjectType.FIRE_PIT: (100.0, 100.0),
     ObjectType.PLANTER_POT: (50.0, 50.0),
+    # Infrastructure
+    ObjectType.RAISED_BED: (120.0, 80.0),
+    ObjectType.COMPOST_BIN: (100.0, 100.0),
+    ObjectType.COLD_FRAME: (120.0, 60.0),
+    ObjectType.RAIN_BARREL: (60.0, 60.0),
+    ObjectType.WATER_TAP: (20.0, 20.0),
+    ObjectType.TOOL_SHED: (200.0, 150.0),
 }
 
 # Cache for QSvgRenderer instances (path -> renderer)

--- a/src/open_garden_planner/core/object_types.py
+++ b/src/open_garden_planner/core/object_types.py
@@ -69,6 +69,14 @@ class ObjectType(Enum):
     FIRE_PIT = auto()
     PLANTER_POT = auto()
 
+    # Garden infrastructure (SVG-rendered)
+    RAISED_BED = auto()
+    COMPOST_BIN = auto()
+    COLD_FRAME = auto()
+    RAIN_BARREL = auto()
+    WATER_TAP = auto()
+    TOOL_SHED = auto()
+
     # Generic geometric shapes (for backwards compatibility)
     GENERIC_RECTANGLE = auto()
     GENERIC_POLYGON = auto()
@@ -255,6 +263,48 @@ OBJECT_STYLES: dict[ObjectType, ObjectStyle] = {
         stroke_color=QColor(140, 80, 30),  # Dark terracotta
         stroke_width=1.5,
         display_name="Planter/Pot",
+        fill_pattern=FillPattern.SOLID,
+    ),
+    ObjectType.RAISED_BED: ObjectStyle(
+        fill_color=QColor(139, 90, 43, 180),  # Wood brown
+        stroke_color=QColor(100, 60, 20),  # Dark wood
+        stroke_width=2.0,
+        display_name="Raised Bed",
+        fill_pattern=FillPattern.SOLID,
+    ),
+    ObjectType.COMPOST_BIN: ObjectStyle(
+        fill_color=QColor(90, 70, 40, 180),  # Dark brown
+        stroke_color=QColor(60, 45, 25),  # Very dark brown
+        stroke_width=1.5,
+        display_name="Compost Bin",
+        fill_pattern=FillPattern.SOLID,
+    ),
+    ObjectType.COLD_FRAME: ObjectStyle(
+        fill_color=QColor(200, 220, 240, 160),  # Light glass blue
+        stroke_color=QColor(150, 155, 160),  # Silver aluminum
+        stroke_width=2.0,
+        display_name="Cold Frame",
+        fill_pattern=FillPattern.SOLID,
+    ),
+    ObjectType.RAIN_BARREL: ObjectStyle(
+        fill_color=QColor(60, 100, 60, 180),  # Dark green
+        stroke_color=QColor(40, 70, 40),  # Darker green
+        stroke_width=1.5,
+        display_name="Rain Barrel",
+        fill_pattern=FillPattern.SOLID,
+    ),
+    ObjectType.WATER_TAP: ObjectStyle(
+        fill_color=QColor(160, 170, 180, 200),  # Steel gray
+        stroke_color=QColor(100, 110, 120),  # Dark steel
+        stroke_width=1.5,
+        display_name="Water Tap",
+        fill_pattern=FillPattern.SOLID,
+    ),
+    ObjectType.TOOL_SHED: ObjectStyle(
+        fill_color=QColor(160, 130, 90, 180),  # Light wood
+        stroke_color=QColor(100, 75, 45),  # Dark wood
+        stroke_width=2.0,
+        display_name="Tool Shed",
         fill_pattern=FillPattern.SOLID,
     ),
     ObjectType.GENERIC_RECTANGLE: ObjectStyle(

--- a/src/open_garden_planner/core/tools/base_tool.py
+++ b/src/open_garden_planner/core/tools/base_tool.py
@@ -51,6 +51,14 @@ class ToolType(Enum):
     FIRE_PIT = auto()
     PLANTER_POT = auto()
 
+    # Garden infrastructure (SVG-rendered)
+    RAISED_BED = auto()
+    COMPOST_BIN = auto()
+    COLD_FRAME = auto()
+    RAIN_BARREL = auto()
+    WATER_TAP = auto()
+    TOOL_SHED = auto()
+
     # Generic geometric shapes (backwards compatibility)
     RECTANGLE = auto()
     POLYGON = auto()

--- a/src/open_garden_planner/resources/objects/infrastructure/cold_frame.svg
+++ b/src/open_garden_planner/resources/objects/infrastructure/cold_frame.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 60">
+  <!-- Cold Frame - top-down view with glass lid -->
+  <!-- Shadow -->
+  <rect x="4" y="4" width="116" height="56" rx="2" fill="#00000020"/>
+  <!-- Wood base frame -->
+  <rect x="2" y="2" width="116" height="56" rx="2" fill="#A08040" stroke="#705828" stroke-width="2"/>
+  <!-- Glass panel (transparent blue tint) -->
+  <rect x="6" y="6" width="108" height="48" rx="1" fill="#C8DDF0" fill-opacity="0.6" stroke="#90A0B0" stroke-width="1"/>
+  <!-- Glass frame dividers -->
+  <line x1="60" y1="6" x2="60" y2="54" stroke="#90A0B0" stroke-width="1.5"/>
+  <line x1="6" y1="30" x2="114" y2="30" stroke="#90A0B0" stroke-width="1.5"/>
+  <!-- Glass reflection highlights -->
+  <line x1="15" y1="12" x2="45" y2="12" stroke="#FFFFFF" stroke-width="1" opacity="0.4"/>
+  <line x1="70" y1="14" x2="100" y2="14" stroke="#FFFFFF" stroke-width="1" opacity="0.3"/>
+  <line x1="15" y1="36" x2="50" y2="36" stroke="#FFFFFF" stroke-width="1" opacity="0.35"/>
+  <line x1="68" y1="38" x2="95" y2="38" stroke="#FFFFFF" stroke-width="1" opacity="0.3"/>
+  <!-- Small plants visible through glass -->
+  <circle cx="30" cy="20" r="4" fill="#4A8030" opacity="0.3"/>
+  <circle cx="90" cy="22" r="3.5" fill="#4A8030" opacity="0.25"/>
+  <circle cx="35" cy="44" r="3" fill="#4A8030" opacity="0.3"/>
+  <circle cx="85" cy="42" r="4" fill="#4A8030" opacity="0.25"/>
+  <!-- Hinge at back -->
+  <rect x="50" y="2" width="8" height="3" rx="1" fill="#888" stroke="#666" stroke-width="0.5"/>
+  <rect x="20" y="2" width="8" height="3" rx="1" fill="#888" stroke="#666" stroke-width="0.5"/>
+  <rect x="90" y="2" width="8" height="3" rx="1" fill="#888" stroke="#666" stroke-width="0.5"/>
+</svg>

--- a/src/open_garden_planner/resources/objects/infrastructure/compost_bin.svg
+++ b/src/open_garden_planner/resources/objects/infrastructure/compost_bin.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <!-- Compost Bin - top-down view -->
+  <!-- Shadow -->
+  <rect x="6" y="6" width="92" height="92" rx="4" fill="#00000020"/>
+  <!-- Outer wood slat walls -->
+  <rect x="2" y="2" width="92" height="92" rx="4" fill="#6B4A28" stroke="#4A3218" stroke-width="2"/>
+  <!-- Horizontal wood slat lines -->
+  <line x1="2" y1="20" x2="94" y2="20" stroke="#5A3E20" stroke-width="1" opacity="0.5"/>
+  <line x1="2" y1="38" x2="94" y2="38" stroke="#5A3E20" stroke-width="1" opacity="0.5"/>
+  <line x1="2" y1="56" x2="94" y2="56" stroke="#5A3E20" stroke-width="1" opacity="0.5"/>
+  <line x1="2" y1="74" x2="94" y2="74" stroke="#5A3E20" stroke-width="1" opacity="0.5"/>
+  <!-- Interior compost material visible from top -->
+  <rect x="8" y="8" width="80" height="80" rx="2" fill="#5C4020"/>
+  <!-- Compost texture - organic debris -->
+  <circle cx="25" cy="25" r="4" fill="#4A6020" opacity="0.5"/>
+  <circle cx="55" cy="20" r="3" fill="#6A5530" opacity="0.4"/>
+  <circle cx="40" cy="45" r="5" fill="#4A6020" opacity="0.4"/>
+  <circle cx="70" cy="40" r="3" fill="#785028" opacity="0.5"/>
+  <circle cx="30" cy="65" r="4" fill="#6A5530" opacity="0.4"/>
+  <circle cx="60" cy="70" r="3" fill="#4A6020" opacity="0.5"/>
+  <circle cx="75" cy="60" r="4" fill="#785028" opacity="0.4"/>
+  <!-- Small leaf/twig details -->
+  <ellipse cx="20" cy="50" rx="5" ry="2" fill="#5A7030" opacity="0.3" transform="rotate(30 20 50)"/>
+  <ellipse cx="65" cy="55" rx="4" ry="2" fill="#5A7030" opacity="0.3" transform="rotate(-20 65 55)"/>
+  <ellipse cx="45" cy="75" rx="5" ry="2" fill="#5A7030" opacity="0.3" transform="rotate(45 45 75)"/>
+</svg>

--- a/src/open_garden_planner/resources/objects/infrastructure/rain_barrel.svg
+++ b/src/open_garden_planner/resources/objects/infrastructure/rain_barrel.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 60 60">
+  <!-- Rain Barrel - top-down view (circular) -->
+  <!-- Shadow -->
+  <ellipse cx="33" cy="33" rx="26" ry="26" fill="#00000020"/>
+  <!-- Barrel body (outer) -->
+  <circle cx="30" cy="30" r="26" fill="#3A6A3A" stroke="#2A4A2A" stroke-width="2"/>
+  <!-- Barrel rim -->
+  <circle cx="30" cy="30" r="23" fill="none" stroke="#2E5530" stroke-width="1.5"/>
+  <!-- Barrel lid -->
+  <circle cx="30" cy="30" r="21" fill="#3D7040" stroke="#2E5530" stroke-width="0.8"/>
+  <!-- Lid handle (centered bar) -->
+  <rect x="22" y="28" width="16" height="4" rx="2" fill="#555" stroke="#444" stroke-width="0.8"/>
+  <!-- Barrel top texture - concentric circles -->
+  <circle cx="30" cy="30" r="16" fill="none" stroke="#357035" stroke-width="0.5" opacity="0.5"/>
+  <circle cx="30" cy="30" r="10" fill="none" stroke="#357035" stroke-width="0.5" opacity="0.4"/>
+  <!-- Water inlet hole -->
+  <circle cx="42" cy="15" r="3" fill="#2A5A30" stroke="#1E4020" stroke-width="0.8"/>
+  <!-- Small rivet/bolt details -->
+  <circle cx="12" cy="18" r="1" fill="#2E5530"/>
+  <circle cx="48" cy="42" r="1" fill="#2E5530"/>
+  <circle cx="18" cy="46" r="1" fill="#2E5530"/>
+  <circle cx="42" cy="18" r="1" fill="#2E5530"/>
+</svg>

--- a/src/open_garden_planner/resources/objects/infrastructure/raised_bed.svg
+++ b/src/open_garden_planner/resources/objects/infrastructure/raised_bed.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 80">
+  <!-- Raised Bed - top-down view with wood frame and soil fill -->
+  <!-- Shadow -->
+  <rect x="5" y="5" width="115" height="75" rx="3" fill="#00000020"/>
+  <!-- Outer wood frame -->
+  <rect x="2" y="2" width="115" height="75" rx="3" fill="#8B6914" stroke="#5C4410" stroke-width="2"/>
+  <!-- Inner wood frame edge -->
+  <rect x="6" y="6" width="107" height="67" rx="2" fill="#A07828" stroke="#7A5A1E" stroke-width="1"/>
+  <!-- Soil interior -->
+  <rect x="10" y="10" width="99" height="59" rx="1" fill="#6B4226"/>
+  <!-- Soil texture - small dots and marks -->
+  <circle cx="20" cy="20" r="1.5" fill="#5A3520" opacity="0.6"/>
+  <circle cx="45" cy="15" r="1" fill="#7D5030" opacity="0.5"/>
+  <circle cx="70" cy="25" r="1.5" fill="#5A3520" opacity="0.6"/>
+  <circle cx="95" cy="18" r="1" fill="#7D5030" opacity="0.5"/>
+  <circle cx="30" cy="40" r="1.5" fill="#5A3520" opacity="0.6"/>
+  <circle cx="55" cy="45" r="1" fill="#7D5030" opacity="0.5"/>
+  <circle cx="80" cy="38" r="1.5" fill="#5A3520" opacity="0.6"/>
+  <circle cx="25" cy="58" r="1" fill="#7D5030" opacity="0.5"/>
+  <circle cx="60" cy="55" r="1.5" fill="#5A3520" opacity="0.6"/>
+  <circle cx="90" cy="52" r="1" fill="#7D5030" opacity="0.5"/>
+  <!-- Small plant seedling hints -->
+  <circle cx="35" cy="30" r="3" fill="#4A8030" opacity="0.4"/>
+  <circle cx="65" cy="35" r="2.5" fill="#4A8030" opacity="0.35"/>
+  <circle cx="85" cy="50" r="3" fill="#4A8030" opacity="0.4"/>
+  <!-- Wood grain lines on frame -->
+  <line x1="3" y1="15" x2="8" y2="15" stroke="#6E5010" stroke-width="0.5" opacity="0.4"/>
+  <line x1="3" y1="55" x2="8" y2="55" stroke="#6E5010" stroke-width="0.5" opacity="0.4"/>
+  <line x1="110" y1="25" x2="115" y2="25" stroke="#6E5010" stroke-width="0.5" opacity="0.4"/>
+  <line x1="110" y1="60" x2="115" y2="60" stroke="#6E5010" stroke-width="0.5" opacity="0.4"/>
+</svg>

--- a/src/open_garden_planner/resources/objects/infrastructure/tool_shed.svg
+++ b/src/open_garden_planner/resources/objects/infrastructure/tool_shed.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 150">
+  <!-- Tool Shed - top-down view -->
+  <!-- Shadow -->
+  <rect x="6" y="6" width="194" height="144" rx="3" fill="#00000020"/>
+  <!-- Roof (slightly larger than walls, visible from above) -->
+  <rect x="2" y="2" width="194" height="144" rx="3" fill="#8B7355" stroke="#6B5535" stroke-width="2.5"/>
+  <!-- Roof ridge line -->
+  <line x1="100" y1="5" x2="100" y2="143" stroke="#7A6348" stroke-width="2"/>
+  <!-- Roof shingle/panel lines (left side) -->
+  <line x1="10" y1="25" x2="98" y2="25" stroke="#7E644A" stroke-width="0.8" opacity="0.4"/>
+  <line x1="10" y1="50" x2="98" y2="50" stroke="#7E644A" stroke-width="0.8" opacity="0.4"/>
+  <line x1="10" y1="75" x2="98" y2="75" stroke="#7E644A" stroke-width="0.8" opacity="0.4"/>
+  <line x1="10" y1="100" x2="98" y2="100" stroke="#7E644A" stroke-width="0.8" opacity="0.4"/>
+  <line x1="10" y1="125" x2="98" y2="125" stroke="#7E644A" stroke-width="0.8" opacity="0.4"/>
+  <!-- Roof shingle/panel lines (right side) -->
+  <line x1="102" y1="25" x2="190" y2="25" stroke="#7E644A" stroke-width="0.8" opacity="0.4"/>
+  <line x1="102" y1="50" x2="190" y2="50" stroke="#7E644A" stroke-width="0.8" opacity="0.4"/>
+  <line x1="102" y1="75" x2="190" y2="75" stroke="#7E644A" stroke-width="0.8" opacity="0.4"/>
+  <line x1="102" y1="100" x2="190" y2="100" stroke="#7E644A" stroke-width="0.8" opacity="0.4"/>
+  <line x1="102" y1="125" x2="190" y2="125" stroke="#7E644A" stroke-width="0.8" opacity="0.4"/>
+  <!-- Door visible on one side (front wall) -->
+  <rect x="80" y="138" width="40" height="8" rx="1" fill="#6B5535" stroke="#4A3A22" stroke-width="1"/>
+  <!-- Door handle -->
+  <circle cx="112" cy="142" r="2" fill="#AAA" stroke="#888" stroke-width="0.5"/>
+  <!-- Window (visible as small rectangle on roof side) -->
+  <rect x="30" y="60" width="20" height="15" rx="1" fill="#A0C0D8" fill-opacity="0.5" stroke="#808A94" stroke-width="0.8"/>
+  <line x1="40" y1="60" x2="40" y2="75" stroke="#808A94" stroke-width="0.5"/>
+  <line x1="30" y1="67" x2="50" y2="67" stroke="#808A94" stroke-width="0.5"/>
+</svg>

--- a/src/open_garden_planner/resources/objects/infrastructure/water_tap.svg
+++ b/src/open_garden_planner/resources/objects/infrastructure/water_tap.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30 30">
+  <!-- Water Tap / Spigot - top-down view (small fixture) -->
+  <!-- Shadow -->
+  <ellipse cx="17" cy="17" rx="12" ry="12" fill="#00000018"/>
+  <!-- Base plate (circular mounting plate) -->
+  <circle cx="15" cy="15" r="12" fill="#A0AAB4" stroke="#707A84" stroke-width="1.5"/>
+  <!-- Inner mounting ring -->
+  <circle cx="15" cy="15" r="8" fill="#B0BAC4" stroke="#808A94" stroke-width="1"/>
+  <!-- Pipe center -->
+  <circle cx="15" cy="15" r="4" fill="#808A94" stroke="#606A74" stroke-width="1"/>
+  <circle cx="15" cy="15" r="2" fill="#606A74"/>
+  <!-- Handle (cross-shaped valve) -->
+  <rect x="13" y="4" width="4" height="22" rx="1.5" fill="#6080A0" stroke="#405060" stroke-width="0.8"/>
+  <rect x="4" y="13" width="22" height="4" rx="1.5" fill="#6080A0" stroke="#405060" stroke-width="0.8"/>
+  <!-- Center bolt -->
+  <circle cx="15" cy="15" r="2.5" fill="#505A64" stroke="#404A54" stroke-width="0.5"/>
+  <!-- Water droplet hint -->
+  <circle cx="22" cy="22" r="1.5" fill="#4A90D0" opacity="0.5"/>
+</svg>

--- a/src/open_garden_planner/ui/canvas/canvas_view.py
+++ b/src/open_garden_planner/ui/canvas/canvas_view.py
@@ -253,6 +253,29 @@ class CanvasView(QGraphicsView):
             tool.display_name = display_name
             self._tool_manager.register_tool(tool)
 
+        # Register garden infrastructure tools (SVG-rendered)
+        rect_infrastructure = [
+            (ObjectType.RAISED_BED, ToolType.RAISED_BED, "Raised Bed"),
+            (ObjectType.COMPOST_BIN, ToolType.COMPOST_BIN, "Compost Bin"),
+            (ObjectType.COLD_FRAME, ToolType.COLD_FRAME, "Cold Frame"),
+            (ObjectType.TOOL_SHED, ToolType.TOOL_SHED, "Tool Shed"),
+        ]
+        for obj_type, tool_type, display_name in rect_infrastructure:
+            tool = RectangleTool(self, object_type=obj_type)
+            tool.tool_type = tool_type
+            tool.display_name = display_name
+            self._tool_manager.register_tool(tool)
+
+        circle_infrastructure = [
+            (ObjectType.RAIN_BARREL, ToolType.RAIN_BARREL, "Rain Barrel"),
+            (ObjectType.WATER_TAP, ToolType.WATER_TAP, "Water Tap"),
+        ]
+        for obj_type, tool_type, display_name in circle_infrastructure:
+            tool = CircleTool(self, object_type=obj_type)
+            tool.tool_type = tool_type
+            tool.display_name = display_name
+            self._tool_manager.register_tool(tool)
+
         # Connect tool change signal
         self._tool_manager.tool_changed.connect(self.tool_changed.emit)
 

--- a/src/open_garden_planner/ui/panels/gallery_panel.py
+++ b/src/open_garden_planner/ui/panels/gallery_panel.py
@@ -27,7 +27,12 @@ from PyQt6.QtWidgets import (
 )
 
 from open_garden_planner.core.fill_patterns import _TEXTURES_DIR, FillPattern
-from open_garden_planner.core.furniture_renderer import _FURNITURE_DIR, _FURNITURE_FILES
+from open_garden_planner.core.furniture_renderer import (
+    _FURNITURE_DIR,
+    _FURNITURE_FILES,
+    _INFRASTRUCTURE_DIR,
+    _INFRASTRUCTURE_FILES,
+)
 from open_garden_planner.core.object_types import OBJECT_STYLES, ObjectType
 from open_garden_planner.core.plant_renderer import (
     _CATEGORIES_DIR,
@@ -432,6 +437,28 @@ def _build_gallery_categories() -> list[GalleryCategory]:
             GalleryItem(name=name, tool_type=tool, object_type=obj, thumbnail=thumb)
         )
     categories.append(GalleryCategory("Gardening", gardening_items))
+
+    # --- Garden Infrastructure ---
+    infra_items: list[GalleryItem] = []
+    infra_objects = [
+        ("Raised Bed", ToolType.RAISED_BED, ObjectType.RAISED_BED),
+        ("Compost Bin", ToolType.COMPOST_BIN, ObjectType.COMPOST_BIN),
+        ("Cold Frame", ToolType.COLD_FRAME, ObjectType.COLD_FRAME),
+        ("Rain Barrel", ToolType.RAIN_BARREL, ObjectType.RAIN_BARREL),
+        ("Water Tap", ToolType.WATER_TAP, ObjectType.WATER_TAP),
+        ("Tool Shed", ToolType.TOOL_SHED, ObjectType.TOOL_SHED),
+    ]
+    for name, tool, obj in infra_objects:
+        svg_filename = _INFRASTRUCTURE_FILES.get(obj, "")
+        svg_path = _INFRASTRUCTURE_DIR / f"{svg_filename}.svg"
+        thumb = _render_svg_thumbnail(svg_path)
+        if thumb is None:
+            style = OBJECT_STYLES[obj]
+            thumb = _render_color_circle_thumbnail(style.fill_color)
+        infra_items.append(
+            GalleryItem(name=name, tool_type=tool, object_type=obj, thumbnail=thumb)
+        )
+    categories.append(GalleryCategory("Garden Infrastructure", infra_items))
 
     # --- Paths & Surfaces ---
     surface_items: list[GalleryItem] = []

--- a/tests/unit/test_infrastructure_renderer.py
+++ b/tests/unit/test_infrastructure_renderer.py
@@ -1,0 +1,139 @@
+"""Unit tests for garden infrastructure SVG rendering (US-6.9)."""
+
+from pathlib import Path
+
+import pytest
+from PyQt6.QtGui import QPixmap
+
+from open_garden_planner.core.furniture_renderer import (
+    FURNITURE_DEFAULT_DIMENSIONS,
+    _INFRASTRUCTURE_DIR,
+    _INFRASTRUCTURE_FILES,
+    clear_furniture_cache,
+    get_default_dimensions,
+    get_furniture_svg_path,
+    is_furniture_type,
+    render_furniture_pixmap,
+)
+from open_garden_planner.core.object_types import ObjectType
+
+
+INFRASTRUCTURE_TYPES = [
+    ObjectType.RAISED_BED,
+    ObjectType.COMPOST_BIN,
+    ObjectType.COLD_FRAME,
+    ObjectType.RAIN_BARREL,
+    ObjectType.WATER_TAP,
+    ObjectType.TOOL_SHED,
+]
+
+
+class TestIsInfrastructureType:
+    """Tests for is_furniture_type detecting infrastructure objects."""
+
+    @pytest.mark.parametrize("obj_type", INFRASTRUCTURE_TYPES)
+    def test_infrastructure_types_detected(self, qtbot: object, obj_type: ObjectType) -> None:  # noqa: ARG002
+        assert is_furniture_type(obj_type) is True
+
+    def test_house_is_not_infrastructure(self, qtbot: object) -> None:  # noqa: ARG002
+        assert is_furniture_type(ObjectType.HOUSE) is False
+
+    def test_generic_rect_is_not_infrastructure(self, qtbot: object) -> None:  # noqa: ARG002
+        assert is_furniture_type(ObjectType.GENERIC_RECTANGLE) is False
+
+
+class TestInfrastructureSVGFiles:
+    """Tests for infrastructure SVG file existence."""
+
+    @pytest.mark.parametrize("obj_type", INFRASTRUCTURE_TYPES)
+    def test_svg_file_exists(self, obj_type: ObjectType) -> None:
+        filename = _INFRASTRUCTURE_FILES[obj_type]
+        path = _INFRASTRUCTURE_DIR / f"{filename}.svg"
+        assert path.exists(), f"Infrastructure SVG missing: {filename}.svg"
+        assert path.is_file()
+        assert path.stat().st_size > 0
+
+    @pytest.mark.parametrize("obj_type", INFRASTRUCTURE_TYPES)
+    def test_svg_has_valid_header(self, obj_type: ObjectType) -> None:
+        filename = _INFRASTRUCTURE_FILES[obj_type]
+        path = _INFRASTRUCTURE_DIR / f"{filename}.svg"
+        content = path.read_text(encoding="utf-8")
+        assert "<svg" in content, f"{filename}.svg is not valid SVG"
+        assert "</svg>" in content
+
+    def test_six_infrastructure_files_mapped(self, qtbot: object) -> None:  # noqa: ARG002
+        assert len(_INFRASTRUCTURE_FILES) == 6
+
+
+class TestGetInfrastructureSvgPath:
+    """Tests for SVG path resolution."""
+
+    @pytest.mark.parametrize("obj_type", INFRASTRUCTURE_TYPES)
+    def test_infrastructure_type_resolves(self, qtbot: object, obj_type: ObjectType) -> None:  # noqa: ARG002
+        path = get_furniture_svg_path(obj_type)
+        assert path is not None
+        assert path.exists()
+
+    @pytest.mark.parametrize("obj_type", INFRASTRUCTURE_TYPES)
+    def test_infrastructure_svg_in_infrastructure_dir(self, qtbot: object, obj_type: ObjectType) -> None:  # noqa: ARG002
+        path = get_furniture_svg_path(obj_type)
+        assert path is not None
+        assert "infrastructure" in str(path)
+
+
+class TestRenderInfrastructurePixmap:
+    """Tests for SVG to QPixmap rendering."""
+
+    @pytest.fixture(autouse=True)
+    def clear_caches(self) -> None:
+        clear_furniture_cache()
+        yield  # type: ignore[misc]
+        clear_furniture_cache()
+
+    @pytest.mark.parametrize("obj_type", INFRASTRUCTURE_TYPES)
+    def test_render_returns_pixmap(self, qtbot: object, obj_type: ObjectType) -> None:  # noqa: ARG002
+        w, h = FURNITURE_DEFAULT_DIMENSIONS[obj_type]
+        pixmap = render_furniture_pixmap(obj_type, width=w, height=h)
+        assert pixmap is not None
+        assert isinstance(pixmap, QPixmap)
+        assert not pixmap.isNull()
+
+    def test_render_raised_bed_default_size(self, qtbot: object) -> None:  # noqa: ARG002
+        pixmap = render_furniture_pixmap(ObjectType.RAISED_BED, width=120, height=80)
+        assert pixmap is not None
+        assert not pixmap.isNull()
+
+    def test_caching_returns_same_pixmap(self, qtbot: object) -> None:  # noqa: ARG002
+        p1 = render_furniture_pixmap(ObjectType.RAISED_BED, width=120, height=80)
+        p2 = render_furniture_pixmap(ObjectType.RAISED_BED, width=120, height=80)
+        assert p1 is p2  # Same object from cache
+
+
+class TestInfrastructureDefaultDimensions:
+    """Tests for default infrastructure dimensions."""
+
+    @pytest.mark.parametrize("obj_type", INFRASTRUCTURE_TYPES)
+    def test_all_types_have_defaults(self, qtbot: object, obj_type: ObjectType) -> None:  # noqa: ARG002
+        w, h = get_default_dimensions(obj_type)
+        assert w > 0
+        assert h > 0
+
+    def test_raised_bed_dimensions(self, qtbot: object) -> None:  # noqa: ARG002
+        w, h = get_default_dimensions(ObjectType.RAISED_BED)
+        assert w == 120.0
+        assert h == 80.0
+
+    def test_tool_shed_dimensions(self, qtbot: object) -> None:  # noqa: ARG002
+        w, h = get_default_dimensions(ObjectType.TOOL_SHED)
+        assert w == 200.0
+        assert h == 150.0
+
+    def test_water_tap_small(self, qtbot: object) -> None:  # noqa: ARG002
+        w, h = get_default_dimensions(ObjectType.WATER_TAP)
+        assert w == 20.0
+        assert h == 20.0
+
+    def test_rain_barrel_dimensions(self, qtbot: object) -> None:  # noqa: ARG002
+        w, h = get_default_dimensions(ObjectType.RAIN_BARREL)
+        assert w == 60.0
+        assert h == 60.0


### PR DESCRIPTION
## Summary
      - Add 6 garden infrastructure objects: raised bed, compost bin, cold frame, rain barrel, water tap, tool shed
      - Each object has an illustrated top-down SVG asset with realistic default dimensions
      - New Garden Infrastructure category in gallery sidebar with thumbnails
      - 51 new unit tests

## Test plan
- [x] All 840 tests pass
- [x] Ruff lint clean
- [x] Manual testing verified

Generated with [Claude Code](https://claude.com/claude-code)")