### PR TITLE
fix(#108): prevent item drift and view pan on double-click when zoomed in

### DIFF
--- a/src/open_garden_planner/ui/canvas/canvas_view.py
+++ b/src/open_garden_planner/ui/canvas/canvas_view.py
@@ -5,6 +5,8 @@ It flips the Y-axis to provide CAD-style coordinates (origin at bottom-left,
 Y increasing upward).
 """
 
+import logging
+
 from PyQt6.QtCore import QPointF, QRectF, Qt, pyqtSignal
 from PyQt6.QtGui import (
     QColor,
@@ -61,6 +63,8 @@ from open_garden_planner.core.tools import (
     VerticalDistanceConstraintTool,
 )
 from open_garden_planner.ui.canvas.canvas_scene import CanvasScene, GuideLine
+
+_log = logging.getLogger(__name__)
 
 
 class CanvasView(QGraphicsView):
@@ -1578,7 +1582,38 @@ class CanvasView(QGraphicsView):
             event.accept()
             return
 
+        # Snapshot positions and scroll state before delegating:
+        # Qt's QGraphicsView::mouseDoubleClickEvent internally re-runs its press handler
+        # (mousePressEventHandler), which can interact with ItemIsMovable and AnchorUnderMouse
+        # under the Y-flip transform to produce spurious position jumps and view panning (issue #108).
+        _pre_dbl = {item: item.pos() for item in self.scene().selectedItems()}
+        _hbar = self.horizontalScrollBar().value()
+        _vbar = self.verticalScrollBar().value()
+
         super().mouseDoubleClickEvent(event)
+
+        # Restore any position that shifted during double-click processing.
+        for item, pos in _pre_dbl.items():
+            if item.pos() != pos:
+                _log.warning(
+                    "Double-click caused position drift on %s: %s → %s (zoom=%.2f) — restoring.",
+                    type(item).__name__, pos, item.pos(), self._zoom_factor,
+                )
+                item.setPos(pos)
+
+        # Restore scroll position if the internal press handler panned the view.
+        if self.horizontalScrollBar().value() != _hbar:
+            _log.warning(
+                "Double-click caused H-scroll drift: %d → %d (zoom=%.2f) — restoring.",
+                _hbar, self.horizontalScrollBar().value(), self._zoom_factor,
+            )
+            self.horizontalScrollBar().setValue(_hbar)
+        if self.verticalScrollBar().value() != _vbar:
+            _log.warning(
+                "Double-click caused V-scroll drift: %d → %d (zoom=%.2f) — restoring.",
+                _vbar, self.verticalScrollBar().value(), self._zoom_factor,
+            )
+            self.verticalScrollBar().setValue(_vbar)
 
     def keyPressEvent(self, event: QKeyEvent) -> None:
         """Handle key press for tool operations and editing."""
@@ -1878,6 +1913,10 @@ class CanvasView(QGraphicsView):
             current_pos = item.pos()
             delta = current_pos - start_pos
             if delta.x() != 0 or delta.y() != 0:
+                _log.warning(
+                    "Item drag delta: start=%s current=%s delta=%s zoom=%.2f",
+                    start_pos, current_pos, delta, self._zoom_factor,
+                )
                 item_deltas.append((item, delta))
 
         for item, start_pos in self._constraint_propagated_starts.items():

--- a/src/open_garden_planner/ui/canvas/items/resize_handle.py
+++ b/src/open_garden_planner/ui/canvas/items/resize_handle.py
@@ -1394,6 +1394,11 @@ class VertexEditMixin:
 
         self._is_vertex_edit_mode = True
 
+        # Prevent accidental whole-item drag while editing individual vertices
+        if hasattr(self, 'setFlag'):
+            from PyQt6.QtWidgets import QGraphicsItem
+            self.setFlag(QGraphicsItem.GraphicsItemFlag.ItemIsMovable, False)  # type: ignore[attr-defined]
+
         # Hide resize and rotation handles if they exist
         if hasattr(self, 'hide_resize_handles'):
             self.hide_resize_handles()  # type: ignore[attr-defined]
@@ -1411,6 +1416,11 @@ class VertexEditMixin:
             return
 
         self._is_vertex_edit_mode = False
+
+        # Restore whole-item movability
+        if hasattr(self, 'setFlag'):
+            from PyQt6.QtWidgets import QGraphicsItem
+            self.setFlag(QGraphicsItem.GraphicsItemFlag.ItemIsMovable, True)  # type: ignore[attr-defined]
 
         # Remove vertex and midpoint handles + annotations
         self._remove_vertex_handles()
@@ -2053,6 +2063,11 @@ class RectVertexEditMixin:
 
         self._is_rect_vertex_edit_mode = True
 
+        # Prevent accidental whole-item drag while editing individual corners
+        if hasattr(self, 'setFlag'):
+            from PyQt6.QtWidgets import QGraphicsItem
+            self.setFlag(QGraphicsItem.GraphicsItemFlag.ItemIsMovable, False)  # type: ignore[attr-defined]
+
         # Hide resize and rotation handles if they exist
         if hasattr(self, 'hide_resize_handles'):
             self.hide_resize_handles()  # type: ignore[attr-defined]
@@ -2069,6 +2084,11 @@ class RectVertexEditMixin:
             return
 
         self._is_rect_vertex_edit_mode = False
+
+        # Restore whole-item movability
+        if hasattr(self, 'setFlag'):
+            from PyQt6.QtWidgets import QGraphicsItem
+            self.setFlag(QGraphicsItem.GraphicsItemFlag.ItemIsMovable, True)  # type: ignore[attr-defined]
 
         # Remove corner handles and annotations
         self._remove_rect_corner_handles()
@@ -2384,6 +2404,11 @@ class PolylineVertexEditMixin:
 
         self._is_vertex_edit_mode = True
 
+        # Prevent accidental whole-item drag while editing individual vertices
+        if hasattr(self, 'setFlag'):
+            from PyQt6.QtWidgets import QGraphicsItem
+            self.setFlag(QGraphicsItem.GraphicsItemFlag.ItemIsMovable, False)  # type: ignore[attr-defined]
+
         # Hide rotation handle if it exists
         if hasattr(self, 'hide_rotation_handle'):
             self.hide_rotation_handle()  # type: ignore[attr-defined]
@@ -2399,6 +2424,11 @@ class PolylineVertexEditMixin:
             return
 
         self._is_vertex_edit_mode = False
+
+        # Restore whole-item movability
+        if hasattr(self, 'setFlag'):
+            from PyQt6.QtWidgets import QGraphicsItem
+            self.setFlag(QGraphicsItem.GraphicsItemFlag.ItemIsMovable, True)  # type: ignore[attr-defined]
 
         # Remove vertex and midpoint handles + annotations
         self._remove_vertex_handles()


### PR DESCRIPTION
## Summary
- Fixes #108 — objects moving and viewport panning when double-clicking to enter vertex edit mode while zoomed in
- Root cause: `QGraphicsView::mouseDoubleClickEvent` internally re-runs `mousePressEventHandler`, which interacts with `ItemIsMovable` and `AnchorUnderMouse` under the Y-flip transform, producing spurious item jumps and view pans proportional to zoom level

## Changes
- **`canvas_view.py`**: snapshot/restore item positions and scrollbar values around `super().mouseDoubleClickEvent()`, with `WARNING` logs at each drift site for diagnostics
- **`resize_handle.py`**: disable `ItemIsMovable` on all three vertex edit mixins (`VertexEditMixin`, `RectVertexEditMixin`, `PolylineVertexEditMixin`) while in vertex edit mode, re-enabling on exit — second layer of defence against whole-item drag during vertex editing

## Test plan
- [x] Draw polygon, rectangle, polyline; zoom in ~500%
- [x] Double-click each to enter vertex edit mode — object does not move
- [x] Camera does not pan on double-click
- [x] Escape exits vertex edit mode — item is movable again
- [x] Lint passes (`ruff check src/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)