### PR TITLE
feat(US-6.10): Add object snapping & alignment tools

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -190,7 +190,7 @@ tests/
 | ✅ | 6.7  | Branded green theme (light/dark)                  |
 | ✅ | 6.8  | Outdoor furniture objects                         |
 | ✅ | 6.9  | Garden infrastructure objects                     |
-|        | 6.10 | Object snapping & alignment tools                 |
+| ✅ | 6.10 | Object snapping & alignment tools                 |
 | ✅ | 6.11 | Fullscreen preview mode (F11)                     |
 |        | 6.12 | Internationalization (EN + DE, Qt Linguist)       |
 |        | 6.13 | Print support with scaling                        |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -135,7 +135,7 @@
 | US-6.7 | Branded green theme (light/dark variants) | Should | ✅ Done |
 | US-6.8 | Outdoor furniture objects | Must | ✅ Done |
 | US-6.9 | Garden infrastructure objects | Must | ✅ Done |
-| US-6.10 | Object snapping & alignment tools | Should | |
+| US-6.10 | Object snapping & alignment tools | Should | ✅ Done |
 | US-6.11 | Fullscreen preview mode (F11) | Should | ✅ Done |
 | US-6.12 | Internationalization (EN + DE, Qt Linguist) | Must | |
 | US-6.13 | Print support with scaling | Should | |

--- a/src/open_garden_planner/app/application.py
+++ b/src/open_garden_planner/app/application.py
@@ -243,6 +243,53 @@ class GardenPlannerApp(QMainWindow):
 
         menu.addSeparator()
 
+        # Align submenu
+        align_menu = menu.addMenu("Ali&gn && Distribute")
+
+        align_left = QAction("Align &Left", self)
+        align_left.setStatusTip("Align selected objects to the left edge")
+        align_left.triggered.connect(self._on_align_left)
+        align_menu.addAction(align_left)
+
+        align_right = QAction("Align &Right", self)
+        align_right.setStatusTip("Align selected objects to the right edge")
+        align_right.triggered.connect(self._on_align_right)
+        align_menu.addAction(align_right)
+
+        align_top = QAction("Align &Top", self)
+        align_top.setStatusTip("Align selected objects to the top edge")
+        align_top.triggered.connect(self._on_align_top)
+        align_menu.addAction(align_top)
+
+        align_bottom = QAction("Align &Bottom", self)
+        align_bottom.setStatusTip("Align selected objects to the bottom edge")
+        align_bottom.triggered.connect(self._on_align_bottom)
+        align_menu.addAction(align_bottom)
+
+        align_center_h = QAction("Align Center &Horizontally", self)
+        align_center_h.setStatusTip("Align selected objects to horizontal center")
+        align_center_h.triggered.connect(self._on_align_center_h)
+        align_menu.addAction(align_center_h)
+
+        align_center_v = QAction("Align Center &Vertically", self)
+        align_center_v.setStatusTip("Align selected objects to vertical center")
+        align_center_v.triggered.connect(self._on_align_center_v)
+        align_menu.addAction(align_center_v)
+
+        align_menu.addSeparator()
+
+        dist_h = QAction("Distribute &Horizontal", self)
+        dist_h.setStatusTip("Distribute selected objects with equal horizontal spacing")
+        dist_h.triggered.connect(self._on_distribute_horizontal)
+        align_menu.addAction(dist_h)
+
+        dist_v = QAction("Distribute &Vertical", self)
+        dist_v.setStatusTip("Distribute selected objects with equal vertical spacing")
+        dist_v.triggered.connect(self._on_distribute_vertical)
+        align_menu.addAction(dist_v)
+
+        menu.addSeparator()
+
         # Auto-Save submenu
         autosave_menu = menu.addMenu("Auto-&Save")
 
@@ -310,6 +357,15 @@ class GardenPlannerApp(QMainWindow):
         self.snap_action.setChecked(True)
         self.snap_action.setStatusTip("Toggle snap to grid")
         menu.addAction(self.snap_action)
+
+        # Toggle Object Snap
+        self._object_snap_action = QAction("Snap to &Objects", self)
+        self._object_snap_action.setShortcut(QKeySequence("O"))
+        self._object_snap_action.setCheckable(True)
+        self._object_snap_action.setChecked(True)
+        self._object_snap_action.setStatusTip("Toggle snap to object edges and centers")
+        self._object_snap_action.triggered.connect(self._on_toggle_object_snap)
+        menu.addAction(self._object_snap_action)
 
         menu.addSeparator()
 
@@ -510,10 +566,11 @@ class GardenPlannerApp(QMainWindow):
         # Initial selection display
         self.update_selection(0, [])
 
-        # Initialize shadow, scale bar, and labels state from settings
+        # Initialize shadow, scale bar, labels, and object snap state from settings
         QTimer.singleShot(0, self._init_shadows_from_settings)
         QTimer.singleShot(0, self._init_scale_bar_from_settings)
         QTimer.singleShot(0, self._init_labels_from_settings)
+        QTimer.singleShot(0, self._init_object_snap_from_settings)
 
     def _setup_sidebar(self) -> None:
         """Set up the right sidebar with collapsible panels."""
@@ -1229,6 +1286,14 @@ class GardenPlannerApp(QMainWindow):
         self.canvas_scene.set_labels_visible(checked)
         get_settings().show_labels = checked
 
+    def _init_object_snap_from_settings(self) -> None:
+        """Initialize object snap state from persisted settings."""
+        from open_garden_planner.app.settings import get_settings
+
+        enabled = get_settings().object_snap_enabled
+        self._object_snap_action.setChecked(enabled)
+        self.canvas_view.set_object_snap_enabled(enabled)
+
     def _on_toggle_preview_mode(self, checked: bool) -> None:
         """Handle toggle preview mode action."""
         if checked:
@@ -1327,6 +1392,53 @@ class GardenPlannerApp(QMainWindow):
     def _on_toggle_snap(self, checked: bool) -> None:
         """Handle toggle snap action."""
         self.canvas_view.set_snap_enabled(checked)
+
+    def _on_toggle_object_snap(self, checked: bool) -> None:
+        """Handle toggle object snap action."""
+        from open_garden_planner.app.settings import get_settings
+
+        self.canvas_view.set_object_snap_enabled(checked)
+        get_settings().object_snap_enabled = checked
+
+    def _on_align_left(self) -> None:
+        """Align selected objects to the left edge."""
+        from open_garden_planner.core.alignment import AlignMode
+        self.canvas_view.align_selected(AlignMode.LEFT)
+
+    def _on_align_right(self) -> None:
+        """Align selected objects to the right edge."""
+        from open_garden_planner.core.alignment import AlignMode
+        self.canvas_view.align_selected(AlignMode.RIGHT)
+
+    def _on_align_top(self) -> None:
+        """Align selected objects to the top edge."""
+        from open_garden_planner.core.alignment import AlignMode
+        self.canvas_view.align_selected(AlignMode.TOP)
+
+    def _on_align_bottom(self) -> None:
+        """Align selected objects to the bottom edge."""
+        from open_garden_planner.core.alignment import AlignMode
+        self.canvas_view.align_selected(AlignMode.BOTTOM)
+
+    def _on_align_center_h(self) -> None:
+        """Align selected objects to horizontal center."""
+        from open_garden_planner.core.alignment import AlignMode
+        self.canvas_view.align_selected(AlignMode.CENTER_H)
+
+    def _on_align_center_v(self) -> None:
+        """Align selected objects to vertical center."""
+        from open_garden_planner.core.alignment import AlignMode
+        self.canvas_view.align_selected(AlignMode.CENTER_V)
+
+    def _on_distribute_horizontal(self) -> None:
+        """Distribute selected objects with equal horizontal spacing."""
+        from open_garden_planner.core.alignment import DistributeMode
+        self.canvas_view.distribute_selected(DistributeMode.HORIZONTAL)
+
+    def _on_distribute_vertical(self) -> None:
+        """Distribute selected objects with equal vertical spacing."""
+        from open_garden_planner.core.alignment import DistributeMode
+        self.canvas_view.distribute_selected(DistributeMode.VERTICAL)
 
     def _on_zoom_in(self) -> None:
         """Handle zoom in action."""

--- a/src/open_garden_planner/app/settings.py
+++ b/src/open_garden_planner/app/settings.py
@@ -28,6 +28,7 @@ class AppSettings:
     KEY_SHOW_SHADOWS = "appearance/show_shadows"
     KEY_SHOW_SCALE_BAR = "appearance/show_scale_bar"
     KEY_SHOW_LABELS = "appearance/show_labels"
+    KEY_OBJECT_SNAP = "canvas/object_snap_enabled"
 
     # Default values
     DEFAULT_AUTOSAVE_ENABLED = True
@@ -35,6 +36,7 @@ class AppSettings:
     DEFAULT_SHOW_SHADOWS = True
     DEFAULT_SHOW_SCALE_BAR = True
     DEFAULT_SHOW_LABELS = True
+    DEFAULT_OBJECT_SNAP = True
     DEFAULT_AUTOSAVE_INTERVAL_MINUTES = 5
     MIN_AUTOSAVE_INTERVAL_MINUTES = 1
     MAX_AUTOSAVE_INTERVAL_MINUTES = 30
@@ -216,6 +218,20 @@ class AppSettings:
     def show_labels(self, show: bool) -> None:
         """Set whether to show object labels on the canvas."""
         self._settings.setValue(self.KEY_SHOW_LABELS, show)
+
+    @property
+    def object_snap_enabled(self) -> bool:
+        """Whether snap-to-object is enabled."""
+        return self._settings.value(
+            self.KEY_OBJECT_SNAP,
+            self.DEFAULT_OBJECT_SNAP,
+            type=bool,
+        )
+
+    @object_snap_enabled.setter
+    def object_snap_enabled(self, enabled: bool) -> None:
+        """Set whether snap-to-object is enabled."""
+        self._settings.setValue(self.KEY_OBJECT_SNAP, enabled)
 
     def sync(self) -> None:
         """Force settings to be written to storage."""

--- a/src/open_garden_planner/core/__init__.py
+++ b/src/open_garden_planner/core/__init__.py
@@ -1,6 +1,7 @@
 """Core business logic and document management."""
 
 from open_garden_planner.core.commands import (
+    AlignItemsCommand,
     Command,
     CommandManager,
     CreateItemCommand,
@@ -19,6 +20,7 @@ from open_garden_planner.core.project import (
 )
 
 __all__ = [
+    "AlignItemsCommand",
     "Command",
     "CommandManager",
     "CreateItemCommand",

--- a/src/open_garden_planner/core/alignment.py
+++ b/src/open_garden_planner/core/alignment.py
@@ -1,0 +1,164 @@
+"""Alignment and distribution tools for multi-selected objects.
+
+Provides functions to compute per-item movement deltas for alignment
+(left, right, top, bottom, center H, center V) and distribution
+(equal horizontal/vertical spacing).
+"""
+
+from __future__ import annotations
+
+from enum import Enum, auto
+
+from PyQt6.QtCore import QPointF
+from PyQt6.QtWidgets import QGraphicsItem
+
+
+class AlignMode(Enum):
+    """Alignment modes for multi-selection."""
+
+    LEFT = auto()
+    RIGHT = auto()
+    TOP = auto()
+    BOTTOM = auto()
+    CENTER_H = auto()
+    CENTER_V = auto()
+
+
+class DistributeMode(Enum):
+    """Distribution modes for multi-selection."""
+
+    HORIZONTAL = auto()
+    VERTICAL = auto()
+
+
+def align_items(
+    items: list[QGraphicsItem],
+    mode: AlignMode,
+) -> list[tuple[QGraphicsItem, QPointF]]:
+    """Compute per-item movement deltas for alignment.
+
+    The alignment reference is the bounding box of the entire selection.
+    For example, LEFT aligns all items to the leftmost edge of the selection.
+
+    Args:
+        items: The items to align (must have 2+ items for meaningful result).
+        mode: The alignment mode.
+
+    Returns:
+        List of (item, delta) tuples where delta is the QPointF movement.
+        Items that don't need to move have delta (0, 0).
+    """
+    if len(items) < 2:
+        return []
+
+    rects = [(item, item.sceneBoundingRect()) for item in items]
+    result: list[tuple[QGraphicsItem, QPointF]] = []
+
+    if mode == AlignMode.LEFT:
+        target = min(r.left() for _, r in rects)
+        for item, rect in rects:
+            dx = target - rect.left()
+            result.append((item, QPointF(dx, 0)))
+
+    elif mode == AlignMode.RIGHT:
+        target = max(r.right() for _, r in rects)
+        for item, rect in rects:
+            dx = target - rect.right()
+            result.append((item, QPointF(dx, 0)))
+
+    elif mode == AlignMode.TOP:
+        target = min(r.top() for _, r in rects)
+        for item, rect in rects:
+            dy = target - rect.top()
+            result.append((item, QPointF(0, dy)))
+
+    elif mode == AlignMode.BOTTOM:
+        target = max(r.bottom() for _, r in rects)
+        for item, rect in rects:
+            dy = target - rect.bottom()
+            result.append((item, QPointF(0, dy)))
+
+    elif mode == AlignMode.CENTER_H:
+        # Align to the horizontal center of the bounding box
+        all_left = min(r.left() for _, r in rects)
+        all_right = max(r.right() for _, r in rects)
+        target = (all_left + all_right) / 2.0
+        for item, rect in rects:
+            dx = target - rect.center().x()
+            result.append((item, QPointF(dx, 0)))
+
+    elif mode == AlignMode.CENTER_V:
+        # Align to the vertical center of the bounding box
+        all_top = min(r.top() for _, r in rects)
+        all_bottom = max(r.bottom() for _, r in rects)
+        target = (all_top + all_bottom) / 2.0
+        for item, rect in rects:
+            dy = target - rect.center().y()
+            result.append((item, QPointF(0, dy)))
+
+    return result
+
+
+def distribute_items(
+    items: list[QGraphicsItem],
+    mode: DistributeMode,
+) -> list[tuple[QGraphicsItem, QPointF]]:
+    """Compute per-item movement deltas for equal-spacing distribution.
+
+    Items are distributed so that the space between them is equal.
+    The first and last items (by position) stay in place.
+
+    Args:
+        items: The items to distribute (must have 3+ items for meaningful result).
+        mode: The distribution mode (horizontal or vertical).
+
+    Returns:
+        List of (item, delta) tuples.
+    """
+    if len(items) < 3:
+        return []
+
+    rects = [(item, item.sceneBoundingRect()) for item in items]
+
+    if mode == DistributeMode.HORIZONTAL:
+        # Sort by horizontal center position
+        rects.sort(key=lambda pair: pair[1].center().x())
+
+        # Total extent from first center to last center
+        first_center = rects[0][1].center().x()
+        last_center = rects[-1][1].center().x()
+        total_span = last_center - first_center
+
+        if total_span == 0:
+            return [(item, QPointF(0, 0)) for item in items]
+
+        step = total_span / (len(rects) - 1)
+
+        result: list[tuple[QGraphicsItem, QPointF]] = []
+        for i, (item, rect) in enumerate(rects):
+            target_center = first_center + step * i
+            dx = target_center - rect.center().x()
+            result.append((item, QPointF(dx, 0)))
+
+        return result
+
+    else:  # VERTICAL
+        # Sort by vertical center position
+        rects.sort(key=lambda pair: pair[1].center().y())
+
+        first_center = rects[0][1].center().y()
+        last_center = rects[-1][1].center().y()
+        total_span = last_center - first_center
+
+        if total_span == 0:
+            return [(item, QPointF(0, 0)) for item in items]
+
+        step = total_span / (len(rects) - 1)
+
+        result = []
+        for i, (item, rect) in enumerate(rects):
+            target_center = first_center + step * i
+            dy = target_center - rect.center().y()
+            result.append((item, QPointF(0, dy)))
+
+        return result

--- a/src/open_garden_planner/core/commands.py
+++ b/src/open_garden_planner/core/commands.py
@@ -478,6 +478,43 @@ class AddVertexCommand(Command):
         self._apply_remove_func(self._item, self._vertex_index)
 
 
+class AlignItemsCommand(Command):
+    """Command for aligning/distributing items with per-item deltas.
+
+    Unlike MoveItemsCommand (uniform delta), each item can move a different amount.
+    Used by alignment and distribution operations.
+    """
+
+    def __init__(
+        self,
+        item_deltas: list[tuple[QGraphicsItem, QPointF]],
+        description_text: str = "Align items",
+    ) -> None:
+        """Initialize the alignment command.
+
+        Args:
+            item_deltas: List of (item, delta) tuples.
+            description_text: Human-readable description for undo menu.
+        """
+        self._item_deltas = list(item_deltas)
+        self._description_text = description_text
+
+    @property
+    def description(self) -> str:
+        """Human-readable description."""
+        return self._description_text
+
+    def execute(self) -> None:
+        """Move each item by its individual delta."""
+        for item, delta in self._item_deltas:
+            item.moveBy(delta.x(), delta.y())
+
+    def undo(self) -> None:
+        """Move each item back by its individual delta."""
+        for item, delta in self._item_deltas:
+            item.moveBy(-delta.x(), -delta.y())
+
+
 class DeleteVertexCommand(Command):
     """Command for deleting a vertex from a polygon."""
 

--- a/src/open_garden_planner/core/snapping.py
+++ b/src/open_garden_planner/core/snapping.py
@@ -1,0 +1,176 @@
+"""Object snapping engine for snap-to-object alignment.
+
+Detects nearby object edges and centers during drag operations,
+returning snap positions and visual guide line data.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from PyQt6.QtCore import QPointF, QRectF
+from PyQt6.QtWidgets import QGraphicsItem
+
+
+@dataclass
+class SnapGuide:
+    """A visual guide line to render during snapping."""
+
+    start: QPointF
+    end: QPointF
+    is_horizontal: bool
+
+
+@dataclass
+class SnapResult:
+    """Result of a snap operation."""
+
+    snapped_pos: QPointF
+    snapped_x: bool = False
+    snapped_y: bool = False
+    guides: list[SnapGuide] = field(default_factory=list)
+
+
+class ObjectSnapper:
+    """Computes snap-to-object positions during drag operations.
+
+    Collects edges and centers from all scene items (excluding dragged items)
+    and finds the nearest snap targets within a threshold.
+    """
+
+    def __init__(self, threshold: float = 10.0) -> None:
+        """Initialize the snapper.
+
+        Args:
+            threshold: Snap distance threshold in scene units (cm).
+        """
+        self._threshold = threshold
+
+    @property
+    def threshold(self) -> float:
+        """Current snap threshold in scene units."""
+        return self._threshold
+
+    @threshold.setter
+    def threshold(self, value: float) -> None:
+        """Set snap threshold."""
+        self._threshold = max(1.0, value)
+
+    @staticmethod
+    def _get_snap_values(item: QGraphicsItem) -> tuple[list[float], list[float]]:
+        """Extract horizontal and vertical snap values from an item.
+
+        Returns x-values (left, center, right) and y-values (top, center, bottom)
+        from the item's scene bounding rect.
+
+        Args:
+            item: A graphics item on the scene.
+
+        Returns:
+            Tuple of (x_values, y_values) in scene coordinates.
+        """
+        rect = item.sceneBoundingRect()
+        x_vals = [rect.left(), rect.center().x(), rect.right()]
+        y_vals = [rect.top(), rect.center().y(), rect.bottom()]
+        return x_vals, y_vals
+
+    def snap(
+        self,
+        dragged_rect: QRectF,
+        scene_items: list[QGraphicsItem],
+        exclude: set[QGraphicsItem] | None = None,
+        canvas_rect: QRectF | None = None,
+    ) -> SnapResult:
+        """Compute the snap offset for a dragged bounding rect.
+
+        Compares left/center/right and top/center/bottom of the dragged rect
+        against the same values of all other items, finding the closest match.
+
+        Args:
+            dragged_rect: The bounding rect of the dragged selection in scene coords.
+            scene_items: All items in the scene.
+            exclude: Items to exclude from snap targets (the dragged items).
+            canvas_rect: Optional canvas boundary rect for guide extent.
+
+        Returns:
+            SnapResult with the adjusted position and guide lines.
+        """
+        if exclude is None:
+            exclude = set()
+
+        # Collect snap x/y values from target items
+        target_x_values: list[float] = []
+        target_y_values: list[float] = []
+
+        for item in scene_items:
+            if item in exclude:
+                continue
+            # Skip items that aren't selectable (background images, etc.)
+            if not (item.flags() & QGraphicsItem.GraphicsItemFlag.ItemIsSelectable):
+                continue
+            x_vals, y_vals = self._get_snap_values(item)
+            target_x_values.extend(x_vals)
+            target_y_values.extend(y_vals)
+
+        # Snap x/y values from the dragged rect
+        drag_x_vals = [dragged_rect.left(), dragged_rect.center().x(), dragged_rect.right()]
+        drag_y_vals = [dragged_rect.top(), dragged_rect.center().y(), dragged_rect.bottom()]
+
+        # Find best X snap
+        best_dx: float | None = None
+        best_x_distance = self._threshold
+        snap_x_target: float | None = None
+
+        for dx in drag_x_vals:
+            for tx in target_x_values:
+                dist = abs(dx - tx)
+                if dist < best_x_distance:
+                    best_x_distance = dist
+                    best_dx = tx - dx
+                    snap_x_target = tx
+
+        # Find best Y snap
+        best_dy: float | None = None
+        best_y_distance = self._threshold
+        snap_y_target: float | None = None
+
+        for dy in drag_y_vals:
+            for ty in target_y_values:
+                dist = abs(dy - ty)
+                if dist < best_y_distance:
+                    best_y_distance = dist
+                    best_dy = ty - dy
+                    snap_y_target = ty
+
+        # Compute snapped position (offset from dragged_rect top-left)
+        dx_offset = best_dx if best_dx is not None else 0.0
+        dy_offset = best_dy if best_dy is not None else 0.0
+
+        snapped_pos = QPointF(dx_offset, dy_offset)
+
+        # Build guide lines
+        guides: list[SnapGuide] = []
+        extent = canvas_rect if canvas_rect else QRectF(0, 0, 10000, 10000)
+
+        if snap_x_target is not None:
+            # Vertical guide line at the snap x position
+            guides.append(SnapGuide(
+                start=QPointF(snap_x_target, extent.top()),
+                end=QPointF(snap_x_target, extent.bottom()),
+                is_horizontal=False,
+            ))
+
+        if snap_y_target is not None:
+            # Horizontal guide line at the snap y position
+            guides.append(SnapGuide(
+                start=QPointF(extent.left(), snap_y_target),
+                end=QPointF(extent.right(), snap_y_target),
+                is_horizontal=True,
+            ))
+
+        return SnapResult(
+            snapped_pos=snapped_pos,
+            snapped_x=best_dx is not None,
+            snapped_y=best_dy is not None,
+            guides=guides,
+        )

--- a/tests/unit/test_alignment.py
+++ b/tests/unit/test_alignment.py
@@ -1,0 +1,258 @@
+"""Tests for the alignment and distribution module."""
+
+import pytest
+from PyQt6.QtCore import QPointF
+from PyQt6.QtWidgets import QGraphicsRectItem, QGraphicsScene
+
+from open_garden_planner.core.alignment import (
+    AlignMode,
+    DistributeMode,
+    align_items,
+    distribute_items,
+)
+
+
+class TestAlignItems:
+    """Tests for the align_items function."""
+
+    @pytest.fixture
+    def scene(self, qtbot) -> QGraphicsScene:
+        """Create a scene so items have valid bounding rects."""
+        return QGraphicsScene()
+
+    def _make_rect(
+        self, scene: QGraphicsScene, x: float, y: float, w: float, h: float
+    ) -> QGraphicsRectItem:
+        """Create a rect item at the given position and add to scene."""
+        item = QGraphicsRectItem(0, 0, w, h)
+        item.setPos(x, y)
+        scene.addItem(item)
+        return item
+
+    def test_needs_at_least_2_items(self, scene) -> None:
+        """Test that align returns empty for less than 2 items."""
+        item = self._make_rect(scene, 0, 0, 50, 50)
+        result = align_items([item], AlignMode.LEFT)
+        assert result == []
+
+    def test_align_left(self, scene) -> None:
+        """Test aligning items to the left edge."""
+        item1 = self._make_rect(scene, 100, 0, 50, 50)
+        item2 = self._make_rect(scene, 200, 0, 50, 50)
+        item3 = self._make_rect(scene, 50, 0, 50, 50)
+
+        result = align_items([item1, item2, item3], AlignMode.LEFT)
+
+        # All items should align to x=50 (leftmost edge)
+        delta_map = {id(item): delta for item, delta in result}
+        assert abs(delta_map[id(item1)].x() - (-50)) < 0.01  # 100 -> 50
+        assert abs(delta_map[id(item2)].x() - (-150)) < 0.01  # 200 -> 50
+        assert abs(delta_map[id(item3)].x()) < 0.01  # Already at 50
+
+    def test_align_right(self, scene) -> None:
+        """Test aligning items to the right edge."""
+        item1 = self._make_rect(scene, 100, 0, 50, 50)  # Right edge at 150
+        item2 = self._make_rect(scene, 200, 0, 50, 50)  # Right edge at 250
+        item3 = self._make_rect(scene, 50, 0, 50, 50)   # Right edge at 100
+
+        result = align_items([item1, item2, item3], AlignMode.RIGHT)
+
+        # All items should align to right edge at 250
+        delta_map = {id(item): delta for item, delta in result}
+        assert abs(delta_map[id(item1)].x() - 100) < 0.01  # 150 -> 250
+        assert abs(delta_map[id(item2)].x()) < 0.01  # Already at 250
+        assert abs(delta_map[id(item3)].x() - 150) < 0.01  # 100 -> 250
+
+    def test_align_top(self, scene) -> None:
+        """Test aligning items to the top edge."""
+        item1 = self._make_rect(scene, 0, 100, 50, 50)
+        item2 = self._make_rect(scene, 0, 200, 50, 50)
+        item3 = self._make_rect(scene, 0, 50, 50, 50)
+
+        result = align_items([item1, item2, item3], AlignMode.TOP)
+
+        delta_map = {id(item): delta for item, delta in result}
+        assert abs(delta_map[id(item1)].y() - (-50)) < 0.01
+        assert abs(delta_map[id(item2)].y() - (-150)) < 0.01
+        assert abs(delta_map[id(item3)].y()) < 0.01
+
+    def test_align_bottom(self, scene) -> None:
+        """Test aligning items to the bottom edge."""
+        item1 = self._make_rect(scene, 0, 100, 50, 50)  # Bottom at 150
+        item2 = self._make_rect(scene, 0, 200, 50, 50)  # Bottom at 250
+        item3 = self._make_rect(scene, 0, 50, 50, 50)   # Bottom at 100
+
+        result = align_items([item1, item2, item3], AlignMode.BOTTOM)
+
+        delta_map = {id(item): delta for item, delta in result}
+        assert abs(delta_map[id(item1)].y() - 100) < 0.01
+        assert abs(delta_map[id(item2)].y()) < 0.01
+        assert abs(delta_map[id(item3)].y() - 150) < 0.01
+
+    def test_align_center_horizontal(self, scene) -> None:
+        """Test aligning items to horizontal center."""
+        item1 = self._make_rect(scene, 0, 0, 50, 50)     # Center at 25
+        item2 = self._make_rect(scene, 200, 0, 50, 50)   # Center at 225
+        # Bounding box: left=0, right=250. Center at 125.
+
+        result = align_items([item1, item2], AlignMode.CENTER_H)
+
+        delta_map = {id(item): delta for item, delta in result}
+        assert abs(delta_map[id(item1)].x() - 100) < 0.01  # 25 -> 125
+        assert abs(delta_map[id(item2)].x() - (-100)) < 0.01  # 225 -> 125
+
+    def test_align_center_vertical(self, scene) -> None:
+        """Test aligning items to vertical center."""
+        item1 = self._make_rect(scene, 0, 0, 50, 50)     # Center at 25
+        item2 = self._make_rect(scene, 0, 200, 50, 50)   # Center at 225
+        # Bounding box: top=0, bottom=250. Center at 125.
+
+        result = align_items([item1, item2], AlignMode.CENTER_V)
+
+        delta_map = {id(item): delta for item, delta in result}
+        assert abs(delta_map[id(item1)].y() - 100) < 0.01  # 25 -> 125
+        assert abs(delta_map[id(item2)].y() - (-100)) < 0.01  # 225 -> 125
+
+    def test_align_no_movement_needed(self, scene) -> None:
+        """Test align when items are already aligned."""
+        item1 = self._make_rect(scene, 100, 0, 50, 50)
+        item2 = self._make_rect(scene, 100, 100, 50, 50)
+
+        result = align_items([item1, item2], AlignMode.LEFT)
+
+        # Both already have left edge at 100
+        for _, delta in result:
+            assert abs(delta.x()) < 0.01
+            assert abs(delta.y()) < 0.01
+
+
+class TestDistributeItems:
+    """Tests for the distribute_items function."""
+
+    @pytest.fixture
+    def scene(self, qtbot) -> QGraphicsScene:
+        """Create a scene so items have valid bounding rects."""
+        return QGraphicsScene()
+
+    def _make_rect(
+        self, scene: QGraphicsScene, x: float, y: float, w: float, h: float
+    ) -> QGraphicsRectItem:
+        """Create a rect item at the given position and add to scene."""
+        item = QGraphicsRectItem(0, 0, w, h)
+        item.setPos(x, y)
+        scene.addItem(item)
+        return item
+
+    def test_needs_at_least_3_items(self, scene) -> None:
+        """Test that distribute returns empty for less than 3 items."""
+        item1 = self._make_rect(scene, 0, 0, 50, 50)
+        item2 = self._make_rect(scene, 100, 0, 50, 50)
+        result = distribute_items([item1, item2], DistributeMode.HORIZONTAL)
+        assert result == []
+
+    def test_distribute_horizontal(self, scene) -> None:
+        """Test horizontal distribution of 3 items."""
+        item1 = self._make_rect(scene, 0, 0, 50, 50)     # Center at 25
+        item2 = self._make_rect(scene, 50, 0, 50, 50)    # Center at 75
+        item3 = self._make_rect(scene, 200, 0, 50, 50)   # Center at 225
+
+        result = distribute_items([item1, item2, item3], DistributeMode.HORIZONTAL)
+
+        # After sorting by center: item1(25), item2(75), item3(225)
+        # Equal spacing: first=25, last=225, step=100
+        # item2 target center = 125, delta = 125 - 75 = 50
+        delta_map = {id(item): delta for item, delta in result}
+        assert abs(delta_map[id(item1)].x()) < 0.01  # First stays
+        assert abs(delta_map[id(item2)].x() - 50) < 0.01  # 75 -> 125
+        assert abs(delta_map[id(item3)].x()) < 0.01  # Last stays
+
+    def test_distribute_vertical(self, scene) -> None:
+        """Test vertical distribution of 3 items."""
+        item1 = self._make_rect(scene, 0, 0, 50, 50)     # Center at 25
+        item2 = self._make_rect(scene, 0, 50, 50, 50)    # Center at 75
+        item3 = self._make_rect(scene, 0, 200, 50, 50)   # Center at 225
+
+        result = distribute_items([item1, item2, item3], DistributeMode.VERTICAL)
+
+        delta_map = {id(item): delta for item, delta in result}
+        assert abs(delta_map[id(item1)].y()) < 0.01  # First stays
+        assert abs(delta_map[id(item2)].y() - 50) < 0.01  # 75 -> 125
+        assert abs(delta_map[id(item3)].y()) < 0.01  # Last stays
+
+    def test_distribute_already_even(self, scene) -> None:
+        """Test distribute when items are already evenly spaced."""
+        item1 = self._make_rect(scene, 0, 0, 50, 50)     # Center at 25
+        item2 = self._make_rect(scene, 100, 0, 50, 50)   # Center at 125
+        item3 = self._make_rect(scene, 200, 0, 50, 50)   # Center at 225
+
+        result = distribute_items([item1, item2, item3], DistributeMode.HORIZONTAL)
+
+        # Already equally spaced (step=100), no movement needed
+        for _, delta in result:
+            assert abs(delta.x()) < 0.01
+            assert abs(delta.y()) < 0.01
+
+    def test_distribute_4_items(self, scene) -> None:
+        """Test distribution of 4 items."""
+        item1 = self._make_rect(scene, 0, 0, 50, 50)     # Center at 25
+        item2 = self._make_rect(scene, 50, 0, 50, 50)    # Center at 75
+        item3 = self._make_rect(scene, 100, 0, 50, 50)   # Center at 125
+        item4 = self._make_rect(scene, 300, 0, 50, 50)   # Center at 325
+
+        result = distribute_items(
+            [item1, item2, item3, item4], DistributeMode.HORIZONTAL
+        )
+
+        # Sorted: item1(25), item2(75), item3(125), item4(325)
+        # Step = (325 - 25) / 3 = 100
+        # Targets: 25, 125, 225, 325
+        delta_map = {id(item): delta for item, delta in result}
+        assert abs(delta_map[id(item1)].x()) < 0.01      # 25 -> 25 (stays)
+        assert abs(delta_map[id(item2)].x() - 50) < 0.01  # 75 -> 125
+        assert abs(delta_map[id(item3)].x() - 100) < 0.01  # 125 -> 225
+        assert abs(delta_map[id(item4)].x()) < 0.01      # 325 -> 325 (stays)
+
+
+class TestAlignItemsCommand:
+    """Tests for the AlignItemsCommand class."""
+
+    def test_execute_moves_items(self, qtbot) -> None:
+        """Test that execute moves each item by its delta."""
+        from open_garden_planner.core.commands import AlignItemsCommand
+
+        item1 = QGraphicsRectItem(0, 0, 50, 50)
+        item1.setPos(0, 0)
+        item2 = QGraphicsRectItem(0, 0, 50, 50)
+        item2.setPos(100, 100)
+
+        deltas = [(item1, QPointF(10, 0)), (item2, QPointF(-20, 0))]
+        command = AlignItemsCommand(deltas, "Align left")
+        command.execute()
+
+        assert abs(item1.pos().x() - 10) < 0.01
+        assert abs(item2.pos().x() - 80) < 0.01
+
+    def test_undo_reverses_movement(self, qtbot) -> None:
+        """Test that undo reverses each item's movement."""
+        from open_garden_planner.core.commands import AlignItemsCommand
+
+        item1 = QGraphicsRectItem(0, 0, 50, 50)
+        item1.setPos(0, 0)
+        item2 = QGraphicsRectItem(0, 0, 50, 50)
+        item2.setPos(100, 100)
+
+        deltas = [(item1, QPointF(10, 0)), (item2, QPointF(-20, 0))]
+        command = AlignItemsCommand(deltas, "Align left")
+        command.execute()
+        command.undo()
+
+        assert abs(item1.pos().x()) < 0.01
+        assert abs(item2.pos().x() - 100) < 0.01
+
+    def test_description(self, qtbot) -> None:
+        """Test the description property."""
+        from open_garden_planner.core.commands import AlignItemsCommand
+
+        item = QGraphicsRectItem(0, 0, 50, 50)
+        command = AlignItemsCommand([(item, QPointF(0, 0))], "Align left")
+        assert command.description == "Align left"

--- a/tests/unit/test_canvas_boundary.py
+++ b/tests/unit/test_canvas_boundary.py
@@ -1,0 +1,106 @@
+"""Tests for canvas boundary enforcement during object movement."""
+
+import pytest
+from PyQt6.QtCore import QPointF
+from PyQt6.QtWidgets import QGraphicsRectItem
+
+from open_garden_planner.ui.canvas.canvas_scene import CanvasScene
+from open_garden_planner.ui.canvas.canvas_view import CanvasView
+
+
+class TestCanvasBoundaryClamping:
+    """Tests for _clamp_items_to_canvas and _clamp_delta_to_canvas."""
+
+    @pytest.fixture
+    def scene(self, qtbot) -> CanvasScene:
+        """Create a canvas scene."""
+        return CanvasScene(width_cm=1000, height_cm=1000)
+
+    @pytest.fixture
+    def view(self, qtbot, scene) -> CanvasView:
+        """Create a canvas view."""
+        return CanvasView(scene)
+
+    def _make_rect(
+        self, scene: CanvasScene, x: float, y: float, w: float, h: float
+    ) -> QGraphicsRectItem:
+        """Create a rect item at the given position and add to scene."""
+        item = QGraphicsRectItem(0, 0, w, h)
+        item.setPos(x, y)
+        item.setFlag(QGraphicsRectItem.GraphicsItemFlag.ItemIsMovable, True)
+        item.setFlag(QGraphicsRectItem.GraphicsItemFlag.ItemIsSelectable, True)
+        scene.addItem(item)
+        return item
+
+    def test_clamp_delta_no_overflow(self, view, scene) -> None:
+        """Delta is unchanged if movement stays inside canvas."""
+        item = self._make_rect(scene, 100, 100, 50, 50)
+        delta = QPointF(10, 10)
+        clamped = view._clamp_delta_to_canvas([item], delta)
+        assert abs(clamped.x() - 10) < 0.01
+        assert abs(clamped.y() - 10) < 0.01
+
+    def test_clamp_delta_right_overflow(self, view, scene) -> None:
+        """Delta is reduced if it would push item past right edge."""
+        # Item right edge at 950+50=1000 (at the boundary already)
+        item = self._make_rect(scene, 950, 100, 50, 50)
+        delta = QPointF(100, 0)
+        clamped = view._clamp_delta_to_canvas([item], delta)
+        # sceneBoundingRect includes pen margin, so right edge is slightly beyond 1000.
+        # The clamped dx should prevent going further right.
+        assert clamped.x() <= 0.5  # At most a tiny float rounding
+
+    def test_clamp_delta_left_overflow(self, view, scene) -> None:
+        """Delta is reduced if it would push item past left edge."""
+        item = self._make_rect(scene, 10, 100, 50, 50)
+        delta = QPointF(-100, 0)
+        clamped = view._clamp_delta_to_canvas([item], delta)
+        # Should not push left edge below 0 (canvas left)
+        result_left = item.sceneBoundingRect().left() + clamped.x()
+        assert result_left >= -0.5  # Allow for pen margin
+
+    def test_clamp_delta_top_overflow(self, view, scene) -> None:
+        """Delta is reduced if it would push item past top edge."""
+        item = self._make_rect(scene, 100, 5, 50, 50)
+        delta = QPointF(0, -100)
+        clamped = view._clamp_delta_to_canvas([item], delta)
+        result_top = item.sceneBoundingRect().top() + clamped.y()
+        assert result_top >= -0.5
+
+    def test_clamp_delta_bottom_overflow(self, view, scene) -> None:
+        """Delta is reduced if it would push item past bottom edge."""
+        item = self._make_rect(scene, 100, 950, 50, 50)
+        delta = QPointF(0, 100)
+        clamped = view._clamp_delta_to_canvas([item], delta)
+        assert clamped.y() <= 0.5
+
+    def test_clamp_items_pushes_back(self, view, scene) -> None:
+        """Items pushed outside the canvas are moved back in."""
+        item = self._make_rect(scene, -50, -50, 50, 50)
+        view._clamp_items_to_canvas([item])
+        rect = item.sceneBoundingRect()
+        canvas = scene.canvas_rect
+        assert rect.left() >= canvas.left() - 0.5
+        assert rect.top() >= canvas.top() - 0.5
+
+    def test_clamp_items_already_inside(self, view, scene) -> None:
+        """Items already inside the canvas are not moved."""
+        item = self._make_rect(scene, 100, 100, 50, 50)
+        original_pos = item.pos()
+        view._clamp_items_to_canvas([item])
+        assert item.pos() == original_pos
+
+    def test_clamp_multiple_items(self, view, scene) -> None:
+        """Multiple items are clamped together as a group."""
+        item1 = self._make_rect(scene, 100, 100, 50, 50)
+        item2 = self._make_rect(scene, 200, 200, 50, 50)
+        # Move both far to the right (outside canvas)
+        item1.setPos(980, 100)
+        item2.setPos(1080, 200)
+        view._clamp_items_to_canvas([item1, item2])
+        # The combined right edge should be within canvas
+        combined_right = max(
+            item1.sceneBoundingRect().right(),
+            item2.sceneBoundingRect().right(),
+        )
+        assert combined_right <= scene.canvas_rect.right() + 0.5

--- a/tests/unit/test_snapping.py
+++ b/tests/unit/test_snapping.py
@@ -1,0 +1,136 @@
+"""Tests for the object snapping engine."""
+
+import pytest
+from PyQt6.QtCore import QPointF, QRectF
+from PyQt6.QtWidgets import QGraphicsRectItem, QGraphicsScene
+
+from open_garden_planner.core.snapping import ObjectSnapper, SnapResult
+
+
+class TestSnapResult:
+    """Tests for SnapResult dataclass."""
+
+    def test_default_values(self, qtbot) -> None:
+        """Test SnapResult defaults."""
+        result = SnapResult(snapped_pos=QPointF(0, 0))
+        assert not result.snapped_x
+        assert not result.snapped_y
+        assert result.guides == []
+
+
+class TestObjectSnapper:
+    """Tests for ObjectSnapper class."""
+
+    @pytest.fixture
+    def snapper(self, qtbot) -> ObjectSnapper:
+        """Create a snapper with default threshold."""
+        return ObjectSnapper(threshold=10.0)
+
+    @pytest.fixture
+    def scene(self, qtbot) -> QGraphicsScene:
+        """Create a scene for testing."""
+        return QGraphicsScene()
+
+    def _make_selectable_rect(
+        self, scene: QGraphicsScene, x: float, y: float, w: float, h: float
+    ) -> QGraphicsRectItem:
+        """Create a selectable rect item and add to scene."""
+        item = QGraphicsRectItem(0, 0, w, h)
+        item.setPos(x, y)
+        item.setFlag(QGraphicsRectItem.GraphicsItemFlag.ItemIsSelectable, True)
+        scene.addItem(item)
+        return item
+
+    def test_no_snap_when_no_targets(self, snapper, scene) -> None:
+        """Test that snapper returns zero offset when there are no targets."""
+        dragged = QRectF(100, 100, 50, 50)
+        result = snapper.snap(dragged, list(scene.items()))
+        assert result.snapped_pos.x() == 0
+        assert result.snapped_pos.y() == 0
+        assert not result.snapped_x
+        assert not result.snapped_y
+
+    def test_snap_x_to_left_edge(self, snapper, scene) -> None:
+        """Test snapping to the left edge of a target item."""
+        target = self._make_selectable_rect(scene, 200, 0, 100, 100)
+        # sceneBoundingRect includes pen margin (~0.5), so target left is ~199.5
+        target_left = target.sceneBoundingRect().left()
+        dragged = QRectF(148, 50, 50, 50)
+        result = snapper.snap(dragged, list(scene.items()), exclude=set())
+        assert result.snapped_x
+        # Snap should move the dragged rect's right edge (198) to target's left edge
+        expected_dx = target_left - 198.0
+        assert abs(result.snapped_pos.x() - expected_dx) < 0.01
+
+    def test_snap_y_to_top_edge(self, snapper, scene) -> None:
+        """Test snapping to the top edge of a target item."""
+        target = self._make_selectable_rect(scene, 0, 200, 100, 100)
+        target_top = target.sceneBoundingRect().top()
+        dragged = QRectF(50, 148, 50, 50)
+        result = snapper.snap(dragged, list(scene.items()), exclude=set())
+        assert result.snapped_y
+        expected_dy = target_top - 198.0
+        assert abs(result.snapped_pos.y() - expected_dy) < 0.01
+
+    def test_no_snap_beyond_threshold(self, snapper, scene) -> None:
+        """Test that items beyond threshold are not snapped to."""
+        self._make_selectable_rect(scene, 200, 200, 100, 100)
+        # Dragged rect far from target
+        dragged = QRectF(0, 0, 50, 50)
+        result = snapper.snap(dragged, list(scene.items()), exclude=set())
+        assert not result.snapped_x
+        assert not result.snapped_y
+
+    def test_snap_to_center(self, snapper, scene) -> None:
+        """Test snapping to the center of a target item."""
+        self._make_selectable_rect(scene, 200, 200, 100, 100)
+        # Target center is at (250, 250)
+        # Dragged center at (248, 248) -> within threshold
+        dragged = QRectF(223, 223, 50, 50)
+        result = snapper.snap(dragged, list(scene.items()), exclude=set())
+        assert result.snapped_x
+        assert result.snapped_y
+
+    def test_excludes_dragged_items(self, snapper, scene) -> None:
+        """Test that excluded items are not used as snap targets."""
+        target = self._make_selectable_rect(scene, 200, 200, 100, 100)
+        # Dragged rect near target - but target is excluded
+        dragged = QRectF(195, 195, 50, 50)
+        result = snapper.snap(
+            dragged, list(scene.items()), exclude={target}
+        )
+        assert not result.snapped_x
+        assert not result.snapped_y
+
+    def test_snap_generates_guides(self, snapper, scene) -> None:
+        """Test that snapping generates visual guide lines."""
+        self._make_selectable_rect(scene, 200, 200, 100, 100)
+        # Dragged rect close enough to snap on both axes
+        dragged = QRectF(195, 195, 50, 50)
+        canvas = QRectF(0, 0, 1000, 1000)
+        result = snapper.snap(
+            dragged, list(scene.items()), exclude=set(), canvas_rect=canvas
+        )
+        assert len(result.guides) >= 1
+
+    def test_threshold_property(self, snapper) -> None:
+        """Test getting and setting the threshold."""
+        assert snapper.threshold == 10.0
+        snapper.threshold = 20.0
+        assert snapper.threshold == 20.0
+
+    def test_threshold_minimum(self, snapper) -> None:
+        """Test that threshold cannot go below 1.0."""
+        snapper.threshold = 0.5
+        assert snapper.threshold == 1.0
+
+    def test_non_selectable_items_ignored(self, snapper, scene) -> None:
+        """Test that non-selectable items are not used as snap targets."""
+        item = QGraphicsRectItem(0, 0, 100, 100)
+        item.setPos(200, 200)
+        # NOT setting ItemIsSelectable
+        scene.addItem(item)
+        dragged = QRectF(195, 195, 50, 50)
+        result = snapper.snap(dragged, list(scene.items()), exclude=set())
+        assert not result.snapped_x
+        assert not result.snapped_y


### PR DESCRIPTION
## Summary
- Smart snap-to-object with magenta dashed visual guide lines during drag (10cm threshold, toggleable via View > Snap to Objects / O key)
- Alignment tools: left, right, top, bottom, center H, center V (Edit > Align & Distribute)
- Distribution tools: equal horizontal/vertical spacing (needs 3+ objects)
- Canvas boundary enforcement: objects cannot be moved outside canvas borders (mouse drag, arrow keys, alignment/distribution all clamped)
- Full undo/redo support for all operations
- 35 new tests (snapping, alignment, boundary clamping)

## New Files
- `src/open_garden_planner/core/snapping.py` — Object snapping engine
- `src/open_garden_planner/core/alignment.py` — Alignment & distribution functions
- `tests/unit/test_snapping.py` — 11 snapping tests
- `tests/unit/test_alignment.py` — 16 alignment/distribution tests
- `tests/unit/test_canvas_boundary.py` — 8 boundary clamping tests

## Modified Files
- `src/open_garden_planner/core/commands.py` — AlignItemsCommand
- `src/open_garden_planner/ui/canvas/canvas_view.py` — Snap during drag, alignment methods, boundary clamping
- `src/open_garden_planner/app/application.py` — View menu toggle, Edit > Align & Distribute submenu
- `src/open_garden_planner/app/settings.py` — object_snap_enabled setting

## Test plan
- [x] All 875 tests pass
- [x] Ruff lint clean
- [ ] Manual test: drag objects near each other, verify magenta guides appear
- [ ] Manual test: toggle View > Snap to Objects off, verify no snapping
- [ ] Manual test: select 2+ objects, use Edit > Align & Distribute > Align Left
- [ ] Manual test: select 3+ objects, use Edit > Align & Distribute > Distribute Horizontal
- [ ] Manual test: try to drag objects outside canvas boundary, verify they stop at edge
- [ ] Manual test: arrow keys near canvas edge stop at boundary
- [ ] Manual test: undo/redo works for alignment operations

🤖 Generated with [Claude Code](https://claude.com/claude-code)