### PR TITLE
docs: convert ASCII flow diagrams to Mermaid

### DIFF
--- a/docs/03-context-and-scope/README.md
+++ b/docs/03-context-and-scope/README.md
@@ -4,20 +4,16 @@
 
 Open Garden Planner operates as a standalone desktop application with optional connections to external plant databases.
 
-```
-                        ┌─────────────────────────┐
-                        │   Open Garden Planner    │
-                        │   (Desktop Application)  │
-                        └────┬──────┬──────┬───────┘
-                             │      │      │
-              ┌──────────────┘      │      └──────────────┐
-              │                     │                     │
-              v                     v                     v
-     ┌────────────────┐   ┌────────────────┐   ┌────────────────┐
-     │   Trefle.io    │   │  Permapeople   │   │  Local Files   │
-     │   Plant API    │   │   Plant API    │   │  (.ogp, PNG,   │
-     │  (Primary)     │   │  (Fallback)    │   │   SVG, CSV)    │
-     └────────────────┘   └────────────────┘   └────────────────┘
+```mermaid
+flowchart TD
+    OGP["Open Garden Planner<br/>(Desktop Application)"]
+    Trefle["Trefle.io Plant API<br/>(Primary)"]
+    Perma["Permapeople Plant API<br/>(Fallback)"]
+    Files["Local Files<br/>(.ogp, PNG, SVG, CSV)"]
+
+    OGP -->|HTTPS REST| Trefle
+    OGP -->|HTTPS REST| Perma
+    OGP -->|read/write| Files
 ```
 
 | External System | Purpose | Interface |
@@ -70,26 +66,26 @@ For detailed plant API setup instructions, see [Plant API Setup Guide](PLANT_API
 
 ## 3.3 Technical Context
 
-```
-┌─────────────────────────────────────────────────┐
-│                  User's Computer                 │
-│                                                  │
-│  ┌──────────────────────────────────────────┐   │
-│  │         Open Garden Planner (PyQt6)       │   │
-│  │  ┌──────┐ ┌──────┐ ┌──────┐ ┌─────────┐ │   │
-│  │  │Canvas│ │Panels│ │Tools │ │ Dialogs │ │   │
-│  │  └──┬───┘ └──┬───┘ └──┬───┘ └────┬────┘ │   │
-│  │     └────────┴────────┴──────────┘       │   │
-│  │              Core Engine                   │   │
-│  │  ┌─────────┐ ┌─────────┐ ┌────────────┐  │   │
-│  │  │Geometry │ │ Objects │ │   Plant    │  │   │
-│  │  │ Engine  │ │  Model  │ │  Service   │  │   │
-│  │  └─────────┘ └─────────┘ └─────┬──────┘  │   │
-│  └────────────┬───────────────────┼──────────┘   │
-│               │                   │              │
-│   ┌───────────v──────┐  ┌────────v─────────┐    │
-│   │   Local Files    │  │   HTTPS / REST   │    │
-│   │ (.ogp, exports)  │  │  (Plant APIs)    │    │
-│   └──────────────────┘  └──────────────────┘    │
-└─────────────────────────────────────────────────┘
+```mermaid
+flowchart TD
+    subgraph Computer["User's Computer"]
+        subgraph App["Open Garden Planner (PyQt6)"]
+            subgraph UI["UI Layer"]
+                Canvas[Canvas]
+                Panels[Panels]
+                Tools[Tools]
+                Dialogs[Dialogs]
+            end
+            subgraph Core["Core Engine"]
+                Geom[Geometry Engine]
+                Objs[Objects Model]
+                PlantSvc[Plant Service]
+            end
+            UI --> Core
+        end
+        Files["Local Files<br/>(.ogp, exports)"]
+        Net["HTTPS / REST<br/>(Plant APIs)"]
+        Core --> Files
+        PlantSvc --> Net
+    end
 ```

--- a/docs/05-building-block-view/README.md
+++ b/docs/05-building-block-view/README.md
@@ -2,36 +2,35 @@
 
 ## 5.1 High-Level Architecture
 
-```
-┌─────────────────────────────────────────────────────────────────┐
-│                        Presentation Layer                        │
-│  ┌──────────┐ ┌──────────┐ ┌──────────┐ ┌──────────┐           │
-│  │  Canvas  │ │  Tools   │ │  Panels  │ │  Dialogs │           │
-│  │  Widget  │ │  Widget  │ │ (Props,  │ │ (Export, │           │
-│  │          │ │          │ │  Layers) │ │  Import) │           │
-│  └────┬─────┘ └────┬─────┘ └────┬─────┘ └────┬─────┘           │
-│       │            │            │            │                   │
-├───────┴────────────┴────────────┴────────────┴──────────────────┤
-│                        Application Layer                         │
-│  ┌──────────────┐ ┌──────────────┐ ┌──────────────────────────┐ │
-│  │   Document   │ │    Tools     │ │      Commands            │ │
-│  │   Manager    │ │   Manager    │ │   (Undo/Redo Stack)      │ │
-│  └──────┬───────┘ └──────┬───────┘ └──────────┬───────────────┘ │
-│         │                │                    │                  │
-├─────────┴────────────────┴────────────────────┴─────────────────┤
-│                          Domain Layer                            │
-│  ┌────────────┐ ┌────────────┐ ┌────────────┐ ┌──────────────┐  │
-│  │  Geometry  │ │   Objects  │ │   Plants   │ │    Layers    │  │
-│  │   Engine   │ │   Model    │ │   Model    │ │    Model     │  │
-│  └────────────┘ └────────────┘ └────────────┘ └──────────────┘  │
-│                                                                  │
-├──────────────────────────────────────────────────────────────────┤
-│                       Infrastructure Layer                       │
-│  ┌────────────┐ ┌────────────┐ ┌────────────┐ ┌──────────────┐  │
-│  │   File     │ │   Export   │ │  Plant DB  │ │   Settings   │  │
-│  │   I/O      │ │   Engine   │ │    API     │ │   Storage    │  │
-│  └────────────┘ └────────────┘ └────────────┘ └──────────────┘  │
-└──────────────────────────────────────────────────────────────────┘
+```mermaid
+flowchart TD
+    subgraph Pres["Presentation Layer"]
+        Canvas[Canvas Widget]
+        Tools[Tools Widget]
+        Panels["Panels<br/>(Props, Layers)"]
+        Dialogs["Dialogs<br/>(Export, Import)"]
+    end
+    subgraph App["Application Layer"]
+        DocMgr[Document Manager]
+        ToolMgr[Tools Manager]
+        Cmds["Commands<br/>(Undo/Redo Stack)"]
+    end
+    subgraph Dom["Domain Layer"]
+        Geom[Geometry Engine]
+        Objs[Objects Model]
+        Plants[Plants Model]
+        Layers[Layers Model]
+    end
+    subgraph Inf["Infrastructure Layer"]
+        IO["File I/O"]
+        Exp[Export Engine]
+        API[Plant DB API]
+        Sett[Settings Storage]
+    end
+
+    Pres --> App
+    App --> Dom
+    Dom --> Inf
 ```
 
 ## 5.2 Module Structure
@@ -159,24 +158,34 @@ class GardenObject(ABC):
 
 ### Object Type Hierarchy
 
+```mermaid
+classDiagram
+    class GardenObject {
+        <<abstract>>
+    }
+    class ShapeObject
+    class PlantObject
+    class FurnitureObject
+    class InfrastructureObject
+
+    GardenObject <|-- ShapeObject
+    GardenObject <|-- PlantObject
+    GardenObject <|-- FurnitureObject
+    GardenObject <|-- InfrastructureObject
+
+    ShapeObject <|-- RectangleObject
+    ShapeObject <|-- PolygonObject
+    ShapeObject <|-- CircleObject
+    ShapeObject <|-- PolylineObject
+
+    PlantObject <|-- TreePlant
+    PlantObject <|-- ShrubPlant
+    PlantObject <|-- PerennialPlant
+    PlantObject <|-- AnnualPlant
+    PlantObject <|-- GroundCoverPlant
 ```
-GardenObject (ABC)
-├── ShapeObject
-│   ├── RectangleObject (house, garage, terrace, driveway)
-│   ├── PolygonObject (custom shapes, garden beds)
-│   ├── CircleObject (ponds, circular features)
-│   └── PolylineObject (fences, paths, walls)
-├── PlantObject
-│   ├── TreePlant
-│   ├── ShrubPlant
-│   ├── PerennialPlant
-│   ├── AnnualPlant
-│   └── GroundCoverPlant
-├── FurnitureObject (Phase 6)
-│   ├── Table, Chair, Bench, Parasol, BBQ, etc.
-└── InfrastructureObject (Phase 6)
-    ├── RaisedBed, CompostBin, Greenhouse, etc.
-```
+
+Concrete shape types: `RectangleObject` (house, garage, terrace, driveway), `PolygonObject` (custom shapes, garden beds), `CircleObject` (ponds, circular features), `PolylineObject` (fences, paths, walls). `FurnitureObject` (Phase 6) covers tables, chairs, benches, parasols, BBQs etc.; `InfrastructureObject` (Phase 6) covers raised beds, compost bins, greenhouses etc.
 
 ## 5.4 Project File Format
 

--- a/docs/06-runtime-view/README.md
+++ b/docs/06-runtime-view/README.md
@@ -2,139 +2,161 @@
 
 ## 6.1 Drawing Workflow
 
-```
-User selects tool (e.g., Rectangle Tool)
-    │
-    ├── ToolManager activates RectangleTool
-    ├── Canvas cursor changes to crosshair
-    │
-    v
-User clicks first point on canvas
-    │
-    ├── Tool captures start coordinate (scene coords)
-    ├── Preview rectangle drawn (rubber band)
-    │
-    v
-User clicks second point (or drags)
-    │
-    ├── Tool calculates final geometry
-    ├── Creates AddObjectCommand with Rectangle data
-    ├── Command pushed to UndoStack
-    ├── Command.execute() creates RectangleItem in scene
-    ├── Scene emits objectAdded signal
-    └── Properties panel updates if auto-select enabled
+```mermaid
+flowchart TD
+    A([User selects tool<br/>e.g. Rectangle Tool])
+    A1[ToolManager activates RectangleTool]
+    A2[Canvas cursor changes to crosshair]
+    B([User clicks first point on canvas])
+    B1[Tool captures start coordinate<br/>scene coords]
+    B2[Preview rectangle drawn<br/>rubber band]
+    C([User clicks second point<br/>or drags])
+    C1[Tool calculates final geometry]
+    C2[Creates AddObjectCommand<br/>with Rectangle data]
+    C3[Command pushed to UndoStack]
+    C4[Command.execute creates<br/>RectangleItem in scene]
+    C5[Scene emits objectAdded signal]
+    C6[Properties panel updates<br/>if auto-select enabled]
+
+    A --> A1 --> A2 --> B
+    B --> B1 --> B2 --> C
+    C --> C1 --> C2 --> C3 --> C4 --> C5 --> C6
 ```
 
 ## 6.2 Save/Load Flow
 
 ### Save
-```
-User triggers Save (Ctrl+S)
-    │
-    ├── ProjectManager.save()
-    ├── Serialize all scene objects → JSON
-    ├── Include: layers, objects, metadata, background images (base64)
-    ├── Write to .ogp file (atomic write via temp file)
-    └── Status bar shows "Saved"
+
+```mermaid
+flowchart TD
+    S0([User triggers Save<br/>Ctrl+S])
+    S1[ProjectManager.save]
+    S2[Serialize all scene objects to JSON]
+    S3["Include: layers, objects, metadata,<br/>background images (base64)"]
+    S4[Write to .ogp file<br/>atomic write via temp file]
+    S5[Status bar shows 'Saved']
+
+    S0 --> S1 --> S2 --> S3 --> S4 --> S5
 ```
 
 ### Load
-```
-User opens .ogp file
-    │
-    ├── ProjectManager.load()
-    ├── Parse JSON, validate version
-    ├── Clear current scene
-    ├── Reconstruct layers
-    ├── Reconstruct objects → create QGraphicsItems
-    ├── Reconstruct background images
-    ├── Fit view to content
-    └── UndoStack cleared (fresh session)
+
+```mermaid
+flowchart TD
+    L0([User opens .ogp file])
+    L1[ProjectManager.load]
+    L2[Parse JSON, validate version]
+    L3[Clear current scene]
+    L4[Reconstruct layers]
+    L5[Reconstruct objects<br/>create QGraphicsItems]
+    L6[Reconstruct background images]
+    L7[Fit view to content]
+    L8[UndoStack cleared<br/>fresh session]
+
+    L0 --> L1 --> L2 --> L3 --> L4 --> L5 --> L6 --> L7 --> L8
 ```
 
 ## 6.3 Plant API Integration Flow
 
-```
-User searches for plant species
-    │
-    ├── Check local SQLite cache first
-    │   ├── Cache hit → return cached data
-    │   └── Cache miss → continue
-    │
-    ├── Try Trefle.io API (primary)
-    │   ├── Success → cache result, return data
-    │   └── Failure → try fallback
-    │
-    ├── Try Permapeople API (secondary)
-    │   ├── Success → cache result, return data
-    │   └── Failure → try fallback
-    │
-    ├── Check bundled plant database
-    │   ├── Found → return data
-    │   └── Not found → continue
-    │
-    └── Allow manual entry (user creates custom species)
+```mermaid
+flowchart TD
+    Start([User searches for plant species])
+    Cache{Local SQLite<br/>cache hit?}
+    Trefle{Trefle.io<br/>success?}
+    Perma{Permapeople<br/>success?}
+    Bundled{Found in<br/>bundled DB?}
+    Manual[Allow manual entry<br/>user creates custom species]
+    Return([Return data])
+    CacheWrite[Cache result]
+
+    Start --> Cache
+    Cache -->|hit| Return
+    Cache -->|miss| Trefle
+    Trefle -->|yes| CacheWrite
+    Trefle -->|no| Perma
+    Perma -->|yes| CacheWrite
+    Perma -->|no| Bundled
+    Bundled -->|yes| Return
+    Bundled -->|no| Manual
+    Manual --> Return
+    CacheWrite --> Return
 ```
 
 ## 6.4 Export Flow
 
-```
-User triggers Export (File → Export as PNG/SVG)
-    │
-    ├── Export dialog shown (format, DPI, options)
-    ├── User configures and confirms
-    │
-    ├── [PNG] QGraphicsScene.render() → QImage → save as PNG
-    │   └── Options: DPI (72/150/300), include/exclude grid
-    │
-    ├── [SVG] QSvgGenerator renders scene
-    │   └── Options: include/exclude annotations
-    │
-    └── [CSV] Iterate plant objects → extract metadata → write CSV
+```mermaid
+flowchart TD
+    Start(["User triggers Export<br/>File → Export as PNG/SVG"])
+    Dlg[Export dialog shown<br/>format, DPI, options]
+    Conf[User configures and confirms]
+    Fmt{Format?}
+
+    PNG["QGraphicsScene.render → QImage → PNG<br/>options: DPI 72/150/300, grid on/off"]
+    SVG["QSvgGenerator renders scene<br/>options: annotations on/off"]
+    CSV[Iterate plant objects<br/>extract metadata → write CSV]
+
+    Done([File written])
+
+    Start --> Dlg --> Conf --> Fmt
+    Fmt -->|PNG| PNG --> Done
+    Fmt -->|SVG| SVG --> Done
+    Fmt -->|CSV| CSV --> Done
 ```
 
 ## 6.5 Undo/Redo Flow
 
-```
-User performs action (e.g., move object)
-    │
-    ├── Tool creates MoveObjectCommand(obj, old_pos, new_pos)
-    ├── UndoStack.push(command)
-    │   ├── command.execute() applies the change
-    │   └── Redo stack cleared (new branch)
-    │
-    v
-User presses Ctrl+Z (Undo)
-    │
-    ├── UndoStack.undo()
-    │   ├── command.undo() reverses the change
-    │   └── Command moved to redo stack
-    │
-    v
-User presses Ctrl+Y (Redo)
-    │
-    ├── UndoStack.redo()
-    │   ├── command.execute() re-applies the change
-    │   └── Command moved back to undo stack
+```mermaid
+flowchart TD
+    A([User performs action<br/>e.g. move object])
+    A1["Tool creates MoveObjectCommand<br/>(obj, old_pos, new_pos)"]
+    A2[UndoStack.push command]
+    A3[command.execute applies the change]
+    A4[Redo stack cleared<br/>new branch]
+
+    B([User presses Ctrl+Z<br/>Undo])
+    B1[UndoStack.undo]
+    B2[command.undo reverses the change]
+    B3[Command moved to redo stack]
+
+    C([User presses Ctrl+Y<br/>Redo])
+    C1[UndoStack.redo]
+    C2[command.execute re-applies the change]
+    C3[Command moved back to undo stack]
+
+    A --> A1 --> A2 --> A3 --> A4
+    A4 --> B
+    B --> B1 --> B2 --> B3
+    B3 --> C
+    C --> C1 --> C2 --> C3
 ```
 
 ## 6.6 Auto-Save Flow
 
-```
-Timer fires every N seconds (configurable)
-    │
-    ├── Check if document has unsaved changes
-    │   └── No changes → skip
-    │
-    ├── Serialize current state to temp file
-    │   └── Path: ~/.open-garden-planner/autosave/<project-hash>.ogp
-    │
-    └── On next successful manual save, remove auto-save file
+```mermaid
+flowchart TD
+    T([Timer fires every N seconds<br/>configurable])
+    Dirty{Unsaved<br/>changes?}
+    Skip([Skip])
+    Ser["Serialize current state to temp file<br/>~/.open-garden-planner/autosave/&lt;project-hash&gt;.ogp"]
+    Manual[On next successful manual save<br/>remove auto-save file]
 
-On startup:
-    │
-    ├── Check for auto-save files
-    │   └── Found → prompt user: "Recover unsaved changes?"
-    │       ├── Yes → load auto-save
-    │       └── No → delete auto-save, proceed normally
+    T --> Dirty
+    Dirty -->|no| Skip
+    Dirty -->|yes| Ser --> Manual
+```
+
+```mermaid
+flowchart TD
+    Boot([On startup])
+    Check{Auto-save<br/>files found?}
+    Prompt["Prompt user:<br/>'Recover unsaved changes?'"]
+    Load[Load auto-save]
+    Del[Delete auto-save<br/>proceed normally]
+    Done([Continue])
+
+    Boot --> Check
+    Check -->|no| Done
+    Check -->|yes| Prompt
+    Prompt -->|Yes| Load
+    Prompt -->|No| Del
 ```

--- a/docs/07-deployment-view/README.md
+++ b/docs/07-deployment-view/README.md
@@ -12,29 +12,18 @@ Open Garden Planner is distributed as:
 
 ### Build Pipeline
 
+```mermaid
+flowchart TD
+    Src([Source Code])
+    PI["PyInstaller<br/>(--onedir, installer/ogp.spec)<br/>bundles Python 3.12 + deps + resources,<br/>windowed mode, app icon"]
+    Bundle["dist/OpenGardenPlanner/<br/>~99 MB"]
+    NSIS["NSIS Installer Script<br/>(installer/ogp_installer.nsi)<br/>wizard, Start Menu + desktop shortcut,<br/>file association, upgrade detection,<br/>EN+DE languages"]
+    Out["OpenGardenPlanner-v1.0.0-Setup.exe<br/>~34 MB (LZMA solid, 32% ratio)"]
+
+    Src --> PI --> Bundle --> NSIS --> Out
 ```
-Source Code
-    │
-    ├── PyInstaller (--onedir mode, spec: installer/ogp.spec)
-    │   ├── Bundle Python 3.12 runtime
-    │   ├── Bundle all dependencies (PyQt6, Pillow, requests, etc.)
-    │   ├── Bundle resources (SVGs, textures, translations, icons)
-    │   ├── Set application icon (installer/ogp_app.ico)
-    │   ├── Windowed mode (no console)
-    │   └── Output: dist/OpenGardenPlanner/ directory (~99 MB)
-    │
-    └── NSIS Installer Script (installer/ogp_installer.nsi)
-        ├── LZMA solid compression (32% ratio → ~34 MB installer)
-        ├── Install wizard (welcome, license, path, components)
-        ├── Copy bundled files to Program Files
-        ├── Create Start Menu shortcut + uninstaller shortcut
-        ├── Optional desktop shortcut
-        ├── Optional .ogp file association with custom icon
-        ├── Add to Add/Remove Programs (with size estimate)
-        ├── Upgrade detection (silently uninstalls previous version)
-        ├── English + German language support
-        └── Output: OpenGardenPlanner-v1.0.0-Setup.exe
-```
+
+See the **Installer Features** table below for the full feature list.
 
 ### How to Build
 
@@ -167,17 +156,25 @@ Two workflow files in `.github/workflows/`:
 
 **Trigger**: Every push to any branch + every PR to `master`
 
-```
-Lint job (ubuntu-latest):
-    ├── Set up Python 3.11
-    ├── Install dependencies (pip install -e ".[dev]")
-    └── Run ruff check src/
+```mermaid
+flowchart TD
+    Trigger(["push / PR to master"])
+    subgraph Lint["Lint job (ubuntu-latest)"]
+        L1[Set up Python 3.11]
+        L2["Install deps<br/>pip install -e .[dev]"]
+        L3["ruff check src/"]
+        L1 --> L2 --> L3
+    end
+    subgraph Test["Test job (ubuntu-latest)"]
+        T1[Set up Python 3.11]
+        T2["Install system deps<br/>libegl1, libxkbcommon0, libxcb-cursor0"]
+        T3["Install deps<br/>pip install -e .[dev]"]
+        T4["pytest tests/ -v<br/>under xvfb for Qt"]
+        T1 --> T2 --> T3 --> T4
+    end
 
-Test job (ubuntu-latest):
-    ├── Set up Python 3.11
-    ├── Install system deps (libegl1, libxkbcommon0, libxcb-cursor0)
-    ├── Install dependencies (pip install -e ".[dev]")
-    └── Run pytest tests/ -v (under xvfb for Qt)
+    Trigger --> Lint
+    Trigger --> Test
 ```
 
 ### Release Workflow (`release.yml`)
@@ -189,19 +186,31 @@ Test job (ubuntu-latest):
 - Label `minor` → bump minor (1.0.0 → 1.1.0)
 - Label `patch` or no label → bump patch (1.0.0 → 1.0.1)
 
-```
-Release job (windows-latest):
-    ├── Checkout with full history (for git tags)
-    ├── Determine next version from latest tag + merged PR labels
-    ├── Skip if tag already exists (idempotent)
-    ├── Set up Python 3.11
-    ├── Install dependencies + PyInstaller
-    ├── Install NSIS (via choco)
-    ├── Build installer: python installer/build_installer.py --version X.Y.Z
-    ├── Generate SHA256 checksum
-    └── Create GitHub Release with auto-generated notes
-        ├── Upload OpenGardenPlanner-vX.Y.Z-Setup.exe
-        └── Upload SHA256SUMS.txt
+```mermaid
+flowchart TD
+    Trigger(["push to master / PR merge"])
+    subgraph Job["Release job (windows-latest)"]
+        R1[Checkout with full history<br/>for git tags]
+        R2[Determine next version<br/>latest tag + PR labels]
+        R3{Tag<br/>already exists?}
+        R4[Set up Python 3.11]
+        R5[Install deps + PyInstaller]
+        R6[Install NSIS via choco]
+        R7["Build installer:<br/>python installer/build_installer.py --version X.Y.Z"]
+        R8[Generate SHA256 checksum]
+        R9[Create GitHub Release<br/>auto-generated notes]
+        R10a[Upload OpenGardenPlanner-vX.Y.Z-Setup.exe]
+        R10b[Upload SHA256SUMS.txt]
+        Skip([Skip<br/>idempotent])
+
+        R1 --> R2 --> R3
+        R3 -->|yes| Skip
+        R3 -->|no| R4 --> R5 --> R6 --> R7 --> R8 --> R9
+        R9 --> R10a
+        R9 --> R10b
+    end
+
+    Trigger --> R1
 ```
 
 ### PR Labels for Versioning


### PR DESCRIPTION
## Summary

- Replaces 13 ASCII box-drawing diagrams with native Mermaid blocks across four arc42 chapters: context (3.1, 3.3), building-block view (5.1 architecture, 5.3 object hierarchy), runtime view (all of 6.1–6.6, with 6.2 split into save+load and 6.6 into autosave+startup), and deployment view (7.2 build pipeline, 7.4 CI workflow, 7.4 release workflow).
- Two trees intentionally kept as text: 5.2 module directory tree and the quality goals outline in chapter 10 — both rely on indentation as their primary structure.
- No code, images, or tests touched. Pure docs change.

## Why

Mermaid renders natively on GitHub (since Feb 2022) and in VS Code's built-in markdown preview (since v1.71). The previous ASCII diagrams broke under any monospace-font change, copy/paste through proportional-font tools, or line wrapping in narrow columns. Mermaid produces real vector diagrams while keeping the source text-based and diff-friendly.

## Review

Independent PR review (fresh worktree) flagged 5 unquoted Mermaid labels containing `/` that would have failed to parse on GitHub. All 5 were fixed before this PR was opened (defensive double-quoting on labels containing special characters).

## Test plan

- [ ] Open each touched file in VS Code's built-in markdown preview (Ctrl+Shift+V) and confirm every Mermaid block renders without a red error box:
  - [ ] `docs/03-context-and-scope/README.md` — 3.1 business context, 3.3 technical context
  - [ ] `docs/05-building-block-view/README.md` — 5.1 architecture, 5.3 object hierarchy
  - [ ] `docs/06-runtime-view/README.md` — 6.1, 6.2 save, 6.2 load, 6.3, 6.4, 6.5, 6.6 (two diagrams)
  - [ ] `docs/07-deployment-view/README.md` — 7.2 build, 7.4 CI, 7.4 release
- [ ] Spot-check the same files in GitHub's web view from this PR — Mermaid should render identically there.
- [ ] Confirm that each Mermaid diagram conveys at least the same information as the ASCII it replaced. A few inline annotations were moved to surrounding prose where they would have cluttered nodes (5.3 shape-type details; 7.2 NSIS feature bullets — the latter were already covered by the existing "Installer Features" table).

🤖 Generated with [Claude Code](https://claude.com/claude-code)