### PR TITLE
feat(DI-1): add Bandit SAST to CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,3 +51,20 @@ jobs:
         env:
           QT_QPA_PLATFORM: offscreen
         run: pytest tests/ -v
+
+  security:
+    name: Security
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install Bandit
+        run: pip install "bandit>=1.7.0"
+
+      - name: Run Bandit (fail on HIGH severity)
+        run: bandit -r src/ --severity-level high

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,9 @@ venv/Scripts/python.exe -m pytest tests/ -v
 # Lint
 venv/Scripts/python.exe -m ruff check src/
 
+# Security scan
+venv/Scripts/python.exe -m bandit -r src/ --severity-level high
+
 # Build & verify exe (before every merge)
 venv/Scripts/python.exe -m PyInstaller installer/ogp.spec --noconfirm
 timeout 8 dist/OpenGardenPlanner/OpenGardenPlanner.exe
@@ -35,6 +38,7 @@ All architecture documentation follows arc42 in `docs/`. Key references:
 | i18n rules & translation how-to      | `docs/08-crosscutting-concepts/` (section 8.3)        |
 | QGraphicsView overlay widget patterns | `docs/08-crosscutting-concepts/` (section 8.9)       |
 | Integration test policy (MANDATORY)  | `docs/08-crosscutting-concepts/` (section 8.10)      |
+| Security scanning / SAST (Bandit)    | `docs/08-crosscutting-concepts/` (section 8.11)      |
 | Known pitfalls & technical debt      | `docs/11-risks-and-technical-debt/` (section 11.4)    |
 | Functional requirements (FR-*)       | `docs/functional-requirements.md`                     |
 | Architecture decisions (ADRs)        | `docs/09-architecture-decisions/`                     |
@@ -65,7 +69,10 @@ After merge, wait for the CI release, then update **both** `pyproject.toml` and 
 2. Read user story from `docs/roadmap.md`
 3. Clarify with `AskUserQuestion` if needed
 4. Implement with type hints
-5. Write tests, run lint
+5. Write tests, run lint and security scan:
+   - `pytest tests/ -v`
+   - `ruff check src/`
+   - `bandit -r src/ --severity-level high`
 6. **Write integration test** — every US needs at least one end-to-end test in `tests/integration/test_<feature>.py` that simulates the primary UI workflow (tool activate → gesture → verify state). **No merge without this. No exceptions.** See `docs/08-crosscutting-concepts/` section 8.10.
 7. Build exe and verify it launches (see Quick Reference)
 8. **WAIT for user to manually test and approve** — provide a testing checklist

--- a/docs/08-crosscutting-concepts/README.md
+++ b/docs/08-crosscutting-concepts/README.md
@@ -341,3 +341,26 @@ def canvas(qtbot):
 ### CI
 
 Integration tests run automatically in CI (`ci.yml`) alongside unit and widget tests. Qt rendering uses `QT_QPA_PLATFORM=offscreen` — no display server required.
+
+## 8.11 Security Scanning (SAST)
+
+**Tool:** [Bandit](https://bandit.readthedocs.io/) — a Python SAST tool that detects common security anti-patterns (subprocess injection, unsafe deserialization, weak cryptography, hardcoded secrets, etc.).
+
+**CI enforcement:** The `security` job in `ci.yml` runs `bandit -r src/ --severity-level high` on every push. CI fails only on HIGH-severity findings. MEDIUM and LOW findings are printed in the log for awareness but do not block merges.
+
+**Local use:**
+```bash
+venv/Scripts/python.exe -m bandit -r src/ --severity-level high
+
+# See ALL findings (MEDIUM + LOW) for awareness:
+venv/Scripts/python.exe -m bandit -r src/
+```
+
+**Suppressing a false positive** (use sparingly — always add a justification comment):
+```python
+result = subprocess.run(cmd)  # nosec B603 — cmd is constructed internally, never from user input
+```
+
+**Scope:** `src/` only. Test files are excluded — `assert` statements and test helpers are intentional and not security-relevant.
+
+**Adding new checks:** If a feature introduces a new code pattern that warrants attention (e.g. cryptography, XML parsing, network server code), review the relevant Bandit rule IDs and verify the CI job covers them.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -39,13 +39,24 @@
 1. Implement feature with type hints
 2. Write unit/widget tests (`tests/unit/`, `tests/ui/`)
 3. **Write integration test** (`tests/integration/`) — mandatory
-4. Run `pytest tests/ -v` and `ruff check src/` — must be green
+4. Run `pytest tests/ -v`, `ruff check src/`, and `bandit -r src/ --severity-level high` — must all be green
 5. Build exe, wait for manual user approval
 6. Commit, push, PR, merge
 
 ### Translation (i18n)
 
 Every user-visible string must be wrapped for translation. See `docs/08-crosscutting-concepts/` section 8.3.
+
+---
+
+## Dev Infrastructure
+
+> Infrastructure improvements that apply project-wide, independent of product user stories.
+> These are tracked here rather than as numbered product US entries.
+
+| Status | ID   | Description            | Notes                                                         |
+|--------|------|------------------------|---------------------------------------------------------------|
+| ✅     | DI-1 | SAST pipeline (Bandit) | HIGH-severity scan in CI; `bandit>=1.7.0` added as dev dep   |
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dev = [
     "pytest-cov>=4.1.0",
     "ruff>=0.1.0",
     "mypy>=1.8.0",
+    "bandit>=1.7.0",
 ]
 
 [project.scripts]

--- a/src/open_garden_planner/core/plant_renderer.py
+++ b/src/open_garden_planner/core/plant_renderer.py
@@ -404,7 +404,7 @@ def _stable_random_for_item(item_id: str, seed_offset: int = 0) -> float:
     Returns:
         Float between 0.0 and 1.0
     """
-    h = hashlib.md5(f"{item_id}:{seed_offset}".encode()).hexdigest()
+    h = hashlib.md5(f"{item_id}:{seed_offset}".encode(), usedforsecurity=False).hexdigest()
     return int(h[:8], 16) / 0xFFFFFFFF
 
 


### PR DESCRIPTION
## Summary

- Adds a new parallel `security` CI job running `bandit -r src/ --severity-level high` on every push
- Adds `bandit>=1.7.0` as a dev dependency so developers can run it locally
- Fixes one pre-existing HIGH finding (B324): `hashlib.md5` in `plant_renderer.py` now uses `usedforsecurity=False` — the hash is a deterministic number seed, not a security primitive
- Documents the SAST requirement in CLAUDE.md (Quick Reference + workflow step 5), arc42 §8.11, and a new Dev Infrastructure section in `docs/roadmap.md`

## Test plan

- [x] `bandit -r src/ --severity-level high` exits 0 locally (zero HIGH findings)
- [x] `pytest tests/ -v` — 1868 tests pass
- [x] `ruff check src/` — clean
- [ ] CI `security` job appears and passes in GitHub Actions after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)