### PR TITLE
chore: fix stale DXF docstring and README status (#245, #246)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,13 @@ Open Garden Planner fills the gap: **engineering-grade precision meets gardener-
 - **Image Calibration**: Import satellite imagery and calibrate to real-world scale
 - **Rich Plant Metadata**: Track species, varieties, planting dates, and growing requirements
 - **Online Plant Database**: Search Trefle.io, Perenual, and Permapeople for plant data
-- **Object Library**: Property structures, garden beds, plants, paths, fences
+- **Object Library**: Property structures, garden beds, containers, trellises, plants, paths, fences
+- **CAD Precision Tools**: Relative/polar coordinate input, snapping (midpoint, intersection, tangent, perpendicular), Bezier/arc drawing, fillet/chamfer
+- **Smart Symbols**: Reusable parametric blocks (raised beds, pergolas, greenhouses) that regenerate on parameter edit
 - **Layers**: Organize objects into manageable layers with visibility/lock controls
-- **Standard Formats**: JSON project files (.ogp), PNG/SVG export, CSV plant lists
+- **Standard Formats**: JSON project files (.ogp), PNG/SVG/PDF/DXF export, CSV plant lists
+- **Garden Smart Features**: Harvest tracking, task management & reminders, succession planting, soil health tracking
+- **AI Agent Integration**: Embedded MCP server exposes the live plan to AI assistants for reading, visualizing, and exporting
 - **Modern UI**: Clean interface with light and dark modes, keyboard shortcuts
 - **Auto-Save**: Periodic auto-save with crash recovery
 
@@ -102,9 +106,10 @@ To enable online plant search, see the [Plant API Setup Guide](docs/03-context-a
 
 ## Status
 
-**Phases 1-5 complete.** Currently working on Phase 6: Visual Polish & Public Release (v1.0).
-
-See the [Development Roadmap](docs/roadmap.md) for detailed progress.
+**Phases 1-13 shipped** (v1.23.0) — CAD precision tooling, garden smart features, and an
+embedded AI agent integration (MCP server) are all live. See the
+[Development Roadmap](docs/roadmap.md) for the authoritative, up-to-date phase/user-story
+table.
 
 ## Documentation
 

--- a/src/open_garden_planner/services/dxf_service.py
+++ b/src/open_garden_planner/services/dxf_service.py
@@ -321,7 +321,7 @@ class DxfImportService:
         """Parse a DXF file and return scene items ready to be added.
 
         The caller is responsible for adding items to the scene via a Command.
-        Y-coordinates are negated (DXF Y-up → Qt Y-down) and scaled.
+        Y-coordinates are scaled only; no negation (DXF Y-up matches OGP scene Y-up).
         """
         import ezdxf
 


### PR DESCRIPTION
## Summary

Pure documentation-drift fixes, no runtime behavior change:

- **#245**: `DxfImportService.import_file`'s docstring claimed Y-coordinates are negated on import (`DXF Y-up → Qt Y-down`). The actual code (and its own inline comment) correctly does **no** negation — scene Y is already Y-up, matching DXF. The docstring described the exact double-flip bug this project's §11.4 pitfall log warns against. Fixed the docstring only; no code change.
- **#246**: README `## Status` said "Phases 1-5 complete... Phase 6 (v1.0)"; actual state is Phases 1-13 shipped (v1.23.0), with Package D (Agent Integration/MCP) in flight. Updated the Status line to reflect current state and point to `docs/roadmap.md` as the source of truth going forward. Also refreshed the Features list with capabilities that shipped since it was last written but weren't mentioned: containers/trellises/smart symbols (Package C), CAD precision tooling (Packages A/B), garden smart features (harvest/tasks/succession/soil), and the embedded AI agent/MCP integration (Package D).

## Why this is a `chore:` commit, not a feature/fix

Per this repo's change-control convention, doc-only changes are classified as a chore. The squash-merge commit message (`chore: ...`) causes `release.yml`'s job-level guard to skip the release job entirely — no version bump, no tag, no installer build for this merge.

## Test plan

- [x] `git diff` reviewed — only the intended two files/sections touched.
- [x] Modified Python file re-parses cleanly (`ast.parse`) — docstring-only edit, no logic change.
- [ ] CI (`ruff check src/`, `pytest tests/ -v`, `bandit -r src/ --severity-level high`) green — this session doesn't have the project's dev venv installed, so these weren't run locally; relying on the CI gate.
- [ ] Manual check: read the updated README Status/Features sections and the DXF docstring for accuracy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UdZXCRDc24w7wu85UzU5v9

---
_Generated by [Claude Code](https://claude.ai/code/session_01UdZXCRDc24w7wu85UzU5v9)_