### PR TITLE
feat(US-7.7): Numeric position input

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -309,7 +309,7 @@ tests/
 | ✅     | 7.4  | Dimension line visualization                         |
 | ✅     | 7.5  | Constraint solver drag integration                   |
 | ✅     | 7.6  | Constraints manager panel                            |
-|        | 7.7  | Numeric position input                               |
+| ✅     | 7.7  | Numeric position input                               |
 |        | 7.8  | Numeric dimension input                              |
 |        | 7.9  | Horizontal/Vertical alignment constraints            |
 |        | 7.10 | Angle constraints                                    |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -354,7 +354,7 @@
 | US-7.4 | Dimension line visualization (FreeCAD-style, toggleable) | Must | ✅ Done |
 | US-7.5 | Constraint solver drag integration (chain propagation) | Must | ✅ Done |
 | US-7.6 | Constraints manager panel | Must | ✅ Done |
-| US-7.7 | Numeric position input (editable X, Y in properties) | Must | |
+| US-7.7 | Numeric position input (editable X, Y in properties) | Must | ✅ Done |
 | US-7.8 | Numeric dimension input (editable width/height/radius) | Must | |
 | US-7.9 | Horizontal/Vertical alignment constraints | Should | |
 | US-7.10 | Angle constraints | Should | |

--- a/src/open_garden_planner/app/application.py
+++ b/src/open_garden_planner/app/application.py
@@ -611,6 +611,12 @@ class GardenPlannerApp(QMainWindow):
         cmd_mgr.can_undo_changed.connect(lambda _: self.constraints_panel.refresh())
         cmd_mgr.can_redo_changed.connect(lambda _: self.constraints_panel.refresh())
 
+        # Refresh properties panel after any command (move/resize/vertex edit/undo/redo)
+        # Use QTimer.singleShot to defer the update and avoid crash during spin box interaction
+        cmd_mgr.command_executed.connect(lambda _: QTimer.singleShot(0, self._update_properties_panel))
+        cmd_mgr.can_undo_changed.connect(lambda _: QTimer.singleShot(0, self._update_properties_panel))
+        cmd_mgr.can_redo_changed.connect(lambda _: QTimer.singleShot(0, self._update_properties_panel))
+
         # Set splitter as central widget
         self.setCentralWidget(splitter)
 


### PR DESCRIPTION
## Summary
- Implemented editable X,Y coordinate fields in the properties panel
- Position displayed as CAD coordinates (Y-up, origin at bottom-left)
- Uses QDoubleSpinBox with 1 decimal precision and cm units
- Changes create MoveItemsCommand for full undo/redo support
- Includes bounds validation to prevent moving objects outside canvas

## Technical Details
- **Coordinate System Fix**: After the view's Y-flip transform, scene coordinates align with CAD coordinates. Used `boundingRect().topLeft()` for accurate position calculation (includes stroke width).
- **Bounds Validation**: Uses `canvas_rect` (0,0 to width,height) instead of scene rect to ensure objects stay within canvas bounds.
- **Constraint Solver Integration**: Position changes trigger `_compute_constraint_propagation()` to update constrained objects.
- **Auto-Updates**: Position fields update automatically when objects are dragged, resized, or modified.

## Test Plan
- [x] Verify X,Y fields display correct CAD coordinates (Y-up, origin at bottom-left)
- [x] Verify editing X field moves object horizontally
- [x] Verify editing Y field moves object vertically
- [x] Verify bounds validation prevents moving outside canvas
- [x] Verify undo/redo works for position changes
- [x] Verify fields update when dragging objects
- [x] Verify constraint solver updates dependent objects when moving constrained objects

🤖 Generated with [Claude Code](https://claude.com/claude-code)