### PR TITLE
fix(#137, #138): embed background image as base64 + move-to-layer context menu

### DIFF
--- a/src/open_garden_planner/core/commands.py
+++ b/src/open_garden_planner/core/commands.py
@@ -1174,3 +1174,55 @@ class ArrayAlongPathCommand(Command):
         for item in self._items:
             if item.scene() is not None:
                 self._scene.removeItem(item)
+
+
+class MoveToLayerCommand(Command):
+    """Move one or more scene items to a different layer (undoable).
+
+    Snapshots each item's current ``layer_id`` at construction time so that
+    undo restores every item to its individual original layer, even when items
+    come from different layers before the move.
+    """
+
+    def __init__(
+        self,
+        items: list[QGraphicsItem],
+        target_layer_id: UUID,
+        scene: QGraphicsScene,
+        target_layer_name: str,
+    ) -> None:
+        """Initialise the command.
+
+        Args:
+            items: Items to move (must have a ``layer_id`` attribute).
+            target_layer_id: UUID of the destination layer.
+            scene: The canvas scene (used to refresh visibility and z-order).
+            target_layer_name: Human-readable name of the target layer
+                (used in the undo description only; not looked up at undo time).
+        """
+        # Snapshot (item, original_layer_id) at construction — before any move
+        self._moves: list[tuple[QGraphicsItem, UUID | None]] = [
+            (item, item.layer_id) for item in items  # type: ignore[union-attr]
+        ]
+        self._target_layer_id = target_layer_id
+        self._scene = scene
+        self._target_layer_name = target_layer_name
+
+    @property
+    def description(self) -> str:
+        n = len(self._moves)
+        return f"Move {n} item(s) to layer '{self._target_layer_name}'"
+
+    def execute(self) -> None:
+        """Assign all items to the target layer and refresh scene visuals."""
+        for item, _ in self._moves:
+            item.layer_id = self._target_layer_id  # type: ignore[union-attr]
+        self._scene._update_items_visibility()  # type: ignore[attr-defined]
+        self._scene._update_items_z_order()  # type: ignore[attr-defined]
+
+    def undo(self) -> None:
+        """Restore each item to its original layer and refresh scene visuals."""
+        for item, old_layer_id in self._moves:
+            item.layer_id = old_layer_id  # type: ignore[union-attr]
+        self._scene._update_items_visibility()  # type: ignore[attr-defined]
+        self._scene._update_items_z_order()  # type: ignore[attr-defined]

--- a/src/open_garden_planner/ui/canvas/items/background_image_item.py
+++ b/src/open_garden_planner/ui/canvas/items/background_image_item.py
@@ -4,7 +4,9 @@ Displays an imported image (satellite photo, etc.) that can be calibrated
 to real-world scale.
 """
 
-from PyQt6.QtCore import QPointF
+import base64
+
+from PyQt6.QtCore import QBuffer, QByteArray, QIODevice, QPointF
 from PyQt6.QtGui import QPixmap
 from PyQt6.QtWidgets import (
     QGraphicsItem,
@@ -26,12 +28,16 @@ class BackgroundImageItem(QGraphicsPixmapItem):
         self,
         image_path: str,
         parent: QGraphicsItem | None = None,
+        *,
+        _pixmap_data: bytes | None = None,
     ) -> None:
         """Initialize the background image item.
 
         Args:
-            image_path: Path to the image file
+            image_path: Path to the image file (used as display hint when _pixmap_data is given)
             parent: Parent graphics item
+            _pixmap_data: Raw PNG bytes to load from (internal use by from_dict only).
+                When provided, image_path is stored as a hint only and the file need not exist.
         """
         super().__init__(parent)
 
@@ -40,10 +46,16 @@ class BackgroundImageItem(QGraphicsPixmapItem):
         self._locked = False
         self._scale_factor = 1.0  # pixels per cm after calibration
 
-        # Load the image
-        self._original_pixmap = QPixmap(image_path)
-        if self._original_pixmap.isNull():
-            raise ValueError(f"Failed to load image: {image_path}")
+        # Load the image — either from embedded bytes or from disk path
+        if _pixmap_data is not None:
+            self._original_pixmap = QPixmap()
+            self._original_pixmap.loadFromData(QByteArray(_pixmap_data))
+            if self._original_pixmap.isNull():
+                raise ValueError("Failed to load image from embedded data")
+        else:
+            self._original_pixmap = QPixmap(image_path)
+            if self._original_pixmap.isNull():
+                raise ValueError(f"Failed to load image: {image_path}")
 
         # Flip vertically to compensate for view's Y-flip transform (CAD convention)
         from PyQt6.QtGui import QTransform
@@ -142,10 +154,22 @@ class BackgroundImageItem(QGraphicsPixmapItem):
         return w / self._scale_factor, h / self._scale_factor
 
     def to_dict(self) -> dict:
-        """Serialize the item to a dictionary for saving."""
+        """Serialize the item to a dictionary for saving.
+
+        The original pixmap is embedded as a base64-encoded PNG so that the
+        project file is self-contained and portable across machines.
+        ``image_path`` is kept as a human-readable hint only — it is not used
+        when loading if ``image_data`` is present.
+        """
+        buf = QBuffer()
+        buf.open(QIODevice.OpenModeFlag.WriteOnly)
+        self._original_pixmap.save(buf, "PNG")
+        image_data_b64 = base64.b64encode(bytes(buf.data())).decode("ascii")
+        buf.close()
         return {
             "type": "background_image",
             "image_path": self._image_path,
+            "image_data": image_data_b64,
             "position": {"x": self.pos().x(), "y": self.pos().y()},
             "opacity": self._opacity,
             "locked": self._locked,
@@ -154,15 +178,23 @@ class BackgroundImageItem(QGraphicsPixmapItem):
 
     @classmethod
     def from_dict(cls, data: dict) -> "BackgroundImageItem":
-        """Create an item from a dictionary."""
-        item = cls(data["image_path"])
+        """Create an item from a dictionary.
+
+        Prefers ``image_data`` (base64 PNG, portable) when present; falls back
+        to ``image_path`` for legacy project files that pre-date embedding.
+        """
+        image_path = data.get("image_path", "")
+        if "image_data" in data:
+            pixmap_bytes = base64.b64decode(data["image_data"])
+            item = cls(image_path, _pixmap_data=pixmap_bytes)
+        else:
+            item = cls(image_path)
         item.setPos(QPointF(data["position"]["x"], data["position"]["y"]))
         item.opacity = data.get("opacity", 1.0)
         item.locked = data.get("locked", False)
         item._scale_factor = data.get("scale_factor", 1.0)
         # Apply saved scale
-        scale = 1.0 / item._scale_factor
-        item.setScale(scale)
+        item.setScale(1.0 / item._scale_factor)
         return item
 
     def contextMenuEvent(self, event: QGraphicsSceneContextMenuEvent) -> None:

--- a/src/open_garden_planner/ui/canvas/items/circle_item.py
+++ b/src/open_garden_planner/ui/canvas/items/circle_item.py
@@ -766,6 +766,11 @@ class CircleItem(RotationHandleMixin, ResizeHandlesMixin, GardenItemMixin, QGrap
 
         menu = QMenu()
 
+        # Move to Layer submenu (hidden when project has only one layer)
+        move_layer_menu = self._build_move_to_layer_menu(menu)
+
+        menu.addSeparator()
+
         # Delete action
         delete_action = menu.addAction("Delete")
 
@@ -866,6 +871,8 @@ class CircleItem(RotationHandleMixin, ResizeHandlesMixin, GardenItemMixin, QGrap
                     if hasattr(v, "create_array_along_path"):
                         v.create_array_along_path()
                         break
+        elif move_layer_menu and action and action.parent() is move_layer_menu:
+            self._dispatch_move_to_layer(action.data())
 
     def to_dict(self) -> dict:
         """Serialize the item to a dictionary for saving."""

--- a/src/open_garden_planner/ui/canvas/items/garden_item.py
+++ b/src/open_garden_planner/ui/canvas/items/garden_item.py
@@ -1,11 +1,14 @@
 """Base mixin for garden canvas items."""
 
 import uuid
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from PyQt6.QtCore import Qt
 from PyQt6.QtGui import QColor, QFont
 from PyQt6.QtWidgets import QGraphicsSimpleTextItem, QGraphicsTextItem
+
+if TYPE_CHECKING:
+    from PyQt6.QtWidgets import QMenu
 
 from open_garden_planner.core.fill_patterns import FillPattern
 from open_garden_planner.core.object_types import ObjectType, StrokeStyle
@@ -693,3 +696,51 @@ class GardenItemMixin:
         # Show the static label again
         if self._label_item is not None:
             self._label_item.show()
+
+    # ------------------------------------------------------------------
+    # Layer-assignment helpers (shared by all item context menus)
+    # ------------------------------------------------------------------
+
+    def _build_move_to_layer_menu(self, parent_menu: "QMenu") -> "QMenu | None":
+        """Append a 'Move to Layer' submenu to *parent_menu* and return it.
+
+        Returns ``None`` when there is only one layer (nothing to move to) or
+        when the item has no scene, in which case nothing is added to the menu.
+        """
+        from PyQt6.QtCore import QCoreApplication
+        from PyQt6.QtWidgets import QMenu
+
+        scene = self.scene()  # type: ignore[attr-defined]
+        if not scene or not hasattr(scene, "layers"):
+            return None
+        layers = scene.layers
+        if len(layers) <= 1:
+            return None
+        label = QCoreApplication.translate("GardenItemMixin", "Move to Layer")
+        layer_menu: QMenu = parent_menu.addMenu(label)
+        for layer in layers:
+            if layer.id != self._layer_id:
+                action = layer_menu.addAction(layer.name)
+                action.setData(layer.id)
+        return layer_menu
+
+    def _dispatch_move_to_layer(self, target_layer_id: "uuid.UUID") -> None:
+        """Move all selected items (or just *self*) to *target_layer_id*.
+
+        Wraps the change in a :class:`MoveToLayerCommand` so that it is
+        fully undoable via the command manager.
+        """
+        from open_garden_planner.core.commands import MoveToLayerCommand
+
+        scene = self.scene()  # type: ignore[attr-defined]
+        if not scene:
+            return
+        selected = [i for i in scene.selectedItems() if hasattr(i, "layer_id")]
+        items = selected if selected else [self]
+        target_layer = scene.get_layer_by_id(target_layer_id)
+        layer_name = target_layer.name if target_layer else str(target_layer_id)
+        cmd = MoveToLayerCommand(items, target_layer_id, scene, layer_name)
+        if scene._command_manager:  # type: ignore[attr-defined]
+            scene._command_manager.execute(cmd)  # type: ignore[attr-defined]
+        else:
+            cmd.execute()  # graceful fallback (e.g. in unit tests without CanvasView)

--- a/src/open_garden_planner/ui/canvas/items/group_item.py
+++ b/src/open_garden_planner/ui/canvas/items/group_item.py
@@ -81,6 +81,12 @@ class GroupItem(GardenItemMixin, QGraphicsItemGroup):
         """Show ungroup action in the context menu."""
         menu = QMenu()
         ungroup_action = menu.addAction("Ungroup")
+
+        menu.addSeparator()
+
+        # Move to Layer submenu (hidden when project has only one layer)
+        move_layer_menu = self._build_move_to_layer_menu(menu)
+
         action = menu.exec(event.screenPos())
         if action == ungroup_action:
             scene = self.scene()
@@ -88,3 +94,5 @@ class GroupItem(GardenItemMixin, QGraphicsItemGroup):
                 views = scene.views()
                 if views and hasattr(views[0], "ungroup_item"):
                     views[0].ungroup_item(self)
+        elif move_layer_menu and action and action.parent() is move_layer_menu:
+            self._dispatch_move_to_layer(action.data())

--- a/src/open_garden_planner/ui/canvas/items/polygon_item.py
+++ b/src/open_garden_planner/ui/canvas/items/polygon_item.py
@@ -809,6 +809,11 @@ class PolygonItem(VertexEditMixin, RotationHandleMixin, ResizeHandlesMixin, Gard
 
         menu.addSeparator()
 
+        # Move to Layer submenu (hidden when project has only one layer)
+        move_layer_menu = self._build_move_to_layer_menu(menu)
+
+        menu.addSeparator()
+
         # Delete action
         delete_action = menu.addAction("Delete")
 
@@ -935,6 +940,8 @@ class PolygonItem(VertexEditMixin, RotationHandleMixin, ResizeHandlesMixin, Gard
                     if hasattr(v, "create_array_along_path"):
                         v.create_array_along_path()
                         break
+        elif move_layer_menu and action and action.parent() is move_layer_menu:
+            self._dispatch_move_to_layer(action.data())
 
     @classmethod
     def from_polygon(cls, polygon: QPolygonF) -> "PolygonItem":

--- a/src/open_garden_planner/ui/canvas/items/polyline_item.py
+++ b/src/open_garden_planner/ui/canvas/items/polyline_item.py
@@ -904,6 +904,11 @@ class PolylineItem(PolylineVertexEditMixin, RotationHandleMixin, GardenItemMixin
 
         menu.addSeparator()
 
+        # Move to Layer submenu (hidden when project has only one layer)
+        move_layer_menu = self._build_move_to_layer_menu(menu)
+
+        menu.addSeparator()
+
         # Delete action
         delete_action = menu.addAction("Delete")
 
@@ -992,3 +997,5 @@ class PolylineItem(PolylineVertexEditMixin, RotationHandleMixin, GardenItemMixin
                     if hasattr(v, "create_array_along_path"):
                         v.create_array_along_path()
                         break
+        elif move_layer_menu and action and action.parent() is move_layer_menu:
+            self._dispatch_move_to_layer(action.data())

--- a/src/open_garden_planner/ui/canvas/items/rectangle_item.py
+++ b/src/open_garden_planner/ui/canvas/items/rectangle_item.py
@@ -544,6 +544,11 @@ class RectangleItem(RectVertexEditMixin, RotationHandleMixin, ResizeHandlesMixin
 
         menu.addSeparator()
 
+        # Move to Layer submenu (hidden when project has only one layer)
+        move_layer_menu = self._build_move_to_layer_menu(menu)
+
+        menu.addSeparator()
+
         # Delete action
         delete_action = menu.addAction("Delete")
 
@@ -670,6 +675,8 @@ class RectangleItem(RectVertexEditMixin, RotationHandleMixin, ResizeHandlesMixin
                     if hasattr(v, "create_array_along_path"):
                         v.create_array_along_path()
                         break
+        elif move_layer_menu and action and action.parent() is move_layer_menu:
+            self._dispatch_move_to_layer(action.data())
 
     @classmethod
     def from_rect(cls, rect: QRectF) -> "RectangleItem":

--- a/src/open_garden_planner/ui/canvas/items/text_item.py
+++ b/src/open_garden_planner/ui/canvas/items/text_item.py
@@ -229,6 +229,12 @@ class TextItem(RotationHandleMixin, GardenItemMixin, QGraphicsTextItem):
         menu = QMenu()
 
         edit_action = menu.addAction(self.tr("Edit Text"))
+
+        menu.addSeparator()
+
+        # Move to Layer submenu (hidden when project has only one layer)
+        move_layer_menu = self._build_move_to_layer_menu(menu)
+
         menu.addSeparator()
         delete_action = menu.addAction(self.tr("Delete"))
 
@@ -239,6 +245,8 @@ class TextItem(RotationHandleMixin, GardenItemMixin, QGraphicsTextItem):
             scene = self.scene()
             if scene:
                 scene.removeItem(self)
+        elif move_layer_menu and chosen and chosen.parent() is move_layer_menu:
+            self._dispatch_move_to_layer(chosen.data())
 
     # ── Visual / bounding ────────────────────────────────────────
 

--- a/tests/integration/test_background_image_portable.py
+++ b/tests/integration/test_background_image_portable.py
@@ -1,0 +1,136 @@
+"""Integration tests: BackgroundImageItem portability across machines (issue #137).
+
+Verifies that:
+  - Background images are embedded as base64 in the saved .ogp project file.
+  - A project reloads its background image correctly even after the original
+    source file has been deleted (simulating "open on another PC").
+  - Legacy project files (no image_data key) still load without crashing.
+"""
+
+# ruff: noqa: ARG002
+
+import json
+from pathlib import Path
+
+import pytest
+from PyQt6.QtGui import QPixmap
+
+from open_garden_planner.core.project import ProjectManager
+from open_garden_planner.ui.canvas.canvas_scene import CanvasScene
+from open_garden_planner.ui.canvas.items.background_image_item import BackgroundImageItem
+
+
+@pytest.fixture()
+def png_image(tmp_path: Path) -> Path:
+    """Create a small test PNG and return its path."""
+    pixmap = QPixmap(64, 64)
+    pixmap.fill()
+    path = tmp_path / "test_bg.png"
+    pixmap.save(str(path))
+    return path
+
+
+class TestBackgroundImagePortability:
+    """End-to-end portability tests for background image embedding."""
+
+    def test_saved_project_contains_image_data_key(
+        self, qtbot, png_image: Path, tmp_path: Path
+    ) -> None:
+        """Saving a project with a background image must embed image_data in the JSON."""
+        scene = CanvasScene(width_cm=5000, height_cm=3000)
+        scene.addItem(BackgroundImageItem(str(png_image)))
+
+        project = ProjectManager()
+        save_path = tmp_path / "test_project.ogp"
+        project.save(scene, save_path)
+
+        with open(save_path, encoding="utf-8") as f:
+            saved = json.load(f)
+
+        bg_items = [
+            obj for obj in saved.get("objects", []) if obj.get("type") == "background_image"
+        ]
+        assert len(bg_items) == 1, "Expected exactly one background_image object in saved JSON"
+        assert "image_data" in bg_items[0], (
+            "background_image must have 'image_data' key for portability"
+        )
+        assert isinstance(bg_items[0]["image_data"], str)
+        assert len(bg_items[0]["image_data"]) > 0
+
+    def test_project_loads_background_image_without_source_file(
+        self, qtbot, png_image: Path, tmp_path: Path
+    ) -> None:
+        """After deleting the source image, the project still loads the background image."""
+        # Save with the source file present
+        scene = CanvasScene(width_cm=5000, height_cm=3000)
+        bg_item = BackgroundImageItem(str(png_image))
+        bg_item.opacity = 0.6
+        bg_item.calibrate(pixels=64, centimeters=200)
+        scene.addItem(bg_item)
+
+        project = ProjectManager()
+        save_path = tmp_path / "portable_test.ogp"
+        project.save(scene, save_path)
+
+        # Delete the source file — simulates opening on another PC
+        png_image.unlink()
+        assert not png_image.exists()
+
+        # Load into a fresh scene
+        fresh_scene = CanvasScene(width_cm=5000, height_cm=3000)
+        fresh_project = ProjectManager()
+        fresh_project.load(fresh_scene, save_path)
+
+        bg_items = [
+            item
+            for item in fresh_scene.items()
+            if isinstance(item, BackgroundImageItem)
+        ]
+        assert len(bg_items) == 1, "Background image should be present after loading"
+        restored = bg_items[0]
+        assert not restored.pixmap().isNull(), "Restored pixmap must not be null"
+        assert restored.opacity == pytest.approx(0.6)
+        assert restored.scale_factor == pytest.approx(64 / 200)
+
+    def test_legacy_project_without_image_data_loads_gracefully(
+        self, qtbot, tmp_path: Path
+    ) -> None:
+        """Legacy .ogp files that only have image_path (no image_data) load without crashing.
+
+        The background image is silently dropped when the path is invalid — this is the
+        existing behaviour for missing files and must be preserved for backward compatibility.
+        """
+        legacy_project = {
+            "version": "1.0",
+            "canvas": {"width_cm": 500, "height_cm": 300},
+            "layers": [
+                {"id": "00000000-0000-0000-0000-000000000001", "name": "Layer 1",
+                 "visible": True, "locked": False, "opacity": 1.0, "z_order": 0}
+            ],
+            "objects": [
+                {
+                    "type": "background_image",
+                    "image_path": "/nonexistent/path/on/disk.png",
+                    # No 'image_data' key — this is the legacy format
+                    "position": {"x": 0.0, "y": 0.0},
+                    "opacity": 1.0,
+                    "locked": False,
+                    "scale_factor": 1.0,
+                }
+            ],
+        }
+        save_path = tmp_path / "legacy.ogp"
+        with open(save_path, "w", encoding="utf-8") as f:
+            json.dump(legacy_project, f)
+
+        scene = CanvasScene(width_cm=5000, height_cm=3000)
+        project = ProjectManager()
+        # Must not raise — the missing background image is silently ignored
+        project.load(scene, save_path)
+
+        bg_items = [
+            item for item in scene.items() if isinstance(item, BackgroundImageItem)
+        ]
+        assert len(bg_items) == 0, (
+            "Background image with invalid legacy path should be silently dropped, not crash"
+        )

--- a/tests/integration/test_move_to_layer.py
+++ b/tests/integration/test_move_to_layer.py
@@ -1,0 +1,187 @@
+"""Integration tests: Move-to-layer via context menu (issue #138).
+
+Verifies that:
+  - MoveToLayerCommand correctly reassigns item.layer_id and refreshes the scene.
+  - The command integrates with the CommandManager for full undo/redo support.
+  - Multi-selection moves all selected items at once (with individual undo per item).
+  - The 'Move to Layer' submenu is suppressed when only one layer exists.
+"""
+
+# ruff: noqa: ARG002
+
+import uuid
+from unittest.mock import MagicMock
+
+import pytest
+from PyQt6.QtCore import QPointF, Qt
+from PyQt6.QtGui import QMouseEvent
+
+from open_garden_planner.core.commands import MoveToLayerCommand
+from open_garden_planner.core.tools import ToolType
+from open_garden_planner.models.layer import Layer
+from open_garden_planner.ui.canvas.canvas_scene import CanvasScene
+from open_garden_planner.ui.canvas.canvas_view import CanvasView
+from open_garden_planner.ui.canvas.items import RectangleItem
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _add_layer(scene: CanvasScene, name: str) -> Layer:
+    """Add a new named layer to the scene and return it."""
+    layer = Layer(id=uuid.uuid4(), name=name, z_order=len(scene.layers))
+    scene.add_layer(layer)
+    return layer
+
+
+def _draw_rect(view: CanvasView, x1: float, y1: float, x2: float, y2: float) -> RectangleItem:
+    """Draw a rectangle via the tool API and return the resulting scene item."""
+    event = MagicMock(spec=QMouseEvent)
+    event.button.return_value = Qt.MouseButton.LeftButton
+    event.buttons.return_value = Qt.MouseButton.LeftButton
+    event.modifiers.return_value = Qt.KeyboardModifier.NoModifier
+
+    view.set_active_tool(ToolType.RECTANGLE)
+    tool = view.tool_manager.active_tool
+    tool.mouse_press(event, QPointF(x1, y1))
+    tool.mouse_move(event, QPointF(x2, y2))
+    tool.mouse_release(event, QPointF(x2, y2))
+
+    items = [i for i in view.scene().items() if isinstance(i, RectangleItem)]
+    return items[-1]  # the most recently added
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestMoveToLayerCommand:
+    """Unit-level tests for MoveToLayerCommand through the CommandManager."""
+
+    def test_move_single_item_changes_layer_id(self, canvas: CanvasView, qtbot) -> None:
+        """Executing MoveToLayerCommand assigns the item to the target layer."""
+        scene = canvas.scene()
+        layer2 = _add_layer(scene, "Layer 2")
+
+        item = _draw_rect(canvas, 100, 100, 300, 200)
+        original_layer_id = item.layer_id
+        assert original_layer_id != layer2.id
+
+        cmd = MoveToLayerCommand([item], layer2.id, scene, "Layer 2")
+        canvas.command_manager.execute(cmd)
+
+        assert item.layer_id == layer2.id
+
+    def test_undo_restores_original_layer(self, canvas: CanvasView, qtbot) -> None:
+        """Undoing MoveToLayerCommand returns the item to its previous layer."""
+        scene = canvas.scene()
+        layer2 = _add_layer(scene, "Layer 2")
+
+        item = _draw_rect(canvas, 100, 100, 300, 200)
+        original_layer_id = item.layer_id
+
+        cmd = MoveToLayerCommand([item], layer2.id, scene, "Layer 2")
+        canvas.command_manager.execute(cmd)
+        assert item.layer_id == layer2.id
+
+        canvas.command_manager.undo()
+        assert item.layer_id == original_layer_id
+
+    def test_redo_reapplies_move(self, canvas: CanvasView, qtbot) -> None:
+        """Redo after undo re-assigns the item to the target layer."""
+        scene = canvas.scene()
+        layer2 = _add_layer(scene, "Layer 2")
+
+        item = _draw_rect(canvas, 100, 100, 300, 200)
+
+        cmd = MoveToLayerCommand([item], layer2.id, scene, "Layer 2")
+        canvas.command_manager.execute(cmd)
+        canvas.command_manager.undo()
+        canvas.command_manager.redo()
+
+        assert item.layer_id == layer2.id
+
+    def test_move_multi_selection_moves_all_items(self, canvas: CanvasView, qtbot) -> None:
+        """Moving multiple items at once works; each item's old layer is captured individually."""
+        scene = canvas.scene()
+        layer2 = _add_layer(scene, "Layer 2")
+
+        item1 = _draw_rect(canvas, 100, 100, 200, 200)
+        item2 = _draw_rect(canvas, 300, 100, 400, 200)
+        old_layer1 = item1.layer_id
+        old_layer2 = item2.layer_id
+
+        cmd = MoveToLayerCommand([item1, item2], layer2.id, scene, "Layer 2")
+        canvas.command_manager.execute(cmd)
+
+        assert item1.layer_id == layer2.id
+        assert item2.layer_id == layer2.id
+
+        canvas.command_manager.undo()
+
+        assert item1.layer_id == old_layer1
+        assert item2.layer_id == old_layer2
+
+    def test_command_description_reflects_item_count(self, canvas: CanvasView, qtbot) -> None:
+        """The command description names the target layer and item count."""
+        scene = canvas.scene()
+        layer2 = _add_layer(scene, "My Garden Layer")
+
+        item = _draw_rect(canvas, 100, 100, 300, 200)
+        cmd = MoveToLayerCommand([item], layer2.id, scene, "My Garden Layer")
+
+        assert "My Garden Layer" in cmd.description
+        assert "1" in cmd.description
+
+
+class TestMoveToLayerMenuVisibility:
+    """Tests for the 'Move to Layer' submenu helper on GardenItemMixin."""
+
+    def test_submenu_absent_when_only_one_layer(self, canvas: CanvasView, qtbot) -> None:
+        """_build_move_to_layer_menu returns None when the project has a single layer."""
+        from PyQt6.QtWidgets import QMenu
+
+        item = _draw_rect(canvas, 100, 100, 300, 200)
+        # Default canvas has one layer only
+        assert len(canvas.scene().layers) == 1
+
+        parent_menu = QMenu()
+        result = item._build_move_to_layer_menu(parent_menu)
+        assert result is None
+
+    def test_submenu_present_when_multiple_layers(self, canvas: CanvasView, qtbot) -> None:
+        """_build_move_to_layer_menu returns a QMenu when ≥2 layers exist."""
+        from PyQt6.QtWidgets import QMenu
+
+        scene = canvas.scene()
+        _add_layer(scene, "Layer 2")
+        assert len(scene.layers) == 2
+
+        item = _draw_rect(canvas, 100, 100, 300, 200)
+
+        parent_menu = QMenu()
+        result = item._build_move_to_layer_menu(parent_menu)
+        assert result is not None
+
+    def test_submenu_excludes_current_layer(self, canvas: CanvasView, qtbot) -> None:
+        """The 'Move to Layer' submenu does not list the item's current layer."""
+        from PyQt6.QtWidgets import QMenu
+
+        scene = canvas.scene()
+        layer2 = _add_layer(scene, "Layer 2")
+
+        item = _draw_rect(canvas, 100, 100, 300, 200)
+        current_layer_id = item.layer_id
+
+        parent_menu = QMenu()
+        submenu = item._build_move_to_layer_menu(parent_menu)
+        assert submenu is not None
+
+        action_datas = [a.data() for a in submenu.actions()]
+        assert current_layer_id not in action_datas, (
+            "Current layer must not appear in 'Move to Layer' submenu"
+        )
+        assert layer2.id in action_datas

--- a/tests/unit/test_background_image_item.py
+++ b/tests/unit/test_background_image_item.py
@@ -145,7 +145,13 @@ class TestBackgroundImageItem:
         assert height == pytest.approx(200.0)
 
     def test_to_dict(self, qtbot, test_image_path: Path) -> None:
-        """Test serialization to dictionary."""
+        """Test serialization to dictionary.
+
+        Verifies that image data is embedded as base64 (portable) and that all
+        other fields are preserved correctly.
+        """
+        import base64
+
         item = BackgroundImageItem(str(test_image_path))
         item.setPos(QPointF(100, 200))
         item.opacity = 0.7
@@ -155,18 +161,55 @@ class TestBackgroundImageItem:
         data = item.to_dict()
 
         assert data["type"] == "background_image"
+        # image_path is kept as a human-readable hint
         assert data["image_path"] == str(test_image_path)
+        # image_data must be present and must be valid base64-encoded bytes
+        assert "image_data" in data
+        assert isinstance(data["image_data"], str)
+        decoded = base64.b64decode(data["image_data"])
+        assert len(decoded) > 0
         assert data["position"]["x"] == pytest.approx(100.0)
         assert data["position"]["y"] == pytest.approx(200.0)
         assert data["opacity"] == pytest.approx(0.7)
         assert data["locked"] is True
         assert data["scale_factor"] == pytest.approx(0.2)
 
-    def test_from_dict(self, qtbot, test_image_path: Path) -> None:
-        """Test deserialization from dictionary."""
+    def test_from_dict_with_image_data(self, qtbot, test_image_path: Path) -> None:
+        """Test deserialization from a dict that contains embedded image_data.
+
+        The source file path need not be valid — the image is loaded from
+        the base64-encoded PNG bytes.
+        """
+        # Generate base64 payload from the fixture image
+        source = BackgroundImageItem(str(test_image_path))
+        embedded_data = source.to_dict()["image_data"]
+
         data = {
             "type": "background_image",
-            "image_path": str(test_image_path),
+            "image_path": "/nonexistent/path/photo.png",  # intentionally invalid
+            "image_data": embedded_data,
+            "position": {"x": 150.0, "y": 250.0},
+            "opacity": 0.8,
+            "locked": True,
+            "scale_factor": 0.3,
+        }
+
+        item = BackgroundImageItem.from_dict(data)
+
+        assert item.image_path == "/nonexistent/path/photo.png"
+        assert not item.pixmap().isNull()
+        assert item.pos().x() == pytest.approx(150.0)
+        assert item.pos().y() == pytest.approx(250.0)
+        assert item.opacity == pytest.approx(0.8)
+        assert item.locked is True
+        assert item.scale_factor == pytest.approx(0.3)
+        assert item.scale() == pytest.approx(1.0 / 0.3)
+
+    def test_from_dict_legacy_path_only(self, qtbot, test_image_path: Path) -> None:
+        """Test backward-compat: old project files with only image_path still load."""
+        data = {
+            "type": "background_image",
+            "image_path": str(test_image_path),  # valid path, no image_data
             "position": {"x": 150.0, "y": 250.0},
             "opacity": 0.8,
             "locked": True,
@@ -176,31 +219,48 @@ class TestBackgroundImageItem:
         item = BackgroundImageItem.from_dict(data)
 
         assert item.image_path == str(test_image_path)
+        assert not item.pixmap().isNull()
         assert item.pos().x() == pytest.approx(150.0)
         assert item.pos().y() == pytest.approx(250.0)
         assert item.opacity == pytest.approx(0.8)
         assert item.locked is True
         assert item.scale_factor == pytest.approx(0.3)
-        # Scale should be 1/0.3 ≈ 3.33
         assert item.scale() == pytest.approx(1.0 / 0.3)
 
     def test_round_trip_serialization(self, qtbot, test_image_path: Path) -> None:
-        """Test that serialization and deserialization preserve data."""
-        # Create an item with specific properties
+        """Test that serialization and deserialization preserve all data."""
         original = BackgroundImageItem(str(test_image_path))
         original.setPos(QPointF(50, 75))
         original.opacity = 0.6
         original.locked = False
         original.calibrate(pixels=100, centimeters=400)
 
-        # Serialize and deserialize
         data = original.to_dict()
         restored = BackgroundImageItem.from_dict(data)
 
-        # Verify all properties match
         assert restored.image_path == original.image_path
         assert restored.pos() == original.pos()
         assert restored.opacity == pytest.approx(original.opacity)
         assert restored.locked == original.locked
         assert restored.scale_factor == pytest.approx(original.scale_factor)
         assert restored.scale() == pytest.approx(original.scale())
+
+    def test_portable_load_without_source_file(
+        self, qtbot, test_image_path: Path
+    ) -> None:
+        """Portable round-trip: image loads correctly even after the source file is deleted."""
+        original = BackgroundImageItem(str(test_image_path))
+        original.opacity = 0.5
+        original.calibrate(pixels=100, centimeters=200)
+        data = original.to_dict()
+
+        # Delete the source file — simulates opening the project on another PC
+        test_image_path.unlink()
+        assert not test_image_path.exists()
+
+        # Must succeed without the original file
+        restored = BackgroundImageItem.from_dict(data)
+
+        assert not restored.pixmap().isNull()
+        assert restored.opacity == pytest.approx(0.5)
+        assert restored.scale_factor == pytest.approx(0.5)


### PR DESCRIPTION
## Summary

- **Fixes #137** — Background images are now embedded as a base64-encoded PNG in the `.ogp` project file (`image_data` key). Projects are fully self-contained: opening on another PC or moving the source file no longer causes the background image to silently disappear. Legacy project files with only `image_path` continue to load via backward-compatible fallback.

- **Fixes #138** — All six placeable item types (Rectangle, Circle, Polygon, Polyline, Group, Text) now expose a **Move to Layer** submenu in their right-click context menu. The submenu is hidden automatically when the project has only one layer. The operation is fully undoable via Ctrl+Z and supports multi-selection (right-clicking any selected item moves all selected items).

## Changes

| Area | What changed |
|---|---|
| `background_image_item.py` | `to_dict()` embeds PNG as base64; `from_dict()` prefers `image_data`, falls back to `image_path`; `__init__` accepts `_pixmap_data: bytes` for internal construction |
| `commands.py` | New `MoveToLayerCommand` — captures per-item old layer for correct multi-item undo |
| `garden_item.py` | New `_build_move_to_layer_menu()` + `_dispatch_move_to_layer()` on `GardenItemMixin` (shared by all six item types) |
| 6 item files | Context menus wired to the new helpers |
| Unit tests | `test_background_image_item.py` updated + 2 new portability tests |
| Integration tests | `test_background_image_portable.py` (3 tests) + `test_move_to_layer.py` (8 tests) |

## Test plan

- [ ] 1884 tests pass (`pytest tests/ -v`) — ✅ confirmed
- [ ] Ruff lint clean — ✅ confirmed
- [ ] Bandit SAST: 0 high-severity issues — ✅ confirmed
- [ ] PyInstaller build succeeds; exe launches (exit 124) — ✅ confirmed
- [ ] **Manual: Issue #137** — import background image, save project, delete source file, reopen project → image still visible with correct opacity/scale
- [ ] **Manual: Issue #138** — create 2 layers, draw rectangle on Layer 1, right-click → Move to Layer → Layer 2; confirm visibility change; Ctrl+Z restores it

🤖 Generated with [Claude Code](https://claude.com/claude-code)