### PR TITLE
fix(ci): prevent zombie QThread SIGABRT in planting-calendar tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,5 +46,5 @@ def isolate_qsettings():
 @pytest.fixture(autouse=True)
 def _no_weather_network():
     """Stub out the weather fetch thread so tests never make real network requests."""
-    with patch("open_garden_planner.ui.widgets.weather_widget._WeatherFetchWorker.start"):
+    with patch("open_garden_planner.ui.widgets.weather_widget._WeatherFetchWorker"):
         yield


### PR DESCRIPTION
## Summary

- CI run 24845955403 (PR #157, US-12.1) failed with exit code 134 (SIGABRT) in `test_location_but_no_frost_date_shows_empty`
- Root cause: `_no_weather_network` autouse fixture patched only `_WeatherFetchWorker.start`, leaving a real `QThread` object in an unstarted/zombie state; Qt's cleanup aborted when the parent widget was destroyed
- Fix: mock the entire `_WeatherFetchWorker` class so no real `QThread` is ever instantiated during tests

## Test plan

- [x] `pytest tests/ -v` — all 2006 tests pass locally
- [x] Previously-crashing `tests/ui/test_planting_calendar_view.py::TestPlantingCalendarViewEmptyState::test_location_but_no_frost_date_shows_empty` passes
- [x] `tests/integration/test_weather_widget.py` — all weather widget tests unchanged
- [x] `test_refresh_starts_worker_when_location_set` still works (it overrides conftest patch with its own `with patch(...)` block)

🤖 Generated with [Claude Code](https://claude.com/claude-code)