### PR TITLE
fix: Restore polygon size on undo after scaling (#41)

### DIFF
--- a/docs/08-crosscutting-concepts/README.md
+++ b/docs/08-crosscutting-concepts/README.md
@@ -33,6 +33,8 @@ class MoveObjectCommand(Command):
 - Commands are pushed onto an UndoStack (QUndoStack)
 - Undo history clears on project close (standard behavior)
 - Each vertex operation, property change, etc. is a separate undoable command
+- The `CommandManager` is owned by `CanvasView` and shared with `CanvasScene` via `scene.get_command_manager()` so that `QGraphicsItem` subclasses can push commands directly when handling resize, rotation, or vertex-editing interactions
+- Operations that change both geometry and position (e.g. scaling from a left handle) must be captured in a single command to avoid requiring multiple undos
 
 ## 8.3 Internationalization (i18n)
 

--- a/src/open_garden_planner/ui/canvas/canvas_scene.py
+++ b/src/open_garden_planner/ui/canvas/canvas_scene.py
@@ -77,6 +77,9 @@ class CanvasScene(QGraphicsScene):
         self._layers: list[Layer] = create_default_layers()
         self._active_layer: Layer | None = self._layers[0] if self._layers else None  # Default to first layer
 
+        # Command manager reference (set by CanvasView after construction)
+        self._command_manager = None
+
     def _update_scene_rect(self) -> None:
         """Update the scene rect with padding for panning."""
         # Add padding around canvas (50% of canvas size on each side)
@@ -208,6 +211,10 @@ class CanvasScene(QGraphicsScene):
     def canvas_rect(self) -> QRectF:
         """Get the actual canvas rectangle (not the scene rect with padding)."""
         return QRectF(0, 0, self._width_cm, self._height_cm)
+
+    def get_command_manager(self):
+        """Get the command manager for undo/redo operations."""
+        return self._command_manager
 
     def resize_canvas(self, width_cm: float, height_cm: float) -> None:
         """Resize the canvas.


### PR DESCRIPTION
## Summary
- **Root cause**: `CanvasScene` was missing `get_command_manager()`, so `_on_resize_end` in all item classes (polygon, rectangle, circle) silently returned without creating `ResizeItemCommand`. Only a `MoveItemsCommand` from `_finalize_drag_move()` captured the position delta.
- Added `_command_manager` attribute and `get_command_manager()` to `CanvasScene`, set by `CanvasView` on init
- Added guard in `_finalize_drag_move()` to skip duplicate `MoveItemsCommand` when `ResizeItemCommand` already covers the position change
- Documented the CommandManager sharing pattern in arc42 section 8.2

Closes #41

## Test plan
- [ ] Draw a polygon, scale from the **left** handle, press Ctrl+Z — size and position should both revert
- [ ] Repeat with **top** handle scaling
- [ ] Repeat with rectangle and circle objects
- [ ] Verify Ctrl+Z / Ctrl+Y (redo) cycle works correctly
- [ ] Verify normal drag-move undo still works (not affected by the guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)