### PR TITLE
fix(#121,#122): constrain mid-edge resize axis & coordinate vertex edit mode

### DIFF
--- a/src/open_garden_planner/ui/canvas/canvas_view.py
+++ b/src/open_garden_planner/ui/canvas/canvas_view.py
@@ -1789,6 +1789,14 @@ class CanvasView(QGraphicsView):
             event.accept()
             return
 
+        # Handle ESC to exit vertex edit mode
+        if event.key() == Qt.Key.Key_Escape:
+            for item in self._canvas_scene.selectedItems():
+                if hasattr(item, 'is_vertex_edit_mode') and item.is_vertex_edit_mode:
+                    item.exit_vertex_edit_mode()
+                    event.accept()
+                    return
+
         # Handle Copy (Ctrl+C)
         if event.key() == Qt.Key.Key_C and event.modifiers() & Qt.KeyboardModifier.ControlModifier:
             self.copy_selected()

--- a/src/open_garden_planner/ui/canvas/items/polygon_item.py
+++ b/src/open_garden_planner/ui/canvas/items/polygon_item.py
@@ -762,6 +762,10 @@ class PolygonItem(VertexEditMixin, RotationHandleMixin, ResizeHandlesMixin, Gard
         """Handle double-click to enter vertex edit mode and start label edit."""
         if event.button() == Qt.MouseButton.LeftButton:
             if not self.is_vertex_edit_mode:
+                # Exit vertex edit mode on any other item first
+                for item in self.scene().items():
+                    if item is not self and hasattr(item, 'is_vertex_edit_mode') and item.is_vertex_edit_mode:
+                        item.exit_vertex_edit_mode()
                 self.enter_vertex_edit_mode()
             self.start_label_edit()
             event.accept()

--- a/src/open_garden_planner/ui/canvas/items/polyline_item.py
+++ b/src/open_garden_planner/ui/canvas/items/polyline_item.py
@@ -826,6 +826,10 @@ class PolylineItem(PolylineVertexEditMixin, RotationHandleMixin, GardenItemMixin
         """Handle double-click to enter vertex edit mode and start label edit."""
         if event.button() == Qt.MouseButton.LeftButton:
             if not self.is_vertex_edit_mode:
+                # Exit vertex edit mode on any other item first
+                for item in self.scene().items():
+                    if item is not self and hasattr(item, 'is_vertex_edit_mode') and item.is_vertex_edit_mode:
+                        item.exit_vertex_edit_mode()
                 self.enter_vertex_edit_mode()
             self.start_label_edit()
             event.accept()

--- a/src/open_garden_planner/ui/canvas/items/rectangle_item.py
+++ b/src/open_garden_planner/ui/canvas/items/rectangle_item.py
@@ -497,6 +497,10 @@ class RectangleItem(RectVertexEditMixin, RotationHandleMixin, ResizeHandlesMixin
         """Handle double-click to enter vertex edit mode and start label edit."""
         if event.button() == Qt.MouseButton.LeftButton:
             if not self.is_vertex_edit_mode:
+                # Exit vertex edit mode on any other item first
+                for item in self.scene().items():
+                    if item is not self and hasattr(item, 'is_vertex_edit_mode') and item.is_vertex_edit_mode:
+                        item.exit_vertex_edit_mode()
                 self.enter_vertex_edit_mode()
             self.start_label_edit()
             event.accept()

--- a/src/open_garden_planner/ui/canvas/items/resize_handle.py
+++ b/src/open_garden_planner/ui/canvas/items/resize_handle.py
@@ -269,9 +269,14 @@ class ResizeHandle(QGraphicsRectItem):
             self._is_dragging = True
             self._drag_start_pos = event.scenePos()
 
-            # Store initial geometry
+            # Store initial geometry — use rect() (actual geometry) rather
+            # than boundingRect() which includes pen width + shadow margin
+            # and would inflate dimensions on every drag.
             if self._parent_item is not None:
-                self._initial_rect = self._parent_item.boundingRect()
+                if hasattr(self._parent_item, 'rect') and callable(self._parent_item.rect):
+                    self._initial_rect = self._parent_item.rect()
+                else:
+                    self._initial_rect = self._parent_item.boundingRect()
                 self._initial_parent_pos = self._parent_item.pos()
 
                 # Notify parent that resize is starting

--- a/src/open_garden_planner/ui/canvas/items/resize_handle.py
+++ b/src/open_garden_planner/ui/canvas/items/resize_handle.py
@@ -364,6 +364,14 @@ class ResizeHandle(QGraphicsRectItem):
             local_dx = delta.x()
             local_dy = delta.y()
 
+        # Constrain mid-edge handles to a single axis so the perpendicular
+        # dimension stays constant (critical for rotated shapes where both
+        # local_dx and local_dy are non-zero from any screen-space drag).
+        if self._position in {HandlePosition.MIDDLE_LEFT, HandlePosition.MIDDLE_RIGHT}:
+            local_dy = 0.0
+        elif self._position in {HandlePosition.TOP_CENTER, HandlePosition.BOTTOM_CENTER}:
+            local_dx = 0.0
+
         # Calculate new rect based on which handle is being dragged
         new_x = init_rect.x()
         new_y = init_rect.y()


### PR DESCRIPTION
## Summary
- **#122 — Resize crosstalk on rotated shapes**: Mid-edge resize handles (`MIDDLE_LEFT`, `MIDDLE_RIGHT`, `TOP_CENTER`, `BOTTOM_CENTER`) now zero out the perpendicular local-delta component before computing the new dimensions. Previously, on rotated shapes the inverse-rotation transform produced non-zero `local_dy` (or `local_dx`) even for a purely horizontal (or vertical) screen drag, causing the perpendicular dimension to drift.
- **#121a — Multiple vertex edit modes**: Entering vertex edit mode on an item now auto-exits vertex edit mode on any other item in the scene first, so only one item is ever in vertex edit at a time.
- **#121b — Escape exits vertex edit**: The canvas view's `keyPressEvent` now checks for Escape when a selected item is in vertex edit mode and exits it, since items' own key handlers never received focus.

Closes #121, closes #122

## Test plan
- [ ] Draw a rectangle, rotate it ~30-45°, note dimensions. Drag a mid-edge handle — the perpendicular dimension must stay constant
- [ ] Double-click object A to enter vertex edit. Double-click object B — A's vertex handles must disappear
- [ ] Double-click an object to enter vertex edit. Press Escape — vertex handles must disappear, resize/rotation handles reappear
- [ ] `pytest tests/ -v` — 1792 tests pass
- [ ] `ruff check src/` — clean
- [ ] Exe build launches successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)