### PR TITLE
chore: sync version to v1.8.32 after DI-1 constraint bug fix PR #141

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "open-garden-planner"
-version = "1.8.31"
+version = "1.8.32"
 description = "Open-source garden planning tool with CAD-like precision"
 readme = "README.md"
 license = {text = "GPL-3.0-or-later"}

--- a/src/open_garden_planner/__init__.py
+++ b/src/open_garden_planner/__init__.py
@@ -5,5 +5,5 @@
 # so this value only matters when running from source (dev mode).
 # Run: git fetch --tags && git describe --tags --abbrev=0
 # then set this to the new tag (without the leading "v").
-__version__ = "1.8.31"
+__version__ = "1.8.32"
 __author__ = "cofade"


### PR DESCRIPTION
Syncs `pyproject.toml` and `src/open_garden_planner/__init__.py` to `v1.8.32` following the CI release after PR #141 (fix: distance constraint moves both items — issue #139).