### PR TITLE
fix: Replace QGraphicsDropShadowEffect with painted shadows (#50)

### DIFF
--- a/src/open_garden_planner/ui/canvas/canvas_view.py
+++ b/src/open_garden_planner/ui/canvas/canvas_view.py
@@ -313,8 +313,8 @@ class CanvasView(QGraphicsView):
         # Flip Y-axis for CAD convention (origin bottom-left, Y up)
         self._apply_transform()
 
-        # Viewport update mode for smooth rendering
-        self.setViewportUpdateMode(QGraphicsView.ViewportUpdateMode.FullViewportUpdate)
+        # Use minimal updates — only repaint dirty regions
+        self.setViewportUpdateMode(QGraphicsView.ViewportUpdateMode.MinimalViewportUpdate)
 
         # Accept drops from gallery panel
         self.setAcceptDrops(True)
@@ -1231,6 +1231,10 @@ class CanvasView(QGraphicsView):
 
         if self._scale_bar_visible:
             painter = QPainter(self.viewport())
+            # Remove clip so the scale bar is always fully drawn,
+            # even with MinimalViewportUpdate where only dirty
+            # regions are repainted.
+            painter.setClipping(False)
             painter.setRenderHint(QPainter.RenderHint.Antialiasing)
             self._draw_scale_bar(painter)
             painter.end()

--- a/src/open_garden_planner/ui/canvas/items/rectangle_item.py
+++ b/src/open_garden_planner/ui/canvas/items/rectangle_item.py
@@ -186,6 +186,14 @@ class RectangleItem(RectVertexEditMixin, RotationHandleMixin, ResizeHandlesMixin
         self.setFlag(QGraphicsRectItem.GraphicsItemFlag.ItemSendsGeometryChanges, True)
         self.setFlag(QGraphicsRectItem.GraphicsItemFlag.ItemIsFocusable, True)
 
+    def boundingRect(self) -> QRectF:
+        """Return bounding rect, expanded for shadow."""
+        base = super().boundingRect()
+        m = self._shadow_margin()
+        if m > 0:
+            base = base.adjusted(-m, -m, m, m)
+        return base
+
     def paint(
         self,
         painter: QPainter,
@@ -198,6 +206,16 @@ class RectangleItem(RectVertexEditMixin, RotationHandleMixin, ResizeHandlesMixin
         flat colored rectangle. For non-furniture rectangles, delegates
         to the default rectangle painting.
         """
+        # Draw painted shadow before the item itself
+        if self._shadows_enabled:
+            rect = self.rect()
+            painter.save()
+            painter.setPen(Qt.PenStyle.NoPen)
+            painter.setBrush(self.SHADOW_COLOR)
+            shadow_rect = rect.translated(self.SHADOW_OFFSET_X, self.SHADOW_OFFSET_Y)
+            painter.drawRect(shadow_rect)
+            painter.restore()
+
         if is_furniture_type(self.object_type):
             rect = self.rect()
             pixmap = render_furniture_pixmap(


### PR DESCRIPTION
## Summary
- Replaced `QGraphicsDropShadowEffect` (CPU offscreen-buffer + Gaussian blur per item per frame) with lightweight **painted shadows** drawn directly in each item's `paint()` method
- Removed OpenGL viewport (effects bypassed GPU anyway) and zoom-based shadow suppression (no longer needed)
- Shadow toggle (View > Show Shadows) continues to work via per-item `shadows_enabled` flag

## Root Cause
`QGraphicsDropShadowEffect` renders each item to a massive offscreen buffer at device resolution, then applies Gaussian blur — on every frame. At high zoom levels, these buffers scale with device pixel area, causing extreme lag on all interactions (moving, panning, zooming).

## Technical Details
- **garden_item.py**: Added `SHADOW_OFFSET_X/Y`, `SHADOW_COLOR` constants, `shadows_enabled` property, `_shadow_margin()` for bounding rect expansion
- **canvas_scene.py**: Removed `QGraphicsDropShadowEffect` import and all effect-related code; `set_shadows_enabled()` now toggles a boolean flag on garden items
- **canvas_view.py**: Removed OpenGL viewport, shadow suppression threshold, reverted to `MinimalViewportUpdate`
- **circle/rectangle/polygon/polyline_item.py**: Each item's `paint()` draws a semi-transparent offset shape before the main item; `boundingRect()` expanded by shadow margin
- **test_drop_shadows.py**: Updated 14 tests to verify painted shadow approach (no `QGraphicsEffect` applied)

## Test plan
- [x] All 920 tests pass (2 pre-existing resize handle failures unrelated)
- [x] Ruff lint clean
- [x] Manual testing: zoom in/out is smooth at all zoom levels
- [x] Shadows visible and toggleable via View menu

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)