### PR TITLE
fix: layer visibility/z-order not applied on load + isolate test QSettings

### DIFF
--- a/src/open_garden_planner/core/project.py
+++ b/src/open_garden_planner/core/project.py
@@ -603,6 +603,12 @@ class ProjectManager(QObject):
             if item:
                 scene.addItem(item)
 
+        # Apply layer visibility/opacity/lock/z-order to all items now that they exist
+        if hasattr(scene, "_update_items_visibility"):
+            scene._update_items_visibility()
+        if hasattr(scene, "_update_items_z_order"):
+            scene._update_items_z_order()
+
         # Load constraints if present
         if data.constraints and hasattr(scene, "constraint_graph"):
             from open_garden_planner.core.constraints import ConstraintGraph

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,3 +12,31 @@ os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 # Add src to path for imports
 src_path = Path(__file__).parent.parent / "src"
 sys.path.insert(0, str(src_path))
+
+
+@pytest.fixture(autouse=True, scope="session")
+def isolate_qsettings():
+    """Redirect QSettings to a test-only registry key for the entire test session.
+
+    This prevents tests from polluting the real user settings (e.g. recent files).
+    The test key is cleared at the end of the session.
+    """
+    from PyQt6.QtCore import QSettings
+
+    def _test_init(self: object) -> None:
+        self._settings = QSettings("cofade_test", "Open Garden Planner Test")  # type: ignore[attr-defined]
+
+    import open_garden_planner.app.settings as settings_module
+
+    original_init = settings_module.AppSettings.__init__
+    settings_module.AppSettings.__init__ = _test_init  # type: ignore[method-assign]
+
+    # Also reset the module-level singleton so a fresh test instance is created
+    settings_module._settings_instance = None  # type: ignore[attr-defined]
+
+    yield
+
+    # Clean up: clear the test registry key and restore original init
+    QSettings("cofade_test", "Open Garden Planner Test").clear()
+    settings_module.AppSettings.__init__ = original_init  # type: ignore[method-assign]
+    settings_module._settings_instance = None  # type: ignore[attr-defined]


### PR DESCRIPTION
## Summary

- **Hidden layers shown on open (#101)**: `set_layers()` called `_update_items_visibility()` before any items existed in the scene, so the visibility state was applied to an empty list. Items were then added with Qt's default visible=true. Fixed by calling `_update_items_visibility()` after all items are added during deserialization.
- **Layer z-order not respected on open**: Same root cause — `_update_items_z_order()` was never called on load, leaving all items at zValue=0 (Qt default). Terrasse rendered on top of Wiese despite being lower in the layer stack. Fixed by calling `_update_items_z_order()` after items are added.
- **Test projects polluting recent history**: Tests calling `ProjectManager.save()`/`load()` wrote file paths to the real Windows Registry (`HKEY_CURRENT_USER\Software\cofade\Open Garden Planner`), causing "test" and "guides" entries to appear in the welcome dialog. Fixed by patching `AppSettings.__init__` in `conftest.py` to use an isolated `cofade_test` registry key for the entire test session, which is cleared at session end.

## Test plan

- [x] All 1481 existing tests pass
- [ ] Open a project saved with a hidden layer — layer should be invisible immediately on load
- [ ] Open a project with multiple layers — verify render order matches panel order (top = front)
- [ ] Run full test suite, then open the app — "test"/"guides" entries no longer appear in recent projects

Closes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)