### PR TITLE
fix: intra-object constraints, rotation blocking, vertex enforcement & issue fixes #130 #131 #132 #133 #135

### DIFF
--- a/docs/11-risks-and-technical-debt/README.md
+++ b/docs/11-risks-and-technical-debt/README.md
@@ -36,6 +36,7 @@
 | TD-004 | Object model | Some object types share code that could be better abstracted | Low |
 | TD-005 | Test coverage | Some UI components lack automated tests | Medium |
 | TD-006 | Error messages | Some error messages are technical, not user-friendly | Low |
+| TD-007 | Constraint anchors | Polygon/polyline edge anchors use dynamic `EDGE_TOP/BOTTOM/LEFT/RIGHT` classification (dominant axis). Classification changes when a vertex moves far enough to flip an edge's axis, causing constraint indicators to jump to the wrong edge. Replace with `AnchorType.EDGE_MIDPOINT` + stable numeric `anchor_index` so the edge identity is axis-independent. Workaround in place (index-only match in `_resolve_anchor_position`). | Medium |
 
 ## 11.4 Known Development Pitfalls
 
@@ -50,6 +51,8 @@ Hard-won lessons from implementation. Read these before modifying the related su
 - **3-anchor constraints not solved on add**: `_compute_constraint_solve_moves()` in `canvas_view.py` collects `constrained_ids` from `anchor_a` and `anchor_b` only. Any constraint with a third anchor (`anchor_c`, e.g. ANGLE) must also add `anchor_c.item_id` here, otherwise the third item is absent from `item_positions` and the solver cannot move it — showing as red/violated until the user manually drags an object.
 
 - **Canvas Y-axis flip**: The view applies `scale(zoom, -zoom)` so **positive scene Y is visually upward** on canvas (CAD-style, origin bottom-left). When computing directional offsets from user-facing angles (e.g. linear array), negate `dy`: `dy = -spacing * sin(angle_rad)` so that 0°=right, 90°=down, 180°=left, 270°=up matches screen-space intuition. The canvas rect in scene coords is `QRectF(0, 0, width_cm, height_cm)` accessed via `self._canvas_scene.canvas_rect`.
+
+- **EDGE_* anchor type instability on polygons/polylines** (TD-007): `_polygon_anchors()` in `measure_snapper.py` classifies each edge as `EDGE_TOP/BOTTOM/LEFT/RIGHT` based on its **current** dominant axis (horizontal vs vertical). This is a dynamic, geometry-dependent label. When a vertex is dragged far enough to flip an edge's dominant axis (e.g. a nearly-horizontal edge becomes nearly-vertical), the freshly-computed anchor type differs from the value stored in the constraint record. `_resolve_anchor_position()` in `dimension_lines.py` then fails on its `(type AND index)` match and falls through to type-only matching, snapping the constraint indicator to the wrong edge. Current workaround: an EDGE_*-aware index-only match block at the top of `_resolve_anchor_position` catches these mismatches before the fallback fires. Long-term fix (TD-007): replace all four `EDGE_*` types with a single `AnchorType.EDGE_MIDPOINT` and use `anchor_index` as the sole edge identity. The edge is always identified by its start-vertex index, not by axis classification, making the anchor stable across all vertex moves.
 
 ## 11.5 Community and Governance
 

--- a/src/open_garden_planner/app/application.py
+++ b/src/open_garden_planner/app/application.py
@@ -718,6 +718,9 @@ class GardenPlannerApp(QMainWindow):
         self.gallery_panel.item_selected.connect(self._on_gallery_item_selected)
         self.canvas_view.tool_changed.connect(self.update_tool)
         self.canvas_view.tool_changed.connect(self._sync_toolbar_state)
+        self.canvas_view.import_background_image_requested.connect(
+            self._on_import_background_image
+        )
 
         # Connect scene selection changes to status bar and panels
         self.canvas_scene.selectionChanged.connect(self._on_selection_changed)
@@ -877,6 +880,7 @@ class GardenPlannerApp(QMainWindow):
 
         # Connect scene layer changes to panel
         self.canvas_scene.layers_changed.connect(lambda: self.layers_panel.set_layers(self.canvas_scene.layers))
+        self.canvas_scene.layer_auto_unhidden.connect(self._on_layer_auto_unhidden)
 
         layers_panel = CollapsiblePanel(self.tr("Layers"), self.layers_panel, expanded=True)
         sidebar_layout.addWidget(layers_panel)
@@ -1283,6 +1287,10 @@ class GardenPlannerApp(QMainWindow):
             self.canvas_view.command_manager.clear()
             self.constraints_panel.refresh()
             self._project_manager.new_project()
+
+            # Apply optional garden year chosen in dialog
+            if dialog.garden_year is not None:
+                self._project_manager.set_season(dialog.garden_year)
 
             # Clear any existing auto-save
             self._autosave_manager.clear_autosave()
@@ -2440,6 +2448,11 @@ class GardenPlannerApp(QMainWindow):
             layer_id: UUID of the layer to delete
         """
         self.canvas_scene.remove_layer(layer_id)
+        self._project_manager.mark_dirty()
+
+    def _on_layer_auto_unhidden(self, layer_id) -> None:
+        """Update the layers panel when the scene auto-unhides a hidden layer."""
+        self.layers_panel.refresh_layer_visibility(layer_id, True)
         self._project_manager.mark_dirty()
 
     def _on_scene_changed_for_plant_search(self) -> None:

--- a/src/open_garden_planner/core/commands.py
+++ b/src/open_garden_planner/core/commands.py
@@ -688,6 +688,37 @@ class DeleteVertexCommand(Command):
         self._apply_add_func(self._item, self._vertex_index, self._position)
 
 
+class MultiVertexMoveCommand(Command):
+    """Undo/redo for one or more vertex moves across one or more items.
+
+    Used to bundle a user-driven vertex drag with automatic constraint
+    corrections into a single Ctrl+Z step.
+    """
+
+    def __init__(
+        self,
+        vertex_moves: "list[tuple[QGraphicsItem, int, QPointF, QPointF]]",
+        description: str = "Move vertex",
+    ) -> None:
+        """Initialize with a list of (item, vertex_index, old_local, new_local) tuples."""
+        self._vertex_moves = vertex_moves
+        self._desc = description
+
+    @property
+    def description(self) -> str:
+        return self._desc
+
+    def execute(self) -> None:
+        for item, idx, _old, new in self._vertex_moves:
+            if hasattr(item, "_move_vertex_to"):
+                item._move_vertex_to(idx, new)
+
+    def undo(self) -> None:
+        for item, idx, old, _new in reversed(self._vertex_moves):
+            if hasattr(item, "_move_vertex_to"):
+                item._move_vertex_to(idx, old)
+
+
 class AddConstraintCommand(Command):
     """Command for adding a constraint (distance, alignment, or angle).
 

--- a/src/open_garden_planner/core/constraints.py
+++ b/src/open_garden_planner/core/constraints.py
@@ -175,6 +175,21 @@ class ConstraintGraph:
                 return True
         return False
 
+    def has_interobject_rotation_constraint(self, item_id: UUID) -> bool:
+        """Return True if *item_id* has a PARALLEL or PERPENDICULAR constraint
+        with at least one anchor on a *different* item.
+
+        Intra-object constraints (both anchors on the same polygon) are excluded:
+        rotating the polygon as a whole preserves its internal angles.
+        """
+        rotation_types = {ConstraintType.PARALLEL, ConstraintType.PERPENDICULAR}
+        for cid in self._adjacency.get(item_id, set()):
+            c = self._constraints.get(cid)
+            if (c and c.constraint_type in rotation_types
+                    and c.anchor_a.item_id != c.anchor_b.item_id):
+                return True
+        return False
+
     def add_constraint(
         self,
         anchor_a: AnchorRef,
@@ -853,8 +868,7 @@ class ConstraintGraph:
                         constraint.anchor_c.anchor_index,
                     )
                     off_c = anchor_offsets.get(key_c, (0.0, 0.0))
-                    cx = positions[id_c][0] + off_c[0]
-                    cy = positions[id_c][1] + off_c[1]
+                    cx, cy = _anchor_pos(id_c, constraint.anchor_c, off_c)
 
                     # Vectors from vertex B to A and B to C
                     ba_x, ba_y = ax - bx, ay - by

--- a/src/open_garden_planner/core/tools/constraint_tool.py
+++ b/src/open_garden_planner/core/tools/constraint_tool.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import math
 
 from PyQt6.QtCore import QCoreApplication, QLineF, QPointF, QRectF, Qt
@@ -30,6 +31,8 @@ from open_garden_planner.core.measure_snapper import (
 )
 from open_garden_planner.core.tools.base_tool import BaseTool, ToolType
 from open_garden_planner.ui.canvas.items import GardenItemMixin
+
+_log = logging.getLogger(__name__)
 
 # Visual constants
 ANCHOR_INDICATOR_RADIUS = 6.0
@@ -310,12 +313,13 @@ class ConstraintTool(BaseTool):
             # Second click: select anchor B and create constraint
             anchor_b = anchor
 
-            # Don't allow constraining same anchor to itself
+            # Don't allow constraining an anchor to itself (same item + same type + same index)
             if (
                 hasattr(self._anchor_a.item, "item_id")
                 and hasattr(anchor_b.item, "item_id")
                 and self._anchor_a.item.item_id == anchor_b.item.item_id
                 and self._anchor_a.anchor_type == anchor_b.anchor_type
+                and self._anchor_a.anchor_index == anchor_b.anchor_index
             ):
                 return True
 
@@ -592,6 +596,7 @@ class CoincidentConstraintTool(ConstraintTool):
                 and hasattr(anchor_b.item, "item_id")
                 and self._anchor_a.item.item_id == anchor_b.item.item_id
                 and self._anchor_a.anchor_type == anchor_b.anchor_type
+                and self._anchor_a.anchor_index == anchor_b.anchor_index
             ):
                 return True
             self._create_constraint(self._anchor_a, anchor_b, 0.0)
@@ -1226,11 +1231,12 @@ class AngleConstraintTool(BaseTool):
 
         if self._anchor_b is None:
             # Second click: select anchor B (vertex)
-            # Must be on a different item from A
+            # Must not be the same anchor point as A
             if (
                 hasattr(self._anchor_a.item, "item_id")
                 and hasattr(anchor.item, "item_id")
                 and self._anchor_a.item.item_id == anchor.item.item_id
+                and self._anchor_a.anchor_index == anchor.anchor_index
             ):
                 return True
             self._anchor_b = anchor
@@ -1249,13 +1255,13 @@ class AngleConstraintTool(BaseTool):
             self._reset()
             return True
 
-        # All three must be different items
-        ids = {
-            self._anchor_a.item.item_id,
-            self._anchor_b.item.item_id,
-            anchor_c.item.item_id,
+        # All three must be distinct anchor points (can be on the same item)
+        anchor_keys = {
+            (self._anchor_a.item.item_id, self._anchor_a.anchor_index),
+            (self._anchor_b.item.item_id, self._anchor_b.anchor_index),
+            (anchor_c.item.item_id, anchor_c.anchor_index),
         }
-        if len(ids) < 3:  # noqa: PLR2004
+        if len(anchor_keys) < 3:  # noqa: PLR2004
             return True
 
         # Compute current angle at vertex B
@@ -1555,8 +1561,9 @@ class SymmetryConstraintTool(BaseTool):
             hasattr(self._anchor_a.item, "item_id")
             and hasattr(anchor_b.item, "item_id")
             and self._anchor_a.item.item_id == anchor_b.item.item_id
+            and self._anchor_a.anchor_index == anchor_b.anchor_index
         ):
-            return True  # Same item — skip
+            return True  # Same anchor point — skip
 
         dialog = SymmetryAxisDialog(self._view)
         if dialog.exec() == QDialog.DialogCode.Accepted:
@@ -2195,6 +2202,7 @@ class EqualConstraintTool(BaseTool):
                 hasattr(self._anchor_a.item, "item_id")
                 and hasattr(anchor_b.item, "item_id")
                 and self._anchor_a.item.item_id == anchor_b.item.item_id
+                and self._anchor_a.anchor_index == anchor_b.anchor_index
             ):
                 return True
 
@@ -2445,6 +2453,8 @@ class ParallelConstraintTool(BaseTool):
                 hasattr(self._edge_a.item, "item_id")
                 and hasattr(edge_b.item, "item_id")
                 and self._edge_a.item.item_id == edge_b.item.item_id
+                and self._edge_a.anchor_type == edge_b.anchor_type
+                and self._edge_a.anchor_index == edge_b.anchor_index
             ):
                 return True
 
@@ -2487,6 +2497,11 @@ class ParallelConstraintTool(BaseTool):
                     "Cannot determine the angle of the selected edge on object B.",
                 ),
             )
+            return
+
+        # Intra-object: use one-time vertex deformation (not an ANGLE constraint).
+        if edge_a.item.item_id == edge_b.item.item_id:
+            _create_intraobject_parallel_from_edges(self._view, edge_a, edge_b)
             return
 
         # Prefer rotating edge B (second-clicked / "target") to align with edge A.
@@ -2746,6 +2761,8 @@ class PerpendicularConstraintTool(BaseTool):
                 hasattr(self._edge_a.item, "item_id")
                 and hasattr(edge_b.item, "item_id")
                 and self._edge_a.item.item_id == edge_b.item.item_id
+                and self._edge_a.anchor_type == edge_b.anchor_type
+                and self._edge_a.anchor_index == edge_b.anchor_index
             ):
                 return True
 
@@ -2792,6 +2809,12 @@ class PerpendicularConstraintTool(BaseTool):
                     "Cannot determine the angle of the selected edge on object B.",
                 ),
             )
+            return
+
+        # Intra-object: rotating the whole item would shift both edges equally.
+        # Instead, deform the polygon vertices via an ANGLE(90°) constraint.
+        if edge_a.item.item_id == edge_b.item.item_id:
+            _create_intraobject_angle_from_edges(self._view, edge_a, edge_b, 90.0)
             return
 
         # Prefer rotating edge B (second-clicked / "target") to be perpendicular to edge A.
@@ -2865,6 +2888,251 @@ class PerpendicularConstraintTool(BaseTool):
 
     def cancel(self) -> None:
         self._reset()
+
+
+# ─── Intra-object edge helper ────────────────────────────────────────────────
+
+
+def _create_intraobject_angle_from_edges(view, edge_a, edge_b, target_deg: float) -> None:
+    """Convert an intra-polygon edge relationship to an ANGLE constraint.
+
+    Works for PolygonItem (CORNER anchors) and PolylineItem (ENDPOINT anchors).
+    Finds the shared vertex between the two adjacent edges by midpoint proximity,
+    then delegates to _execute_constraint_with_solve (vertex-deformation path).
+    """
+    import math as _imath
+
+    from open_garden_planner.core.commands import AddConstraintCommand
+    from open_garden_planner.core.constraints import AnchorRef, ConstraintType
+    from open_garden_planner.core.measure_snapper import AnchorType
+
+    item = edge_a.item
+    scene = view.scene()
+    if not scene:
+        return
+
+    # Resolve item type → vertex accessor
+    if hasattr(item, "polygon") and callable(item.polygon):
+        pg = item.polygon()
+        n = pg.count()
+        vtype = AnchorType.CORNER
+        def _get_v(i: int):  # noqa: E306
+            return item.mapToScene(pg.at(i))
+    elif hasattr(item, "points"):
+        pts = item.points
+        n = len(pts)
+        vtype = AnchorType.ENDPOINT
+        def _get_v(i: int):  # noqa: E306
+            return item.mapToScene(pts[i])
+    else:
+        QMessageBox.information(
+            view,
+            QCoreApplication.translate("ConstraintTool", "Constraint"),
+            QCoreApplication.translate(
+                "ConstraintTool",
+                "Intra-object edge constraints are only supported for polygons and polylines.",
+            ),
+        )
+        return
+
+    if n < 3:
+        return
+
+    # Match each edge anchor to its polygon-edge index by midpoint proximity.
+    # anchor_index is unreliable for rectangle EDGE_* anchors (set to None),
+    # so geometry-based matching is used for all item types.
+    def _edge_idx(anchor) -> int:
+        best, best_d = 0, float("inf")
+        for i in range(n):
+            p1, p2 = _get_v(i), _get_v((i + 1) % n)
+            mid_x = (p1.x() + p2.x()) / 2
+            mid_y = (p1.y() + p2.y()) / 2
+            d = _imath.hypot(anchor.point.x() - mid_x, anchor.point.y() - mid_y)
+            if d < best_d:
+                best_d, best = d, i
+        return best
+
+    i_a = _edge_idx(edge_a)
+    i_b = _edge_idx(edge_b)
+
+    if i_a == i_b:
+        return  # Same edge (guard already prevents this, but be safe)
+
+    # Adjacent edges share exactly one vertex.
+    # Edge i: vertex[i] → vertex[(i+1) % n]
+    if (i_a + 1) % n == i_b:
+        p1_idx, v_idx, p2_idx = i_a, (i_a + 1) % n, (i_b + 1) % n
+    elif (i_b + 1) % n == i_a:
+        p1_idx, v_idx, p2_idx = (i_a + 1) % n, i_a, i_b
+    else:
+        QMessageBox.information(
+            view,
+            QCoreApplication.translate("ConstraintTool", "Constraint"),
+            QCoreApplication.translate(
+                "ConstraintTool",
+                "Please select two adjacent (connected) edges of the same polygon.",
+            ),
+        )
+        return
+
+    uid = item.item_id
+    ref_a = AnchorRef(item_id=uid, anchor_type=vtype, anchor_index=p1_idx)
+    ref_b = AnchorRef(item_id=uid, anchor_type=vtype, anchor_index=v_idx)
+    ref_c = AnchorRef(item_id=uid, anchor_type=vtype, anchor_index=p2_idx)
+
+    command = AddConstraintCommand(
+        graph=scene.constraint_graph,
+        anchor_a=ref_a,
+        anchor_b=ref_b,
+        target_distance=target_deg,
+        constraint_type=ConstraintType.ANGLE,
+        anchor_c=ref_c,
+    )
+    view._execute_constraint_with_solve(command)
+
+
+def _create_intraobject_parallel_from_edges(view, edge_a, edge_b) -> None:
+    """Make two non-adjacent edges of the same polygon parallel via vertex deformation.
+
+    Rotates the end-vertex of edge B around its start-vertex by the angle delta
+    that aligns edge B's direction with edge A's direction.  The deformation is
+    pushed as a MoveVertexCommand so it is fully undoable.
+
+    Adjacent edges are rejected with an informational message because making
+    adjacent edges parallel would collapse the shared vertex (180° corner).
+    """
+    import math as _imath
+
+    from PyQt6.QtCore import QPointF
+
+    from open_garden_planner.core.commands import AddConstraintCommand
+    from open_garden_planner.core.constraints import AnchorRef, ConstraintType
+
+    item = edge_a.item
+    scene = view.scene()
+    if not scene:
+        return
+
+    # Resolve item type → vertex access
+    if hasattr(item, "polygon") and callable(item.polygon):
+        pg = item.polygon()
+        n = pg.count()
+        def _get_v(i: int) -> QPointF:  # noqa: E306
+            return item.mapToScene(pg.at(i))
+        def _local(i: int) -> QPointF:  # noqa: E306
+            return pg.at(i)
+    elif hasattr(item, "points"):
+        pts = item.points
+        n = len(pts)
+        def _get_v(i: int) -> QPointF:  # noqa: E306
+            return item.mapToScene(pts[i])
+        def _local(i: int) -> QPointF:  # noqa: E306
+            return QPointF(pts[i])
+    else:
+        QMessageBox.information(
+            view,
+            QCoreApplication.translate("ConstraintTool", "Constraint"),
+            QCoreApplication.translate(
+                "ConstraintTool",
+                "Intra-object edge constraints are only supported for polygons and polylines.",
+            ),
+        )
+        return
+
+    if n < 4:  # noqa: PLR2004
+        QMessageBox.information(
+            view,
+            QCoreApplication.translate("ConstraintTool", "Parallel Constraint"),
+            QCoreApplication.translate(
+                "ConstraintTool",
+                "The polygon needs at least 4 vertices for a parallel constraint "
+                "between non-adjacent edges.",
+            ),
+        )
+        return
+
+    # Match each edge anchor to its polygon-edge index by midpoint proximity
+    def _edge_idx(anchor) -> int:
+        best, best_d = 0, float("inf")
+        for i in range(n):
+            p1, p2 = _get_v(i), _get_v((i + 1) % n)
+            mid_x = (p1.x() + p2.x()) / 2
+            mid_y = (p1.y() + p2.y()) / 2
+            d = _imath.hypot(anchor.point.x() - mid_x, anchor.point.y() - mid_y)
+            if d < best_d:
+                best_d, best = d, i
+        return best
+
+    i_a = _edge_idx(edge_a)
+    i_b = _edge_idx(edge_b)
+
+    if i_a == i_b:
+        return  # Same edge; already guarded upstream
+
+    # Adjacent edges share a vertex — making them parallel collapses that vertex
+    if (i_a + 1) % n == i_b or (i_b + 1) % n == i_a:
+        QMessageBox.information(
+            view,
+            QCoreApplication.translate("ConstraintTool", "Parallel Constraint"),
+            QCoreApplication.translate(
+                "ConstraintTool",
+                "Adjacent edges of the same polygon cannot be made parallel. "
+                "To set a specific corner angle, use the Angle constraint tool.",
+            ),
+        )
+        return
+
+    # Scene positions of the four relevant vertices
+    p_a1 = _get_v(i_a)
+    p_a2 = _get_v((i_a + 1) % n)
+    p_b1 = _get_v(i_b)
+    p_b2 = _get_v((i_b + 1) % n)
+
+    da_x = p_a2.x() - p_a1.x()
+    da_y = p_a2.y() - p_a1.y()
+    db_x = p_b2.x() - p_b1.x()
+    db_y = p_b2.y() - p_b1.y()
+
+    if _imath.hypot(da_x, da_y) < 1e-9 or _imath.hypot(db_x, db_y) < 1e-9:
+        return  # Degenerate edge
+
+    # Rotation delta from edge B direction to edge A direction,
+    # normalised to (-π/2, π/2] so we pick the shorter arc (parallel = 0° or 180°)
+    delta = _imath.atan2(da_y, da_x) - _imath.atan2(db_y, db_x)
+    while delta > _imath.pi / 2:
+        delta -= _imath.pi
+    while delta <= -_imath.pi / 2:
+        delta += _imath.pi
+
+    if abs(delta) < 1e-6:
+        return  # Already parallel
+
+    # Rotate p_b2 around p_b1 by delta (preserves edge length, aligns direction)
+    cos_d, sin_d = _imath.cos(delta), _imath.sin(delta)
+    rel_x = p_b2.x() - p_b1.x()
+    rel_y = p_b2.y() - p_b1.y()
+    new_b2_scene = QPointF(
+        p_b1.x() + cos_d * rel_x - sin_d * rel_y,
+        p_b1.y() + sin_d * rel_x + cos_d * rel_y,
+    )
+
+    vertex_idx = (i_b + 1) % n
+    old_local = _local(vertex_idx)
+    new_local = item.mapFromScene(new_b2_scene)
+
+    uid = item.item_id
+    ref_a = AnchorRef(item_id=uid, anchor_type=edge_a.anchor_type, anchor_index=edge_a.anchor_index)
+    ref_b = AnchorRef(item_id=uid, anchor_type=edge_b.anchor_type, anchor_index=edge_b.anchor_index)
+
+    cmd = AddConstraintCommand(
+        graph=scene.constraint_graph,
+        anchor_a=ref_a,
+        anchor_b=ref_b,
+        target_distance=getattr(item, "rotation_angle", 0.0),
+        constraint_type=ConstraintType.PARALLEL,
+    )
+    cmd._vertex_moves = [(item, vertex_idx, old_local, new_local)]
+    scene.get_command_manager().execute(cmd)
 
 
 # ─── Fix in place constraint ──────────────────────────────────────────────────
@@ -3226,6 +3494,7 @@ class HorizontalDistanceConstraintTool(ConstraintTool):
                 and hasattr(anchor_b.item, "item_id")
                 and self._anchor_a.item.item_id == anchor_b.item.item_id
                 and self._anchor_a.anchor_type == anchor_b.anchor_type
+                and self._anchor_a.anchor_index == anchor_b.anchor_index
             ):
                 return True
 
@@ -3334,6 +3603,7 @@ class VerticalDistanceConstraintTool(ConstraintTool):
                 and hasattr(anchor_b.item, "item_id")
                 and self._anchor_a.item.item_id == anchor_b.item.item_id
                 and self._anchor_a.anchor_type == anchor_b.anchor_type
+                and self._anchor_a.anchor_index == anchor_b.anchor_index
             ):
                 return True
 

--- a/src/open_garden_planner/ui/canvas/canvas_scene.py
+++ b/src/open_garden_planner/ui/canvas/canvas_scene.py
@@ -54,6 +54,7 @@ class CanvasScene(QGraphicsScene):
     # Signals
     layers_changed = pyqtSignal()
     active_layer_changed = pyqtSignal(object)  # Layer or None
+    layer_auto_unhidden = pyqtSignal(UUID)  # emitted when a draw auto-reveals a hidden layer
 
     def __init__(
         self,
@@ -223,6 +224,9 @@ class CanvasScene(QGraphicsScene):
     def addItem(self, item: QGraphicsItem) -> None:
         """Add an item to the scene, applying shadow and label state.
 
+        Also auto-unhides the item's layer if it is currently hidden, so that
+        drawing on a hidden layer reveals the layer and all its items.
+
         Args:
             item: The graphics item to add
         """
@@ -241,6 +245,14 @@ class CanvasScene(QGraphicsScene):
             item.shadows_enabled = self._shadows_enabled
             item.set_global_labels_visible(self._labels_enabled)
             item.spacing_circles_visible = self._spacing_circles_visible
+
+            # Auto-unhide the target layer so drawing on a hidden layer reveals it
+            if item.layer_id:
+                layer = self.get_layer_by_id(item.layer_id)
+                if layer and not layer.visible:
+                    layer.visible = True
+                    self._update_items_visibility()
+                    self.layer_auto_unhidden.emit(item.layer_id)
 
     # Constraint dimension line management
 

--- a/src/open_garden_planner/ui/canvas/canvas_view.py
+++ b/src/open_garden_planner/ui/canvas/canvas_view.py
@@ -10,6 +10,7 @@ import logging
 from PyQt6.QtCore import QPointF, QRectF, Qt, pyqtSignal
 from PyQt6.QtGui import (
     QColor,
+    QContextMenuEvent,
     QFont,
     QKeyEvent,
     QMouseEvent,
@@ -19,7 +20,7 @@ from PyQt6.QtGui import (
     QTransform,
     QWheelEvent,
 )
-from PyQt6.QtWidgets import QGraphicsItem, QGraphicsView, QInputDialog, QLineEdit
+from PyQt6.QtWidgets import QGraphicsItem, QGraphicsView, QInputDialog, QLineEdit, QMenu
 
 from open_garden_planner.core import (
     AddConstraintCommand,
@@ -88,6 +89,7 @@ class CanvasView(QGraphicsView):
     coordinates_changed = pyqtSignal(float, float)
     zoom_changed = pyqtSignal(float)
     tool_changed = pyqtSignal(str)  # Emitted when active tool changes
+    import_background_image_requested = pyqtSignal()  # Emitted from empty-canvas right-click
 
     # Zoom limits
     min_zoom: float = 0.01  # 1% - very zoomed out
@@ -621,6 +623,15 @@ class CanvasView(QGraphicsView):
         """
         from open_garden_planner.core.constraints import ConstraintType as _CT
 
+        # PARALLEL / PERPENDICULAR / EQUAL are rotation-only: the solver skips them.
+        # Bundling solver moves from OTHER constraints would shift polygon vertices and
+        # make the freshly applied rotation appear violated. Execute cleanly instead.
+        _rotation_only = (_CT.PARALLEL, _CT.PERPENDICULAR, _CT.EQUAL)
+        if command._constraint_type in _rotation_only:  # type: ignore[attr-defined]
+            self.command_manager.execute(command)
+            self._canvas_scene.update_dimension_lines()
+            return
+
         # CAD convention: A is constrained to B → A moves, B stays (reference).
         # Exception: if A already has a FIXED constraint the FIXED pre-pass
         # inside solve_anchored will pin A, so B must remain free to move.
@@ -631,7 +642,11 @@ class CanvasView(QGraphicsView):
             c.constraint_type == _CT.FIXED and c.anchor_a.item_id == anchor_a_id
             for c in graph.constraints.values()
         )
-        extra_pinned: set | None = None if a_is_fixed else {anchor_b_id}
+        # Intra-object constraints (e.g. ANGLE on a polygon vertex) have both
+        # anchors on the same item.  Pinning B would pin the item itself and
+        # prevent the solver from deforming any of its vertices.
+        intra_object = anchor_a_id == anchor_b_id
+        extra_pinned: set | None = None if (a_is_fixed or intra_object) else {anchor_b_id}
 
         # 1. Add the constraint temporarily so the solver can compute moves.
         command.execute()
@@ -1022,6 +1037,22 @@ class CanvasView(QGraphicsView):
 
         event.accept()
 
+    def contextMenuEvent(self, event: QContextMenuEvent) -> None:
+        """Show context menu on empty-canvas right-click."""
+        scene_pos = self.mapToScene(event.pos())
+        items_at = [
+            i for i in self.scene().items(scene_pos)
+            if i.isVisible() and i.flags() & QGraphicsItem.GraphicsItemFlag.ItemIsSelectable
+        ]
+        if items_at:
+            super().contextMenuEvent(event)
+            return
+        menu = QMenu(self)
+        import_action = menu.addAction(self.tr("Import Background Image..."))
+        selected = menu.exec(event.globalPos())
+        if selected == import_action:
+            self.import_background_image_requested.emit()
+
     def mousePressEvent(self, event: QMouseEvent) -> None:
         """Handle mouse press for panning and tool operations."""
         # Grab keyboard focus so Delete/arrow keys work
@@ -1092,6 +1123,16 @@ class CanvasView(QGraphicsView):
             grabber = self.scene().mouseGrabberItem()
             if isinstance(grabber, (ResizeHandle, RotationHandle, VertexHandle)):
                 self._active_drag_handle = grabber
+                # Block rotation for items that have an inter-object PARALLEL or
+                # PERPENDICULAR constraint — rotating would violate the constraint.
+                if isinstance(grabber, RotationHandle):
+                    parent = grabber.parentItem()
+                    if (parent is not None
+                            and hasattr(parent, "item_id")
+                            and self._canvas_scene.constraint_graph
+                                .has_interobject_rotation_constraint(parent.item_id)):
+                        grabber.ungrabMouse()
+                        self._active_drag_handle = None
             else:
                 self._active_drag_handle = None
 
@@ -1190,8 +1231,10 @@ class CanvasView(QGraphicsView):
         self._apply_object_snap_during_drag()
         self._clamp_dragged_items_to_canvas()
 
-        # Propagate constraints to connected items during drag
-        self._propagate_constraints_during_drag()
+        # Propagate constraints to connected items during drag.
+        # Skip during rotation — constraint solving doesn't apply while rotating.
+        if not isinstance(self._active_drag_handle, RotationHandle):
+            self._propagate_constraints_during_drag()
 
         # Update dimension lines in real-time during drag
         if self._drag_start_positions:
@@ -1718,6 +1761,22 @@ class CanvasView(QGraphicsView):
             event.accept()
             return
 
+        # Re-establish mouse grab if Qt dropped it (ItemIgnoresTransformations bug).
+        # Must happen BEFORE super() so the handle receives the release event.
+        if (self._active_drag_handle is not None
+                and self.scene().mouseGrabberItem() is None
+                and self._active_drag_handle.scene() is not None):
+            self._active_drag_handle.grabMouse()
+
+        # Capture whether a vertex drag is ending so we can enforce constraints below.
+        was_vertex_drag = (
+            isinstance(self._active_drag_handle, VertexHandle)
+            and event.button() == Qt.MouseButton.LeftButton
+        )
+        if was_vertex_drag:
+            self._deferring_vertex_undo = True
+            self._deferred_vertex_move = None
+
         # Clear the handle tracking regardless of what handles the release
         self._active_drag_handle = None
 
@@ -1729,13 +1788,136 @@ class CanvasView(QGraphicsView):
                 event.accept()
                 self._drag_start_positions.clear()
                 self._constraint_propagated_starts.clear()
+                if was_vertex_drag:
+                    self._deferring_vertex_undo = False
                 return
 
         super().mouseReleaseEvent(event)
 
+        if was_vertex_drag:
+            self._deferring_vertex_undo = False
+            self._enforce_after_vertex_drag()
+
         # Check if items were dragged and create undo command
         if event.button() == Qt.MouseButton.LeftButton and self._drag_start_positions:
             self._finalize_drag_move()
+
+    def _enforce_after_vertex_drag(self) -> None:
+        """Re-enforce constraints after a polygon vertex drag.
+
+        Runs the ANGLE constraint solver and re-aligns any intra-object PARALLEL
+        constraints, then bundles everything (original drag + all corrections) into
+        a single MultiVertexMoveCommand so Ctrl+Z reverts in one step.
+        """
+        from PyQt6.QtCore import QPointF
+
+        from open_garden_planner.core.commands import MultiVertexMoveCommand
+
+        deferred = getattr(self, '_deferred_vertex_move', None)
+        if deferred is None:
+            return
+        self._deferred_vertex_move = None
+
+        item, vertex_index, old_pos, new_pos = deferred
+
+        # Snapshot ALL current vertex positions (post-drag, pre-correction).
+        snapshots: dict[int, QPointF] = {}
+        if hasattr(item, 'polygon') and callable(item.polygon):
+            pg = item.polygon()
+            for i in range(pg.count()):
+                snapshots[i] = QPointF(pg.at(i))
+
+        # Run the solver (polygon not pinned → vertex deltas for ANGLE constraints apply).
+        _item_moves, vertex_corrections = self._compute_constraint_solve_moves()
+        for gitem, idx, _old_local, new_local in vertex_corrections:
+            if hasattr(gitem, '_move_vertex_to'):
+                gitem._move_vertex_to(idx, new_local)
+
+        # Re-enforce intra-object PARALLEL constraints.
+        self._reenforce_parallel_after_vertex_move(item, vertex_index)
+
+        # Collect ALL vertex changes (original drag + solver + PARALLEL re-alignment).
+        all_moves: list = [(item, vertex_index, old_pos, new_pos)]
+        if hasattr(item, 'polygon') and callable(item.polygon):
+            pg = item.polygon()
+            for i in range(pg.count()):
+                if i == vertex_index:
+                    continue
+                old_v = snapshots.get(i)
+                new_v = pg.at(i)
+                if old_v is not None and (
+                    abs(new_v.x() - old_v.x()) > 0.01 or abs(new_v.y() - old_v.y()) > 0.01
+                ):
+                    all_moves.append((item, i, old_v, new_v))
+
+        cmd = MultiVertexMoveCommand(all_moves)
+        cm = self.command_manager
+        cm._undo_stack.append(cmd)
+        cm._redo_stack.clear()
+        cm.can_undo_changed.emit(True)
+        cm.can_redo_changed.emit(False)
+        cm.command_executed.emit(cmd.description)
+
+        self._canvas_scene.update_dimension_lines()
+
+    def _reenforce_parallel_after_vertex_move(self, item: object, vertex_index: int) -> None:  # noqa: ARG002
+        """Re-align the target edge of every intra-object PARALLEL constraint on *item*."""
+        import math as _m
+
+        from PyQt6.QtCore import QPointF
+
+        from open_garden_planner.core.constraints import ConstraintType
+
+        uid = getattr(item, 'item_id', None)
+        if uid is None or not (hasattr(item, 'polygon') and callable(item.polygon)):
+            return
+
+        graph = self._canvas_scene.constraint_graph
+        pg = item.polygon()  # type: ignore[union-attr]
+        n = pg.count()
+        if n < 4:  # noqa: PLR2004
+            return
+
+        def _scene(i: int) -> QPointF:
+            return item.mapToScene(pg.at(i))  # type: ignore[union-attr]
+
+        for cid in list(graph._adjacency.get(uid, set())):
+            c = graph._constraints.get(cid)
+            if c is None or c.constraint_type != ConstraintType.PARALLEL:
+                continue
+            if c.anchor_a.item_id != uid or c.anchor_b.item_id != uid:
+                continue  # inter-object — skip
+
+            i_a = c.anchor_a.anchor_index  # reference edge start vertex
+            i_b = c.anchor_b.anchor_index  # target edge start vertex
+
+            p_a1, p_a2 = _scene(i_a), _scene((i_a + 1) % n)
+            p_b1, p_b2 = _scene(i_b), _scene((i_b + 1) % n)
+
+            da_x = p_a2.x() - p_a1.x()
+            da_y = p_a2.y() - p_a1.y()
+            db_x = p_b2.x() - p_b1.x()
+            db_y = p_b2.y() - p_b1.y()
+            if _m.hypot(da_x, da_y) < 1e-9 or _m.hypot(db_x, db_y) < 1e-9:
+                continue
+
+            delta = _m.atan2(da_y, da_x) - _m.atan2(db_y, db_x)
+            while delta > _m.pi / 2:
+                delta -= _m.pi
+            while delta <= -_m.pi / 2:
+                delta += _m.pi
+
+            if abs(delta) < 1e-6:
+                continue
+
+            cos_d, sin_d = _m.cos(delta), _m.sin(delta)
+            rel_x = p_b2.x() - p_b1.x()
+            rel_y = p_b2.y() - p_b1.y()
+            new_b2_scene = QPointF(
+                p_b1.x() + cos_d * rel_x - sin_d * rel_y,
+                p_b1.y() + sin_d * rel_x + cos_d * rel_y,
+            )
+            item._move_vertex_to((i_b + 1) % n, item.mapFromScene(new_b2_scene))  # type: ignore[union-attr]
 
     def mouseDoubleClickEvent(self, event: QMouseEvent) -> None:
         """Handle mouse double click for tool operations and constraint editing."""
@@ -2136,6 +2318,27 @@ class CanvasView(QGraphicsView):
                 # children on execute and reattaching on undo.
                 pass
 
+        # Expand deletion to include associated roof ridges (metadata-linked, not Qt children)
+        from uuid import UUID as _UUID
+
+        from open_garden_planner.core.object_types import ObjectType
+
+        _sel_ids = {item.item_id for item in selected if isinstance(item, GardenItemMixin)}
+        for _item in list(selected):
+            if not isinstance(_item, GardenItemMixin):
+                continue
+            if _item.object_type != ObjectType.HOUSE:
+                continue
+            ridge_id_str = _item.metadata.get("ridge_item_id")
+            if ridge_id_str and hasattr(self._canvas_scene, "find_item_by_id"):
+                try:
+                    ridge = self._canvas_scene.find_item_by_id(_UUID(ridge_id_str))
+                except ValueError:
+                    continue
+                if ridge is not None and ridge.item_id not in _sel_ids:
+                    selected.append(ridge)
+                    _sel_ids.add(ridge.item_id)
+
         # Collect constraints to remove for deleted items (garden + construction)
         graph = self._canvas_scene.constraint_graph
         constraints_to_remove = []
@@ -2249,15 +2452,15 @@ class CanvasView(QGraphicsView):
             self._constraint_propagated_starts.clear()
             return
 
-        # If a resize command was just pushed to the undo stack, the position
-        # change is already captured by that command. Creating a separate
-        # MoveItemsCommand would duplicate the position delta and cause
-        # undo to only revert the position without restoring the size.
-        from open_garden_planner.core.commands import ResizeItemCommand
+        # If a resize or rotate command was just pushed to the undo stack, the
+        # position/angle change is already captured by that command. Creating a
+        # separate MoveItemsCommand would duplicate the delta and cause undo to
+        # only revert the position without restoring the size/angle.
+        from open_garden_planner.core.commands import ResizeItemCommand, RotateItemCommand
 
         if self._command_manager.can_undo:
             last_cmd = self._command_manager._undo_stack[-1]
-            if isinstance(last_cmd, ResizeItemCommand):
+            if isinstance(last_cmd, (ResizeItemCommand, RotateItemCommand)):
                 self._drag_start_positions.clear()
                 self._constraint_propagated_starts.clear()
                 return

--- a/src/open_garden_planner/ui/canvas/dimension_lines.py
+++ b/src/open_garden_planner/ui/canvas/dimension_lines.py
@@ -361,6 +361,13 @@ class DimensionLineManager:
             ConstructionLineItem,
         )
 
+        _edge_types = frozenset({
+            AnchorType.EDGE_TOP,
+            AnchorType.EDGE_BOTTOM,
+            AnchorType.EDGE_LEFT,
+            AnchorType.EDGE_RIGHT,
+        })
+
         for item in self._scene.items():
             is_garden = isinstance(item, GardenItemMixin)
             is_construction = isinstance(item, (ConstructionLineItem, ConstructionCircleItem))
@@ -369,7 +376,15 @@ class DimensionLineManager:
             if item.item_id != item_id:
                 continue
             anchors = get_anchor_points(item)
-            # Match by both type and index to distinguish same-type anchors
+            # For polygon/polyline edges the EDGE_* classification is dynamic (determined
+            # by the edge's current dominant axis) and may change as vertices move.
+            # Match by index among all EDGE_* anchors so the indicator stays on the
+            # correct edge regardless of its current orientation.
+            if anchor_type in _edge_types:
+                for anchor in anchors:
+                    if anchor.anchor_type in _edge_types and anchor.anchor_index == anchor_index:
+                        return anchor.point
+            # Standard match: type + index
             for anchor in anchors:
                 if anchor.anchor_type == anchor_type and anchor.anchor_index == anchor_index:
                     return anchor.point

--- a/src/open_garden_planner/ui/canvas/items/circle_item.py
+++ b/src/open_garden_planner/ui/canvas/items/circle_item.py
@@ -472,6 +472,8 @@ class CircleItem(RotationHandleMixin, ResizeHandlesMixin, GardenItemMixin, QGrap
                 self._hide_circle_annotations()
         elif change == QGraphicsItem.GraphicsItemChange.ItemPositionHasChanged:
             self._update_circle_annotations()
+        elif change == QGraphicsItem.GraphicsItemChange.ItemSceneChange and value is None:
+            self.remove_rotation_handle()
 
         return super().itemChange(change, value)
 

--- a/src/open_garden_planner/ui/canvas/items/polygon_item.py
+++ b/src/open_garden_planner/ui/canvas/items/polygon_item.py
@@ -545,6 +545,8 @@ class PolygonItem(VertexEditMixin, RotationHandleMixin, ResizeHandlesMixin, Gard
                 self._update_annotations()
             # Move attached ridge by the same delta
             self._move_ridge_by_delta()
+        elif change == QGraphicsItem.GraphicsItemChange.ItemSceneChange and value is None:
+            self.remove_rotation_handle()
 
         return super().itemChange(change, value)
 

--- a/src/open_garden_planner/ui/canvas/items/polyline_item.py
+++ b/src/open_garden_planner/ui/canvas/items/polyline_item.py
@@ -819,6 +819,8 @@ class PolylineItem(PolylineVertexEditMixin, RotationHandleMixin, GardenItemMixin
                 self.hide_rotation_handle()
         elif change == QGraphicsItem.GraphicsItemChange.ItemPositionHasChanged and self.is_vertex_edit_mode:
             self._update_annotations()
+        elif change == QGraphicsItem.GraphicsItemChange.ItemSceneChange and value is None:
+            self.remove_rotation_handle()
 
         return super().itemChange(change, value)
 

--- a/src/open_garden_planner/ui/canvas/items/rectangle_item.py
+++ b/src/open_garden_planner/ui/canvas/items/rectangle_item.py
@@ -338,6 +338,8 @@ class RectangleItem(RectVertexEditMixin, RotationHandleMixin, ResizeHandlesMixin
                 self.hide_rotation_handle()
         elif change == QGraphicsItem.GraphicsItemChange.ItemPositionHasChanged and self.is_vertex_edit_mode:
             self._update_rect_annotations()
+        elif change == QGraphicsItem.GraphicsItemChange.ItemSceneChange and value is None:
+            self.remove_rotation_handle()
 
         return super().itemChange(change, value)
 

--- a/src/open_garden_planner/ui/canvas/items/resize_handle.py
+++ b/src/open_garden_planner/ui/canvas/items/resize_handle.py
@@ -1753,6 +1753,13 @@ class VertexEditMixin:
         if command_manager is None:
             return
 
+        # Canvas view may request deferred registration so it can bundle constraint
+        # corrections (ANGLE solver + PARALLEL re-alignment) into a single undo step.
+        view = scene.views()[0] if scene.views() else None
+        if view is not None and getattr(view, '_deferring_vertex_undo', False):
+            view._deferred_vertex_move = (self, vertex_index, old_pos, new_pos)
+            return
+
         from open_garden_planner.core.commands import MoveVertexCommand
 
         def apply_vertex_pos(item: QGraphicsItem, index: int, pos: QPointF) -> None:
@@ -2700,6 +2707,13 @@ class PolylineVertexEditMixin:
 
         command_manager = scene.get_command_manager()
         if command_manager is None:
+            return
+
+        # Canvas view may request deferred registration so it can bundle constraint
+        # corrections (ANGLE solver + PARALLEL re-alignment) into a single undo step.
+        view = scene.views()[0] if scene.views() else None
+        if view is not None and getattr(view, '_deferring_vertex_undo', False):
+            view._deferred_vertex_move = (self, vertex_index, old_pos, new_pos)
             return
 
         from open_garden_planner.core.commands import MoveVertexCommand

--- a/src/open_garden_planner/ui/canvas/items/text_item.py
+++ b/src/open_garden_planner/ui/canvas/items/text_item.py
@@ -284,4 +284,6 @@ class TextItem(RotationHandleMixin, GardenItemMixin, QGraphicsTextItem):
                 self.show_rotation_handle()
             else:
                 self.hide_rotation_handle()
+        elif change == QGraphicsItem.GraphicsItemChange.ItemSceneChange and value is None:
+            self.remove_rotation_handle()
         return super().itemChange(change, value)

--- a/src/open_garden_planner/ui/dialogs/new_project_dialog.py
+++ b/src/open_garden_planner/ui/dialogs/new_project_dialog.py
@@ -1,7 +1,10 @@
 """New Project dialog for creating projects with specified dimensions."""
 
+from datetime import date
+
 from PyQt6.QtCore import Qt
 from PyQt6.QtWidgets import (
+    QCheckBox,
     QDialog,
     QDialogButtonBox,
     QDoubleSpinBox,
@@ -9,6 +12,7 @@ from PyQt6.QtWidgets import (
     QGroupBox,
     QHBoxLayout,
     QLabel,
+    QSpinBox,
     QVBoxLayout,
 )
 
@@ -76,6 +80,28 @@ class NewProjectDialog(QDialog):
 
         layout.addWidget(dimensions_group)
 
+        # Garden year group
+        year_group = QGroupBox(self.tr("Garden Year"))
+        year_layout = QVBoxLayout(year_group)
+
+        self._year_checkbox = QCheckBox(self.tr("Assign a year to this plan"))
+        self._year_checkbox.setChecked(False)
+        year_layout.addWidget(self._year_checkbox)
+
+        year_spin_layout = QHBoxLayout()
+        self._year_spinbox = QSpinBox()
+        self._year_spinbox.setRange(2000, 2100)
+        self._year_spinbox.setValue(date.today().year)
+        self._year_spinbox.setMinimumWidth(100)
+        self._year_spinbox.setEnabled(False)
+        year_spin_layout.addWidget(self._year_spinbox)
+        year_spin_layout.addStretch()
+        year_layout.addLayout(year_spin_layout)
+
+        self._year_checkbox.toggled.connect(self._year_spinbox.setEnabled)
+
+        layout.addWidget(year_group)
+
         # Info label
         info_label = QLabel(
             self.tr("Tip: You can resize the canvas later from Edit > Canvas Size.")
@@ -114,6 +140,13 @@ class NewProjectDialog(QDialog):
     def height_m(self) -> float:
         """Get the canvas height in meters."""
         return self.height_spinbox.value()
+
+    @property
+    def garden_year(self) -> int | None:
+        """Get the selected garden year, or None if the year checkbox is unchecked."""
+        if self._year_checkbox.isChecked():
+            return self._year_spinbox.value()
+        return None
 
     def set_dimensions_m(self, width_m: float, height_m: float) -> None:
         """Set the canvas dimensions in meters.

--- a/src/open_garden_planner/ui/panels/layers_panel.py
+++ b/src/open_garden_planner/ui/panels/layers_panel.py
@@ -340,6 +340,23 @@ class LayersPanel(QWidget):
             self.layer_list.setMaximumHeight(height)
             self.layer_list.setMinimumHeight(height)
 
+    def refresh_layer_visibility(self, layer_id: UUID, visible: bool) -> None:
+        """Update the visibility button for a layer without emitting layer_visibility_changed.
+
+        Called when the scene auto-unhides a layer (e.g. when drawing on a hidden layer).
+        """
+        for i in range(self.layer_list.count()):
+            widget = self.layer_list.itemWidget(self.layer_list.item(i))
+            if isinstance(widget, LayerListItem) and widget.layer.id == layer_id:
+                widget.visibility_btn.blockSignals(True)
+                widget.visibility_btn.setChecked(visible)
+                widget.visibility_btn.setIcon(
+                    widget._eye_open_icon if visible else widget._eye_closed_icon
+                )
+                widget.visibility_btn.blockSignals(False)
+                widget._update_styling()
+                break
+
     def _on_layer_selected(self, row: int) -> None:
         """Handle layer selection.
 

--- a/tests/integration/test_issue_fixes.py
+++ b/tests/integration/test_issue_fixes.py
@@ -1,0 +1,304 @@
+"""Integration tests for GitHub issues #130, #131, #132, #133, #135 and rotation/angle bugs.
+
+Each test exercises the primary UI workflow that exposed the bug.
+"""
+
+# ruff: noqa: ARG002
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from PyQt6.QtCore import QPoint, QPointF, Qt
+from PyQt6.QtGui import QContextMenuEvent, QMouseEvent
+
+from open_garden_planner.core.object_types import ObjectType
+from open_garden_planner.core.tools import ToolType
+from open_garden_planner.ui.canvas.canvas_scene import CanvasScene
+from open_garden_planner.ui.canvas.canvas_view import CanvasView
+from open_garden_planner.ui.canvas.items import PolylineItem
+from open_garden_planner.ui.canvas.items import PolygonItem
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _left_click(pos: QPointF | None = None) -> MagicMock:
+    event = MagicMock(spec=QMouseEvent)
+    event.button.return_value = Qt.MouseButton.LeftButton
+    event.buttons.return_value = Qt.MouseButton.LeftButton
+    event.modifiers.return_value = Qt.KeyboardModifier.NoModifier
+    return event
+
+
+def _draw_house(view: CanvasView) -> None:
+    """Draw a HOUSE polygon (4 vertices) and close it."""
+    event = _left_click()
+    view.set_active_tool(ToolType.HOUSE)
+    tool = view.tool_manager.active_tool
+    tool.mouse_press(event, QPointF(100, 100))
+    tool.mouse_press(event, QPointF(400, 100))
+    tool.mouse_press(event, QPointF(400, 400))
+    tool.mouse_press(event, QPointF(100, 400))
+    tool.mouse_double_click(event, QPointF(100, 400))
+
+
+def _draw_triangle(view: CanvasView) -> PolygonItem:
+    """Draw a generic triangle and return the created item."""
+    event = _left_click()
+    view.set_active_tool(ToolType.POLYGON)
+    tool = view.tool_manager.active_tool
+    tool.mouse_press(event, QPointF(100, 100))
+    tool.mouse_press(event, QPointF(500, 100))
+    tool.mouse_press(event, QPointF(300, 400))
+    tool.mouse_double_click(event, QPointF(300, 400))
+    polys = [i for i in view.scene().items() if isinstance(i, PolygonItem)]
+    return polys[0]
+
+
+# ---------------------------------------------------------------------------
+# Issue #135 — roof ridge deleted together with its house polygon
+# ---------------------------------------------------------------------------
+
+
+class TestIssue135RoofRidgeDeletion:
+    """When a HOUSE polygon is deleted, its ROOF_RIDGE must be deleted too."""
+
+    def test_delete_house_also_deletes_ridge(self, canvas: CanvasView, qtbot: object) -> None:
+        """Deleting a HOUSE removes its ROOF_RIDGE in the same command."""
+        _draw_house(canvas)
+
+        scene = canvas.scene()
+        ridges_before = [
+            i for i in scene.items()
+            if isinstance(i, PolylineItem) and i.object_type == ObjectType.ROOF_RIDGE
+        ]
+        assert len(ridges_before) == 1, "Expected one ridge after drawing house"
+
+        # Select the house polygon and delete it
+        houses = [
+            i for i in scene.items()
+            if isinstance(i, PolygonItem) and i.object_type == ObjectType.HOUSE
+        ]
+        assert len(houses) == 1
+        houses[0].setSelected(True)
+
+        canvas._delete_selected_items()  # noqa: SLF001
+
+        ridges_after = [
+            i for i in scene.items()
+            if isinstance(i, PolylineItem) and i.object_type == ObjectType.ROOF_RIDGE
+        ]
+        houses_after = [
+            i for i in scene.items()
+            if isinstance(i, PolygonItem) and i.object_type == ObjectType.HOUSE
+        ]
+        assert len(ridges_after) == 0, "Ridge must be removed when house is deleted"
+        assert len(houses_after) == 0, "House must be removed"
+
+
+# ---------------------------------------------------------------------------
+# Issue #133 — drawing on hidden layer auto-unhides it
+# ---------------------------------------------------------------------------
+
+
+class TestIssue133HiddenLayerAutounhide:
+    """Drawing an item on a hidden layer must automatically unhide that layer."""
+
+    def test_draw_on_hidden_layer_auto_unhides(self, canvas: CanvasView, qtbot: object) -> None:
+        """After hiding the active layer, drawing a circle reveals it again."""
+        scene = canvas.scene()
+        active_layer = scene.active_layer
+        assert active_layer is not None
+
+        # Hide the active layer
+        scene.update_layer_visibility(active_layer.id, False)
+        assert not active_layer.visible, "Layer must be hidden before drawing"
+
+        # Draw a circle on the (now hidden) active layer
+        event = _left_click()
+        canvas.set_active_tool(ToolType.CIRCLE)
+        tool = canvas.tool_manager.active_tool
+        tool.mouse_press(event, QPointF(500, 500))
+        tool.mouse_press(event, QPointF(600, 500))
+
+        # The layer must now be visible again
+        assert active_layer.visible, "Layer must be auto-unhidden after drawing on it"
+
+        # All items on the layer must be visible
+        from open_garden_planner.ui.canvas.items import GardenItemMixin
+        layer_items = [
+            i for i in scene.items()
+            if isinstance(i, GardenItemMixin) and i.layer_id == active_layer.id
+        ]
+        assert layer_items, "At least one item expected on the layer"
+        assert all(i.isVisible() for i in layer_items), "All layer items must be visible"
+
+
+# ---------------------------------------------------------------------------
+# Issue #132 — intra-object constraints allowed
+# ---------------------------------------------------------------------------
+
+
+class TestIssue132IntraObjectConstraints:
+    """Constraints between two anchors of the same item must be allowed."""
+
+    def test_horizontal_constraint_between_same_item_vertices(
+        self, canvas: CanvasView, qtbot: object
+    ) -> None:
+        """Applying HORIZONTAL constraint between two vertices of one polygon succeeds."""
+        _draw_triangle(canvas)
+
+        scene = canvas.scene()
+        constraints_before = len(scene.constraint_graph.constraints)
+
+        canvas.set_active_tool(ToolType.CONSTRAINT_HORIZONTAL)
+        tool = canvas.tool_manager.active_tool
+        event = _left_click()
+
+        # Click near vertex 0 (100, 100) then vertex 1 (500, 100) — both on same polygon
+        tool.mouse_press(event, QPointF(100, 100))
+        tool.mouse_press(event, QPointF(500, 100))
+
+        constraints_after = len(scene.constraint_graph.constraints)
+        assert constraints_after > constraints_before, (
+            "Horizontal constraint between two vertices of the same polygon must be accepted"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Issue #131 — right-click empty canvas emits import signal
+# ---------------------------------------------------------------------------
+
+
+class TestIssue131RightClickCanvasMenu:
+    """Right-clicking on empty canvas must emit import_background_image_requested."""
+
+    def test_signal_exists_on_canvas_view(self, canvas: CanvasView, qtbot: object) -> None:
+        """CanvasView declares the import_background_image_requested signal."""
+        assert hasattr(canvas, "import_background_image_requested")
+
+    def test_right_click_empty_canvas_emits_signal(
+        self, canvas: CanvasView, qtbot: object
+    ) -> None:
+        """Right-click on empty area emits import_background_image_requested when action chosen."""
+        emitted: list[bool] = []
+        canvas.import_background_image_requested.connect(lambda: emitted.append(True))
+
+        event = MagicMock(spec=QContextMenuEvent)
+        event.pos.return_value = QPoint(1000, 1000)  # Far from any items
+        event.globalPos.return_value = QPoint(1000, 1000)
+
+        # Patch QMenu so exec() returns the import action (simulates user selecting it)
+        with patch("open_garden_planner.ui.canvas.canvas_view.QMenu") as MockMenu:
+            mock_menu = MockMenu.return_value
+            mock_action = MagicMock()
+            mock_menu.addAction.return_value = mock_action
+            mock_menu.exec.return_value = mock_action  # user "clicked" the action
+
+            canvas.contextMenuEvent(event)
+
+        assert emitted, "import_background_image_requested must be emitted when user selects the action"
+
+
+# ---------------------------------------------------------------------------
+# Issue #130 — new project dialog exposes garden year
+# ---------------------------------------------------------------------------
+
+
+class TestIssue130NewProjectDialogYear:
+    """NewProjectDialog must provide an optional garden year field."""
+
+    def test_garden_year_none_when_unchecked(self, qtbot: object) -> None:
+        """When the year checkbox is unchecked, garden_year returns None."""
+        from open_garden_planner.ui.dialogs.new_project_dialog import NewProjectDialog
+
+        dialog = NewProjectDialog()
+        qtbot.addWidget(dialog)  # type: ignore[attr-defined]
+
+        assert not dialog._year_checkbox.isChecked()
+        assert dialog.garden_year is None
+
+    def test_garden_year_returned_when_checked(self, qtbot: object) -> None:
+        """When the year checkbox is checked, garden_year returns the spinbox value."""
+        from open_garden_planner.ui.dialogs.new_project_dialog import NewProjectDialog
+
+        dialog = NewProjectDialog()
+        qtbot.addWidget(dialog)  # type: ignore[attr-defined]
+
+        dialog._year_checkbox.setChecked(True)
+        dialog._year_spinbox.setValue(2026)
+
+        assert dialog.garden_year == 2026
+
+
+# ---------------------------------------------------------------------------
+# Rotation undo — Ctrl+Z reverts rotation
+# ---------------------------------------------------------------------------
+
+
+def _draw_rect(view: CanvasView) -> object:
+    """Draw a rectangle and return the created item."""
+    from open_garden_planner.ui.canvas.items import RectangleItem
+
+    event = _left_click()
+    view.set_active_tool(ToolType.RECTANGLE)
+    tool = view.tool_manager.active_tool
+    tool.mouse_press(event, QPointF(100, 100))
+    tool.mouse_move(event, QPointF(400, 300))
+    tool.mouse_release(event, QPointF(400, 300))
+    rects = [i for i in view.scene().items() if isinstance(i, RectangleItem)]
+    return rects[0]
+
+
+class TestRotationUndo:
+    """Ctrl+Z after rotating an item must revert the angle."""
+
+    def test_rotation_undo_reverts_angle(self, canvas: CanvasView, qtbot: object) -> None:
+        """Simulating _on_rotation_end pushes RotateItemCommand; undo reverts angle."""
+        rect = _draw_rect(canvas)
+
+        initial_angle = 0.0
+        rect._apply_rotation(45.0)
+        assert abs(rect.rotation_angle - 45.0) < 0.01
+
+        # Manually trigger the rotation-end command registration
+        rect._on_rotation_end(initial_angle)
+
+        cmd_manager = canvas.scene().get_command_manager()
+        assert cmd_manager.can_undo, "RotateItemCommand must be on the undo stack"
+
+        cmd_manager.undo()
+        assert abs(rect.rotation_angle - 0.0) < 0.01, "Undo must revert angle to 0°"
+
+
+# ---------------------------------------------------------------------------
+# Angle label — cleanup on deletion
+# ---------------------------------------------------------------------------
+
+
+class TestAngleLabelCleanup:
+    """AngleDisplay must not persist after item deletion."""
+
+    def test_angle_display_removed_on_item_deletion(
+        self, canvas: CanvasView, qtbot: object
+    ) -> None:
+        """Deleting a rotated item removes its AngleDisplay from the scene."""
+        from open_garden_planner.ui.canvas.items.resize_handle import AngleDisplay
+
+        rect = _draw_rect(canvas)
+
+        # Create the rotation handle so _angle_display is added to scene
+        rect.show_rotation_handle()
+
+        scene = canvas.scene()
+        displays_before = [i for i in scene.items() if isinstance(i, AngleDisplay)]
+        assert len(displays_before) == 1, "AngleDisplay must be in scene after show_rotation_handle"
+
+        # Delete the rectangle
+        rect.setSelected(True)
+        canvas._delete_selected_items()  # noqa: SLF001
+
+        displays_after = [i for i in scene.items() if isinstance(i, AngleDisplay)]
+        assert len(displays_after) == 0, "AngleDisplay must be removed when item is deleted"


### PR DESCRIPTION
## Summary

- **#130** — Garden year can now be set at project creation (optional spinner in New Project dialog)
- **#131** — Right-click on empty canvas shows \"Import Background Image\" context menu
- **#132** — Intra-object constraints fully supported: PARALLEL, PERPENDICULAR, and ANGLE can now be applied between two edges/vertices of the same polygon/polyline; stored in constraint graph, enforced on vertex drag, undone in one Ctrl+Z step
- **#133** — Drawing on a hidden layer auto-unhides it and syncs the layers panel eye icon
- **#135** — Deleting a roof polygon now also deletes the associated ridge polyline (linked via metadata `ridge_item_id`)

**Constraint engine fixes (follow-up to #141):**
- Rotation is blocked when an item has an inter-object PARALLEL/PERPENDICULAR constraint; intra-object items still rotate freely (`has_interobject_rotation_constraint`)
- Vertex drag re-enforces intra-object constraints post-move and bundles all solver corrections into one `MultiVertexMoveCommand` undo step
- PARALLEL/PERPENDICULAR constraint indicator no longer jumps to the wrong edge after vertex moves (index-only EDGE_* match in `_resolve_anchor_position`)
- TD-007 documented in `docs/11-risks-and-technical-debt/` for the long-term EDGE_* anchor type refactor

Closes #130
Closes #131
Closes #132
Closes #133
Closes #135

## Test plan

- [x] `pytest tests/ -v` — 1880 passed
- [x] `ruff check src/` — clean
- [x] `bandit -r src/ --severity-level high` — 0 high issues
- [x] Manual: rotation blocked on inter-object constraint, allowed for intra-object
- [x] Manual: vertex drag enforces ANGLE/PARALLEL; Ctrl+Z reverts in one step
- [x] Manual: PARALLEL indicator stays on correct edge after vertex move
- [x] Manual: garden year set at project creation
- [x] Manual: right-click empty canvas → Import Background Image
- [x] Manual: draw on hidden layer → layer auto-unhides
- [x] Manual: delete roof → ridge deleted automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)