### PR TITLE
feat(US-11.11): group / ungroup canvas items

### DIFF
--- a/src/open_garden_planner/core/commands.py
+++ b/src/open_garden_planner/core/commands.py
@@ -1040,3 +1040,75 @@ class SetParentBedCommand(Command):
             if new_bed is not None and isinstance(new_bed, GardenItemMixin):
                 new_bed.add_child_id(self._plant.item_id)
         self._plant.parent_bed_id = attach_id
+
+
+class GroupCommand(Command):
+    """Group multiple items into a single movable unit."""
+
+    def __init__(self, scene: QGraphicsScene, items: list[QGraphicsItem]) -> None:
+        self._scene = scene
+        self._items = list(items)
+        self._group: QGraphicsItem | None = None
+
+    @property
+    def description(self) -> str:
+        return f"Group {len(self._items)} items"
+
+    def execute(self) -> None:
+        from open_garden_planner.ui.canvas.items.group_item import GroupItem
+
+        if self._group is None:
+            # Infer layer_id from the first item that has one
+            layer_id = None
+            from open_garden_planner.ui.canvas.items import GardenItemMixin
+            for item in self._items:
+                if isinstance(item, GardenItemMixin) and item.layer_id:
+                    layer_id = item.layer_id
+                    break
+            self._group = GroupItem(layer_id=layer_id)
+
+        self._scene.addItem(self._group)
+        for item in self._items:
+            item.setSelected(False)
+            self._group.addToGroup(item)  # type: ignore[attr-defined]
+        self._group.setSelected(True)
+
+    def undo(self) -> None:
+        if self._group is None:
+            return
+        for item in self._items:
+            self._group.removeFromGroup(item)  # type: ignore[attr-defined]
+            # Restore standard interaction flags cleared by addToGroup
+            item.setFlag(QGraphicsItem.GraphicsItemFlag.ItemIsSelectable, True)
+            item.setFlag(QGraphicsItem.GraphicsItemFlag.ItemIsMovable, True)
+            item.setSelected(True)
+        self._scene.removeItem(self._group)
+
+
+class UngroupCommand(Command):
+    """Ungroup a GroupItem back into independent items."""
+
+    def __init__(self, scene: QGraphicsScene, group: QGraphicsItem) -> None:
+        self._scene = scene
+        self._group = group
+        self._items: list[QGraphicsItem] = list(group.childItems())
+
+    @property
+    def description(self) -> str:
+        return "Ungroup"
+
+    def execute(self) -> None:
+        for item in self._items:
+            self._group.removeFromGroup(item)  # type: ignore[attr-defined]
+            item.setFlag(QGraphicsItem.GraphicsItemFlag.ItemIsSelectable, True)
+            item.setFlag(QGraphicsItem.GraphicsItemFlag.ItemIsMovable, True)
+            item.setSelected(True)
+        self._scene.removeItem(self._group)
+
+    def undo(self) -> None:
+        if self._group.scene() is None:
+            self._scene.addItem(self._group)
+        for item in self._items:
+            item.setSelected(False)
+            self._group.addToGroup(item)  # type: ignore[attr-defined]
+        self._group.setSelected(True)

--- a/src/open_garden_planner/core/project.py
+++ b/src/open_garden_planner/core/project.py
@@ -588,6 +588,12 @@ class ProjectManager(QObject):
 
     def _serialize_item(self, item: QGraphicsItem) -> dict[str, Any] | None:
         """Serialize a single graphics item."""
+        # Skip items that are Qt children of a GroupItem — they are serialized
+        # recursively inside the group's own dict.
+        from open_garden_planner.ui.canvas.items.group_item import GroupItem
+        if isinstance(item.parentItem(), GroupItem):
+            return None
+
         data = self._serialize_item_core(item)
         if data is None:
             return None
@@ -774,6 +780,27 @@ class ProjectManager(QObject):
             if hasattr(item, "rotation_angle") and abs(item.rotation_angle) > 0.01:
                 data["rotation_angle"] = item.rotation_angle
             return data
+
+        from open_garden_planner.ui.canvas.items.group_item import GroupItem
+        if isinstance(item, GroupItem):
+            children: list[dict[str, Any]] = []
+            for child in item.childItems():
+                child_data = self._serialize_item_core(child)
+                if child_data:
+                    children.append(child_data)
+            group_data: dict[str, Any] = {
+                "type": "group",
+                "item_id": str(item.item_id),
+                "children": children,
+                "x": item.pos().x(),
+                "y": item.pos().y(),
+            }
+            if item.layer_id:
+                group_data["layer_id"] = str(item.layer_id)
+            if item.name:
+                group_data["name"] = item.name
+            return group_data
+
         return None
 
     def _deserialize_to_scene(
@@ -898,6 +925,24 @@ class ProjectManager(QObject):
             return ConstructionLineItem.from_dict(obj)
         elif obj_type == "construction_circle":
             return ConstructionCircleItem.from_dict(obj)
+        elif obj_type == "group":
+            import contextlib
+            from uuid import UUID as _UUID
+
+            from open_garden_planner.ui.canvas.items.group_item import GroupItem
+            layer_id = None
+            with contextlib.suppress(ValueError, TypeError, KeyError):
+                layer_id = _UUID(obj["layer_id"])
+            group = GroupItem(layer_id=layer_id, name=obj.get("name", ""))
+            with contextlib.suppress(ValueError, TypeError, KeyError):
+                group._item_id = _UUID(obj["item_id"])
+            for child_data in obj.get("children", []):
+                child = self._deserialize_item_core(child_data)
+                if child is not None:
+                    group.addToGroup(child)
+            if "x" in obj and "y" in obj:
+                group.setPos(float(obj["x"]), float(obj["y"]))
+            return group
 
         # Extract common fields
         object_type = None

--- a/src/open_garden_planner/ui/canvas/canvas_view.py
+++ b/src/open_garden_planner/ui/canvas/canvas_view.py
@@ -1685,6 +1685,15 @@ class CanvasView(QGraphicsView):
             event.accept()
             return
 
+        # Handle Group (Ctrl+G) / Ungroup (Ctrl+Shift+G)
+        if event.key() == Qt.Key.Key_G and event.modifiers() & Qt.KeyboardModifier.ControlModifier:
+            if event.modifiers() & Qt.KeyboardModifier.ShiftModifier:
+                self._ungroup_selected()
+            else:
+                self._group_selected()
+            event.accept()
+            return
+
         # Delegate to active tool first
         tool = self._tool_manager.active_tool
         if tool and tool.key_press(event):
@@ -2640,6 +2649,47 @@ class CanvasView(QGraphicsView):
         # Foreground: text
         painter.setPen(fg_color)
         painter.drawText(int(text_x), int(text_y), label)
+
+    # ------------------------------------------------------------------
+    # Group / Ungroup
+    # ------------------------------------------------------------------
+
+    def _group_selected(self) -> None:
+        """Group all currently selected items (Ctrl+G)."""
+        from open_garden_planner.core.commands import GroupCommand
+        from open_garden_planner.ui.canvas.items.group_item import GroupItem
+
+        selected = [
+            item for item in self.scene().selectedItems()
+            if not isinstance(item, GroupItem) or item.parentItem() is None
+        ]
+        # Need at least 2 items (or 1 group child) — sensible minimum is 2
+        if len(selected) < 2:
+            self.set_status_message(self.tr("Select 2 or more items to group"))
+            return
+
+        command = GroupCommand(self.scene(), selected)
+        self._command_manager.execute(command)
+        self.set_status_message(self.tr("Grouped {n} items").format(n=len(selected)))
+
+    def _ungroup_selected(self) -> None:
+        """Ungroup all selected GroupItems (Ctrl+Shift+G)."""
+        from open_garden_planner.ui.canvas.items.group_item import GroupItem
+
+        groups = [item for item in self.scene().selectedItems() if isinstance(item, GroupItem)]
+        if not groups:
+            self.set_status_message(self.tr("No group selected"))
+            return
+        for group in groups:
+            self.ungroup_item(group)
+
+    def ungroup_item(self, group: "QGraphicsItem") -> None:
+        """Ungroup a specific GroupItem."""
+        from open_garden_planner.core.commands import UngroupCommand
+
+        command = UngroupCommand(self.scene(), group)
+        self._command_manager.execute(command)
+        self.set_status_message(self.tr("Ungrouped"))
 
     def copy_selected(self) -> None:
         """Copy selected items to clipboard (auto-includes bed children)."""

--- a/src/open_garden_planner/ui/canvas/items/__init__.py
+++ b/src/open_garden_planner/ui/canvas/items/__init__.py
@@ -4,6 +4,7 @@ from .background_image_item import BackgroundImageItem
 from .circle_item import CircleItem
 from .construction_item import ConstructionCircleItem, ConstructionLineItem
 from .garden_item import GardenItemMixin
+from .group_item import GroupItem
 from .polygon_item import PolygonItem
 from .polyline_item import PolylineItem
 from .rectangle_item import RectangleItem
@@ -15,6 +16,7 @@ __all__ = [
     "ConstructionCircleItem",
     "ConstructionLineItem",
     "GardenItemMixin",
+    "GroupItem",
     "HandlePosition",
     "PolygonItem",
     "PolylineItem",

--- a/src/open_garden_planner/ui/canvas/items/group_item.py
+++ b/src/open_garden_planner/ui/canvas/items/group_item.py
@@ -1,0 +1,90 @@
+"""Group item: a logical container for grouping multiple canvas items."""
+
+from __future__ import annotations
+
+import uuid
+
+from PyQt6.QtCore import QRectF, Qt
+from PyQt6.QtGui import QColor, QPainter, QPen
+from PyQt6.QtWidgets import (
+    QGraphicsItem,
+    QGraphicsItemGroup,
+    QGraphicsSceneContextMenuEvent,
+    QMenu,
+    QStyleOptionGraphicsItem,
+    QWidget,
+)
+
+from .garden_item import GardenItemMixin
+
+
+class GroupItem(GardenItemMixin, QGraphicsItemGroup):
+    """A group of canvas items that move, copy, and rotate together.
+
+    Items inside a group lose individual selectability/movability; the group
+    is the single unit for all interactions.  Nested groups are supported.
+    """
+
+    def __init__(
+        self,
+        layer_id: uuid.UUID | None = None,
+        name: str = "",
+    ) -> None:
+        GardenItemMixin.__init__(
+            self,
+            object_type=None,
+            name=name,
+            layer_id=layer_id,
+        )
+        QGraphicsItemGroup.__init__(self)
+
+        self.setFlag(QGraphicsItem.GraphicsItemFlag.ItemIsSelectable, True)
+        self.setFlag(QGraphicsItem.GraphicsItemFlag.ItemIsMovable, True)
+        self.setFlag(QGraphicsItem.GraphicsItemFlag.ItemSendsGeometryChanges, True)
+
+    # ------------------------------------------------------------------
+    # Paint
+    # ------------------------------------------------------------------
+
+    def paint(
+        self,
+        painter: QPainter,
+        option: QStyleOptionGraphicsItem,  # noqa: ARG002
+        widget: QWidget | None = None,  # noqa: ARG002
+    ) -> None:
+        """Draw a subtle dashed outline around the group bounding rect."""
+        rect = self.childrenBoundingRect()
+        if rect.isEmpty():
+            return
+
+        # Expand slightly so the outline doesn't clip the children
+        rect = rect.adjusted(-2, -2, 2, 2)
+
+        if self.isSelected():
+            pen = QPen(QColor(60, 130, 200), 1.5, Qt.PenStyle.DashLine)
+        else:
+            pen = QPen(QColor(100, 140, 200, 80), 1, Qt.PenStyle.DotLine)
+
+        painter.setPen(pen)
+        painter.setBrush(Qt.BrushStyle.NoBrush)
+        painter.drawRect(rect)
+
+    def boundingRect(self) -> QRectF:
+        """Return children bounding rect with a small margin."""
+        return self.childrenBoundingRect().adjusted(-4, -4, 4, 4)
+
+    # ------------------------------------------------------------------
+    # Context menu
+    # ------------------------------------------------------------------
+
+    def contextMenuEvent(self, event: QGraphicsSceneContextMenuEvent) -> None:
+        """Show ungroup action in the context menu."""
+        menu = QMenu()
+        ungroup_action = menu.addAction("Ungroup")
+        action = menu.exec(event.screenPos())
+        if action == ungroup_action:
+            scene = self.scene()
+            if scene:
+                views = scene.views()
+                if views and hasattr(views[0], "ungroup_item"):
+                    views[0].ungroup_item(self)

--- a/src/open_garden_planner/ui/panels/properties_panel.py
+++ b/src/open_garden_planner/ui/panels/properties_panel.py
@@ -219,6 +219,20 @@ class PropertiesPanel(QWidget):
         self._clear_form()
         self._updating = True
 
+        # GroupItem — show a compact summary
+        from open_garden_planner.ui.canvas.items.group_item import GroupItem
+        if isinstance(item, GroupItem):
+            count = len(item.childItems())
+            info = QLabel(self.tr("Group ({n} items)").format(n=count))
+            info.setAlignment(Qt.AlignmentFlag.AlignCenter)
+            self._form_layout.addRow(info)
+            hint = QLabel(self.tr("Ctrl+Shift+G to ungroup"))
+            hint.setAlignment(Qt.AlignmentFlag.AlignCenter)
+            hint.setStyleSheet("color: gray; font-size: 11px;")
+            self._form_layout.addRow(hint)
+            self._updating = False
+            return
+
         # Object Type (if applicable)
         if hasattr(item, 'object_type'):
             type_combo = QComboBox()


### PR DESCRIPTION
## Summary
- Select 2+ items → Ctrl+G to group into a single movable/selectable unit with a dashed outline
- Ctrl+Shift+G or right-click → Ungroup restores independence; all children re-selected
- Groups serialize/deserialize in project files (`"type": "group"` with embedded children)
- Properties panel shows "Group (N items)" summary when group selected
- Nested groups supported (group of groups)
- Full undo/redo via GroupCommand / UngroupCommand

## Test plan
- [x] Select 2+ items → Ctrl+G → single bounding box, moves together
- [x] Ctrl+Shift+G / right-click Ungroup → items restored
- [x] Ctrl+Z after group/ungroup → correct undo
- [x] Save + reload project → group intact
- [x] Nested groups work
- [x] 1785 tests pass, ruff clean, exe launches

🤖 Generated with [Claude Code](https://claude.com/claude-code)