### PR TITLE
fix(constraints): distance constraint moves only item A; B stays as reference

### DIFF
--- a/src/open_garden_planner/ui/canvas/canvas_view.py
+++ b/src/open_garden_planner/ui/canvas/canvas_view.py
@@ -619,9 +619,23 @@ class CanvasView(QGraphicsView):
         command through the command manager so the full operation (constraint
         addition + position changes) is a single Ctrl+Z step.
         """
+        from open_garden_planner.core.constraints import ConstraintType as _CT
+
+        # CAD convention: A is constrained to B → A moves, B stays (reference).
+        # Exception: if A already has a FIXED constraint the FIXED pre-pass
+        # inside solve_anchored will pin A, so B must remain free to move.
+        graph = self._canvas_scene.constraint_graph
+        anchor_a_id = command._anchor_a.item_id  # type: ignore[attr-defined]
+        anchor_b_id = command._anchor_b.item_id  # type: ignore[attr-defined]
+        a_is_fixed = any(
+            c.constraint_type == _CT.FIXED and c.anchor_a.item_id == anchor_a_id
+            for c in graph.constraints.values()
+        )
+        extra_pinned: set | None = None if a_is_fixed else {anchor_b_id}
+
         # 1. Add the constraint temporarily so the solver can compute moves.
         command.execute()
-        moves, vertex_moves = self._compute_constraint_solve_moves()
+        moves, vertex_moves = self._compute_constraint_solve_moves(extra_pinned=extra_pinned)
         # 2. Remove temporarily — we want the official execute() below to do it.
         command.undo()
         # 3. Embed the moves into the command so execute() + undo() handle them.
@@ -1867,6 +1881,7 @@ class CanvasView(QGraphicsView):
             constraint_id: UUID of the constraint to edit
         """
         from open_garden_planner.core.commands import EditConstraintDistanceCommand
+        from open_garden_planner.core.constraints import ConstraintType
         from open_garden_planner.core.tools.constraint_tool import DistanceInputDialog
 
         graph = self._canvas_scene.constraint_graph
@@ -1880,9 +1895,22 @@ class CanvasView(QGraphicsView):
             if abs(new_distance - constraint.target_distance) > 0.01:
                 old_distance = constraint.target_distance
 
+                # CAD convention: A moves, B stays.  If A is already FIXED the
+                # pre-pass in solve_anchored pins it, so B must remain free.
+                a_is_fixed = any(
+                    c.constraint_type == ConstraintType.FIXED
+                    and c.anchor_a.item_id == constraint.anchor_a.item_id
+                    for c in graph.constraints.values()
+                )
+                extra_pinned: set | None = (
+                    None if a_is_fixed else {constraint.anchor_b.item_id}
+                )
+
                 # Temporarily apply new distance so solver can compute moves
                 constraint.target_distance = new_distance
-                item_moves, vertex_moves = self._compute_constraint_solve_moves()
+                item_moves, vertex_moves = self._compute_constraint_solve_moves(
+                    extra_pinned=extra_pinned
+                )
                 constraint.target_distance = old_distance  # command will set it
 
                 command = EditConstraintDistanceCommand(
@@ -1946,12 +1974,20 @@ class CanvasView(QGraphicsView):
 
     def _compute_constraint_solve_moves(
         self,
+        extra_pinned: "set | None" = None,
     ) -> "tuple[list[tuple[QGraphicsItem, QPointF, QPointF]], list[tuple[QGraphicsItem, int, QPointF, QPointF]]]":
-        """Run the constraint solver (all items free) and return position changes.
+        """Run the constraint solver and return position changes.
 
         Should be called while the constraint graph already has the desired
         target distances set.  Returns a list of (item, old_pos, new_pos) for
         every item that would move by more than 0.01 cm.
+
+        Args:
+            extra_pinned: Additional item IDs to treat as pinned (immovable)
+                during this solve pass, beyond the always-pinned construction
+                items.  Used to implement the CAD convention that item B (the
+                reference anchor) stays fixed while item A moves to satisfy the
+                new constraint.
         """
         from open_garden_planner.core.measure_snapper import get_anchor_points
         from open_garden_planner.ui.canvas.items import GardenItemMixin
@@ -1998,11 +2034,13 @@ class CanvasView(QGraphicsView):
 
         deformable_items, deformable_vertices = self._gather_deformable_info(item_map)
 
-        # Construction items are always pinned — only garden items move
+        # Construction items are always pinned — only garden items move.
+        # extra_pinned allows callers to additionally pin a reference item so
+        # that only the other item moves (CAD convention: A moves, B stays).
         result = graph.solve_anchored(
             item_positions=item_positions,
             anchor_offsets=anchor_offsets,
-            pinned_items=construction_ids,
+            pinned_items=construction_ids | (extra_pinned or set()),
             max_iterations=20,
             tolerance=1.0,
             deformable_items=deformable_items,

--- a/tests/integration/test_constraint_creation.py
+++ b/tests/integration/test_constraint_creation.py
@@ -1,0 +1,137 @@
+"""Integration tests: distance constraint creation applies CAD convention.
+
+Verifies the fix for issue #139: when a distance constraint is created between
+two free-floating items, only the first-clicked item (A) moves to satisfy the
+distance; the second-clicked item (B) stays in place as the reference.
+"""
+
+# ruff: noqa: ARG002
+
+import math
+from unittest.mock import MagicMock
+
+import pytest
+from PyQt6.QtCore import QPointF, Qt
+from PyQt6.QtGui import QMouseEvent
+
+from open_garden_planner.core.commands import AddConstraintCommand
+from open_garden_planner.core.constraints import AnchorRef, ConstraintType
+from open_garden_planner.core.measure_snapper import AnchorType
+from open_garden_planner.core.tools import ToolType
+from open_garden_planner.ui.canvas.canvas_view import CanvasView
+from open_garden_planner.ui.canvas.items import RectangleItem
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _left_click_event() -> MagicMock:
+    event = MagicMock(spec=QMouseEvent)
+    event.button.return_value = Qt.MouseButton.LeftButton
+    event.modifiers.return_value = Qt.KeyboardModifier.NoModifier
+    return event
+
+
+def _draw_rect(view: CanvasView, x1: float, y1: float, x2: float, y2: float) -> RectangleItem:
+    """Draw a rectangle and return the resulting item."""
+    event = _left_click_event()
+    view.set_active_tool(ToolType.RECTANGLE)
+    tool = view.tool_manager.active_tool
+    tool.mouse_press(event, QPointF(x1, y1))
+    tool.mouse_move(event, QPointF(x2, y2))
+    tool.mouse_release(event, QPointF(x2, y2))
+    rects = [i for i in view.scene().items() if isinstance(i, RectangleItem)]
+    return rects[0]
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestDistanceConstraintCreation:
+    """Issue #139 regression tests for the 'both items move' bug."""
+
+    def test_only_item_a_moves_when_distance_constraint_added(
+        self, canvas: CanvasView, qtbot: object
+    ) -> None:
+        """Adding a distance constraint moves only item A; item B stays fixed.
+
+        Scenario from issue #139: two items 10 m apart, constraint set to 8 m.
+        Expected: item A (first anchor) moves 2 m toward B; B does not move.
+        """
+        # Two rectangles, each 100×100 cm.
+        # rect_a centre at (50, 50), rect_b centre at (1050, 50) → 1000 cm apart.
+        rect_a = _draw_rect(canvas, 0, 0, 100, 100)
+        rect_b = _draw_rect(canvas, 1000, 0, 1100, 100)
+
+        pos_b_before = rect_b.pos()
+
+        # Build a distance constraint: A = rect_a centre, B = rect_b centre.
+        ref_a = AnchorRef(rect_a.item_id, AnchorType.CENTER)
+        ref_b = AnchorRef(rect_b.item_id, AnchorType.CENTER)
+        target_cm = 800.0  # 8 m
+
+        graph = canvas._canvas_scene.constraint_graph
+        command = AddConstraintCommand(
+            graph, ref_a, ref_b, target_cm, constraint_type=ConstraintType.DISTANCE
+        )
+        canvas._execute_constraint_with_solve(command)
+
+        pos_b_after = rect_b.pos()
+
+        # B must not have moved at all (pos() is the Qt item position offset).
+        assert pos_b_after.x() == pytest.approx(pos_b_before.x(), abs=0.1), (
+            "Item B (reference) must not move when a distance constraint is added"
+        )
+        assert pos_b_after.y() == pytest.approx(pos_b_before.y(), abs=0.1), (
+            "Item B (reference) must not move when a distance constraint is added"
+        )
+
+        # The resulting anchor-to-anchor (centre-to-centre) distance must equal
+        # the target.  RectangleItem uses QGraphicsRectItem(x, y, w, h) which
+        # stores the rect in local coords, so the scene centre is
+        # item.mapToScene(item.rect().center()), NOT just item.pos().
+        centre_a = rect_a.mapToScene(rect_a.rect().center())
+        centre_b = rect_b.mapToScene(rect_b.rect().center())
+        dist = math.sqrt(
+            (centre_b.x() - centre_a.x()) ** 2
+            + (centre_b.y() - centre_a.y()) ** 2
+        )
+        assert abs(dist - target_cm) < 1.0, (
+            f"Distance constraint not satisfied: got {dist:.1f} cm, expected {target_cm} cm"
+        )
+
+    def test_item_a_moves_full_correction_not_half(
+        self, canvas: CanvasView, qtbot: object
+    ) -> None:
+        """A moves by the full correction (not just half) when B is the reference.
+
+        Before the fix, each item moved by half the error (50/50 split).
+        After the fix, A moves by the full 200 cm correction; B stays.
+        """
+        rect_a = _draw_rect(canvas, 0, 0, 100, 100)
+        rect_b = _draw_rect(canvas, 1000, 0, 1100, 100)
+
+        # Use scene-space centre because RectangleItem stores the rect in local
+        # coordinates; pos() alone is not sufficient.
+        centre_a_before = rect_a.mapToScene(rect_a.rect().center())
+
+        ref_a = AnchorRef(rect_a.item_id, AnchorType.CENTER)
+        ref_b = AnchorRef(rect_b.item_id, AnchorType.CENTER)
+        target_cm = 800.0
+
+        graph = canvas._canvas_scene.constraint_graph
+        command = AddConstraintCommand(
+            graph, ref_a, ref_b, target_cm, constraint_type=ConstraintType.DISTANCE
+        )
+        canvas._execute_constraint_with_solve(command)
+
+        centre_a_after = rect_a.mapToScene(rect_a.rect().center())
+        # A should have moved ~200 cm (the full correction), not ~100 cm (the half).
+        delta_a = abs(centre_a_after.x() - centre_a_before.x())
+        assert delta_a > 150.0, (
+            f"A moved only {delta_a:.1f} cm — looks like the old 50/50 split is still active"
+        )

--- a/tests/unit/test_constraint_drag.py
+++ b/tests/unit/test_constraint_drag.py
@@ -248,6 +248,37 @@ class TestSolveAnchored:
         result = graph.solve_anchored(positions, {})
         assert id_center in result.over_constrained_items
 
+    def test_b_pinned_as_reference_only_a_moves(self, qtbot) -> None:
+        """Pinning B as reference: only A moves to satisfy the distance.
+
+        This mirrors the CAD convention applied by _execute_constraint_with_solve:
+        anchor B's item_id is passed in extra_pinned (which becomes pinned_items
+        in solve_anchored) so that B stays fixed and A moves the full correction.
+        Scenario from issue #139: objects 10 m apart, target 8 m.
+        """
+        graph = ConstraintGraph()
+        id_a, id_b = uuid4(), uuid4()
+        graph.add_constraint(
+            AnchorRef(id_a, AnchorType.CENTER),
+            AnchorRef(id_b, AnchorType.CENTER),
+            800.0,  # target: 8 m
+        )
+        positions = {id_a: (0.0, 0.0), id_b: (1000.0, 0.0)}  # 10 m apart
+        anchor_offsets = {
+            (id_a, AnchorType.CENTER, 0): (0.0, 0.0),
+            (id_b, AnchorType.CENTER, 0): (0.0, 0.0),
+        }
+
+        # B is passed as pinned — simulates _compute_constraint_solve_moves(extra_pinned={id_b})
+        result = graph.solve_anchored(positions, anchor_offsets, pinned_items={id_b})
+
+        assert result.converged
+        assert id_b not in result.item_deltas, "B (reference) must not move"
+        assert id_a in result.item_deltas, "A must move to satisfy the constraint"
+        new_ax = 0.0 + result.item_deltas[id_a][0]
+        dist = abs(1000.0 - new_ax)
+        assert abs(dist - 800.0) < 1.0, f"Constraint unsatisfied: dist={dist}, target=800"
+
 
 # --- Delete cascade tests ---
 


### PR DESCRIPTION
## Summary

- When setting a distance constraint between two free-floating objects, only the first-clicked item (A) now moves to satisfy the distance; the second-clicked item (B) acts as the fixed reference (CAD convention: A is constrained to B)
- Same fix applied to the edit-constraint-distance workflow
- Exception preserved: if A already has a FIXED constraint, the solver correctly moves B instead (existing behaviour unchanged)

Closes #139

## Implementation

Added `extra_pinned` parameter to `_compute_constraint_solve_moves()` and pass `{anchor_b.item_id}` from `_execute_constraint_with_solve()` and the edit-distance handler, so the Gauss-Seidel solver treats B as pinned during the creation/edit solve pass. The solver itself is unchanged — the fix is purely at the call site.

## Test plan

- [x] New unit test: `test_b_pinned_as_reference_only_a_moves` in `test_constraint_drag.py` — verifies solver moves only A when B is pinned
- [x] New integration tests in `test_constraint_creation.py`:
  - `test_only_item_a_moves_when_distance_constraint_added` — B stays fixed, anchor distance = target after apply
  - `test_item_a_moves_full_correction_not_half` — A moves the full 200 cm, not 100 cm (the old 50/50 split)
- [x] Full suite: 1871 tests pass
- [x] ruff — clean
- [x] bandit (high severity) — no issues
- [x] Manually verified: tree moves toward terrace, terrace stays put

🤖 Generated with [Claude Code](https://claude.com/claude-code)