### PR TITLE
fix(issue-152): raise overlay z-threshold so all layers render in minimap

### DIFF
--- a/src/open_garden_planner/ui/canvas/items/resize_handle.py
+++ b/src/open_garden_planner/ui/canvas/items/resize_handle.py
@@ -107,7 +107,7 @@ class DimensionDisplay(QGraphicsItem):
 
         # Make it render at fixed screen size
         self.setFlag(QGraphicsItem.GraphicsItemFlag.ItemIgnoresTransformations)
-        self.setZValue(2000)  # Above everything
+        self.setZValue(20_000)  # Above everything
 
         self.hide()
 
@@ -272,7 +272,7 @@ class ResizeHandle(QGraphicsRectItem):
         self.setAcceptHoverEvents(True)
         self.setCursor(HANDLE_CURSORS.get(self._position, Qt.CursorShape.ArrowCursor))
         # Z-value above parent
-        self.setZValue(1000)
+        self.setZValue(10_000)
 
     @property
     def handle_position(self) -> HandlePosition:
@@ -541,7 +541,7 @@ class AngleDisplay(QGraphicsItem):
 
         # Make it render at fixed screen size
         self.setFlag(QGraphicsItem.GraphicsItemFlag.ItemIgnoresTransformations)
-        self.setZValue(2000)  # Above everything
+        self.setZValue(20_000)  # Above everything
 
         self.hide()
 
@@ -633,7 +633,7 @@ class RotationHandle(QGraphicsEllipseItem):
         self.setAcceptHoverEvents(True)
         self.setCursor(Qt.CursorShape.CrossCursor)
         # Z-value above parent and resize handles
-        self.setZValue(1001)
+        self.setZValue(10_001)
 
     def update_position(self) -> None:
         """Update handle position above the parent's bounding rect center-top."""
@@ -1136,7 +1136,7 @@ class VertexHandle(QGraphicsRectItem):
         """Configure interaction flags."""
         self.setAcceptHoverEvents(True)
         self.setCursor(Qt.CursorShape.SizeAllCursor)
-        self.setZValue(1002)  # Above rotation and resize handles
+        self.setZValue(10_002)  # Above rotation and resize handles
 
     @property
     def vertex_index(self) -> int:
@@ -1302,7 +1302,7 @@ class MidpointHandle(QGraphicsEllipseItem):
         """Configure interaction flags."""
         self.setAcceptHoverEvents(True)
         self.setCursor(Qt.CursorShape.CrossCursor)
-        self.setZValue(1001)  # Below vertex handles
+        self.setZValue(10_001)  # Below vertex handles
 
     @property
     def edge_index(self) -> int:
@@ -2031,7 +2031,7 @@ class RectCornerHandle(QGraphicsRectItem):
             self.setCursor(Qt.CursorShape.SizeFDiagCursor)
         else:
             self.setCursor(Qt.CursorShape.SizeBDiagCursor)
-        self.setZValue(1002)
+        self.setZValue(10_002)
 
     @property
     def corner(self) -> RectCorner:

--- a/src/open_garden_planner/ui/widgets/minimap_widget.py
+++ b/src/open_garden_planner/ui/widgets/minimap_widget.py
@@ -35,6 +35,11 @@ _VIEWPORT_STROKE_WIDTH = 2.0
 # Throttle interval (ms) — max ~10 fps
 _UPDATE_INTERVAL_MS = 100
 
+# Overlay items (resize/rotation/vertex handles) must use zValue >= this.
+# Layer-based garden items use z_order * 100 (max ~900 for 9 layers), so
+# this constant leaves a safe gap and lets the minimap filter only real overlays.
+_OVERLAY_Z_MIN = 10_000
+
 
 class MinimapWidget(QWidget):
     """Semi-transparent minimap overlay for canvas navigation.
@@ -195,7 +200,7 @@ class MinimapWidget(QWidget):
         ignore_flag = QGraphicsItem.GraphicsItemFlag.ItemIgnoresTransformations
         for item in self._canvas_scene.items():
             if item.isVisible() and (
-                bool(item.flags() & ignore_flag) or item.zValue() >= 100
+                bool(item.flags() & ignore_flag) or item.zValue() >= _OVERLAY_Z_MIN
             ):
                 item.setVisible(False)
                 hidden.append(item)

--- a/tests/unit/test_minimap_widget.py
+++ b/tests/unit/test_minimap_widget.py
@@ -15,6 +15,7 @@ from open_garden_planner.ui.widgets.minimap_widget import (
     MINIMAP_HEIGHT,
     MINIMAP_WIDTH,
     MinimapWidget,
+    _OVERLAY_Z_MIN,
 )
 
 
@@ -198,3 +199,44 @@ class TestMinimapMouseInteraction:
         )
         minimap.mouseReleaseEvent(release)
         assert minimap._dragging is False
+
+
+class TestMinimapOverlayFiltering:
+    """Regression tests for issue #152 — overlay filter must not hide garden items."""
+
+    def test_layer_items_not_hidden_by_overlay_filter(
+        self, canvas_pair: tuple[CanvasView, CanvasScene], qtbot: object
+    ) -> None:
+        """Items on non-bottom layers (zValue = 100, 200, …) must survive
+        _hide_overlay_items() — they were wrongly hidden before the fix."""
+        from PyQt6.QtWidgets import QGraphicsRectItem
+
+        view, scene = canvas_pair
+        item = QGraphicsRectItem(0, 0, 100, 100)
+        item.setZValue(100)  # z_order=1 layer
+        scene.addItem(item)
+
+        minimap = MinimapWidget(view, scene)
+        hidden = minimap._hide_overlay_items()
+        minimap._restore_overlay_items(hidden)
+
+        assert item not in hidden, "Garden item with zValue=100 must not be hidden"
+        assert item.isVisible()
+
+    def test_high_z_overlay_is_hidden_and_restored(
+        self, canvas_pair: tuple[CanvasView, CanvasScene], qtbot: object
+    ) -> None:
+        """Items with zValue >= _OVERLAY_Z_MIN (overlay handles) must be
+        hidden during render and restored afterwards."""
+        from PyQt6.QtWidgets import QGraphicsRectItem
+
+        view, scene = canvas_pair
+        overlay = QGraphicsRectItem(0, 0, 10, 10)
+        overlay.setZValue(_OVERLAY_Z_MIN)
+        scene.addItem(overlay)
+
+        minimap = MinimapWidget(view, scene)
+        hidden = minimap._hide_overlay_items()
+        assert overlay in hidden
+        minimap._restore_overlay_items(hidden)
+        assert overlay.isVisible()


### PR DESCRIPTION
## Summary

- **Root cause:** `MinimapWidget._hide_overlay_items()` used `zValue() >= 100` as the overlay threshold, but the layer system assigns `zValue = z_order * 100` to garden items — so any item on a non-bottom layer (z_order ≥ 1) was being hidden before `scene.render()` and never appeared in the minimap thumbnail
- Raised overlay handle z-values to 10 000+ range in `resize_handle.py` (7 call sites: resize, rotation, vertex, and label handles)
- Added module-level constant `_OVERLAY_Z_MIN = 10_000` to `minimap_widget.py` and updated `_hide_overlay_items()` to use it — now only real overlay items are suppressed during thumbnail render
- Added two regression tests in `TestMinimapOverlayFiltering`: one confirming garden items with zValue=100 are not hidden, one confirming overlay items at `_OVERLAY_Z_MIN` are hidden and restored

## Test plan

- [x] `pytest tests/unit/test_minimap_widget.py -v` — 17 tests pass (2 new regression tests)
- [x] `pytest tests/ -v` — 1946 tests pass
- [x] `ruff check src/` — no lint errors
- [x] PyInstaller build + exe smoke test — exit 124 (OK)
- [ ] Manual: open a plan with objects on multiple layers → confirm all layers appear in minimap

Closes #152

🤖 Generated with [Claude Code](https://claude.ai/claude-code)