### PR TITLE
chore: fix version bump rule — patch per US, minor per phase

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,12 +48,21 @@ Releases are **fully automated** via `.github/workflows/release.yml`. To trigger
 ### Version Assignment for US Implementation
 
 When a US implementation is complete and ready to merge:
-1. Run `git describe --tags --abbrev=0` to get the current latest tag
-2. Assign the PR the appropriate label (`minor` for new features, `patch` for fixes)
+1. Run `git fetch --tags && git describe --tags --abbrev=0` to get the current latest tag
+2. Assign the PR the version label based on the **scope** of change:
+
+   | Scenario | Label | Example |
+   |----------|-------|---------|
+   | Individual US within an **ongoing phase** | `patch` | v1.9.0 → v1.9.1 |
+   | **First US of a brand-new phase** | `minor` | v1.9.x → v1.10.0 |
+   | Major architectural milestone (Phase 11+) | `major` | v1.x → v2.0.0 |
+
+   > **Rule of thumb**: almost every US gets `patch`. Only bump `minor` when the PR starts a new phase.
+
 3. After merge, the CI/CD pipeline tags and publishes the new release automatically
 4. Update the progress table below with ✅ and the version delivered
 5. **Do NOT wait for CI to complete.** The new version is deterministic: apply the bump rule to the
-   current tag yourself (e.g. `v1.7.0` + `minor` label → `v1.8.0`). Update immediately after merge:
+   current tag yourself. Update immediately after merge:
    - `pyproject.toml` → `version = "X.Y.Z"`
    - `src/open_garden_planner/__init__.py` → `__version__ = "X.Y.Z"`
 
@@ -356,7 +365,7 @@ tests/
 
 ## Progress (Phase 8: Location, Climate & Planting Calendar v1.7)
 
-> **Version note**: When implementing each US, check the latest git tag (`git describe --tags --abbrev=0`) and assign the next appropriate minor version at merge time.
+> **Version note**: Remaining Phase 8 USes use the `patch` label (v1.9.x series). The first US of Phase 9 uses `minor` (→ v1.10.0).
 
 | Status | US   | Description                                          |
 | ------ | ---- | ---------------------------------------------------- |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -12,9 +12,9 @@
 | Backlog | - | ✅ Complete | Rotation, vertex editing, annotations |
 | ~~6~~ | ~~v1.0~~ | ~~✅ Complete~~ | ~~Visual Polish & Public Release~~ |
 | ~~7~~ | ~~v1.1 – v1.6~~ | ~~✅ Complete~~ | ~~CAD Precision & Constraints~~ |
-| **8** | **v1.7** | **In Progress** | **Location, Climate & Planting Calendar** |
-| 9 | v1.8 | Planned | Seed Inventory & Propagation Planning |
-| 10 | v1.9 | Planned | Companion Planting & Crop Rotation |
+| **8** | **v1.7 – v1.9.x** | **In Progress** | **Location, Climate & Planting Calendar** |
+| 9 | v1.10 | Planned | Seed Inventory & Propagation Planning |
+| 10 | v1.11 | Planned | Companion Planting & Crop Rotation |
 | 11 | v2.0+ | Future | Advanced Features |
 
 ---


### PR DESCRIPTION
## Summary

- **Root cause**: CLAUDE.md said `minor` for new features, so every individual user story got a minor version bump — Phase 8 alone consumed v1.7, v1.8, and v1.9, which was supposed to be Phase 9's and Phase 10's territory.
- **Fix**: Individual US implementations within an ongoing phase use `patch` label. Only the **first US of a brand-new phase** uses `minor`. Phase 11+ uses `major`.
- Updated `docs/roadmap.md` phase version targets: Phase 9 → v1.10, Phase 10 → v1.11, Phase 11 → v2.0+.
- Added a clear lookup table in CLAUDE.md so the rule is unambiguous.

## No code changes — documentation/process only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)