### PR TITLE
docs(phase-14): plan 3D & Sun/Shade epic — roadmap US table, skill stale-fact fixes (epic #255)

### DIFF
--- a/.claude/skills/ogp-3d-sunshade-campaign/SKILL.md
+++ b/.claude/skills/ogp-3d-sunshade-campaign/SKILL.md
@@ -20,6 +20,12 @@ description: >
 was read from the repo at v1.23.0 (post-US-D1.3). Everything marked
 **TO BUILD** is FUTURE work — none of it exists yet. Do not conflate the two.
 
+**Re-verified 2026-07-19 at v1.24.3 (epic filed as #255, US issues #256–#264):**
+inventory facts held EXCEPT ADR numbering — US-D1.6/D2.0 consumed ADR-035/036,
+so the campaign's ADRs are now **ADR-037** (solar + shadow architecture) and
+**ADR-038** (3D engine choice); next free §8.x is **§8.20**. All ADR references
+below have been updated accordingly.
+
 This is a runbook, not an essay. Work the phases in order. Every phase ends
 in a **gate**: a command, an expected observation (often an exact number),
 and an explicit branch if you see something else. Success at each gate is
@@ -88,7 +94,7 @@ You are NOT starting from zero. These assets exist and were read from source:
 | Decorative shadows toggle | `app/settings.py` `KEY_SHOW_SHADOWS = "appearance/show_shadows"` (line 28, property line 246) → `application.py` `_on_toggle_shadows` (~line 2628) → `canvas_scene.set_shadows_enabled` (line 154) → per-item painted drop shadow (`garden_item.py` lines 211/718) | **Cosmetic only.** Phase 14 must NOT reuse this key or its menu item; rename risk is a UX decision — see Phase 3 step 5. |
 | Roadmap + open question | `docs/roadmap.md` line 2447 "Phase 14: 3D Visualization & Sun/Shade (Future, v2.0)" (Qt3D integration, object heights, sun path sim, walkthrough, growth vis); `docs/11-risks-and-technical-debt/README.md` line 10: "Qt6 3D capabilities vs dedicated engine? Prototype with Qt3D, evaluate PyVista" | The scope contract and the mandated Phase 5 spike. |
 | License | `pyproject.toml` line 10: **GPL-3.0-or-later** | Any new dep must be GPL-compatible (Phase 5 table). |
-| ADR home | `docs/09-architecture-decisions/README.md` — single file, ADR-001…ADR-034. **Next free number: ADR-035** | Where the solar-architecture and 3D-engine ADRs go. |
+| ADR home | `docs/09-architecture-decisions/README.md` — single file, ADR-001…ADR-036 (as of v1.24.3). **Next free number: ADR-037** | Where the solar-architecture (ADR-037) and 3D-engine (ADR-038) ADRs go. |
 
 Quick re-verification (run before trusting this table if months have passed —
 also see "Provenance and maintenance" at the end):
@@ -326,7 +332,7 @@ in `metadata`, which v1.x preserves on load/save (verified: `project.py`
 serializes `item.metadata` wholesale, and unknown keys are untouched). No
 migration, no warning needed.
 
-### Design decisions (make them explicitly, record in ADR-035)
+### Design decisions (make them explicitly, record in ADR-037)
 
 1. **One Qt-free resolver** — `core/object_height.py` (pattern:
    `core/plant_sizing.py`). Precedence:
@@ -476,7 +482,7 @@ band definitions in `docs/12-glossary/`).
 **Performance budget (stated up front):** target garden 30 m × 20 m at 10 cm
 cells = 60 000 cells × ~64 daylight samples (Jun 21 Berlin ≈ 16.7 h / 15 min).
 Python point-in-polygon per (cell, sample) is ~4 M tests — too slow. Use one
-of two vectorized routes (pick in ADR-035):
+of two vectorized routes (pick in ADR-037):
 1. **Rasterize per sample** (recommended): paint the sample's shadow polygons
    into a monochrome `QImage` at grid resolution and accumulate with numpy
    (`QImage` painting is documented thread-safe off the GUI thread, unlike
@@ -551,7 +557,7 @@ at spike time** — the commands are the deliverable, not remembered claims:
 | Installer size delta | compare `dist/` size before/after | < +150 MB or owner explicitly accepts |
 | GPL compatibility of the chosen dep | read its license file, cross-check SPDX | Must be GPL-3-compatible; if a sibling `ogp-external-positioning` skill exists, follow its process |
 
-**Spike deliverable:** ADR-036 "3D engine choice" with the filled-in table,
+**Spike deliverable:** ADR-038 "3D engine choice" with the filled-in table,
 the frozen-exe screenshot, and the decision.
 
 **Kill criteria (write them in the ADR before starting):**
@@ -596,10 +602,10 @@ due north." — the numbers come from the Appendix, so a failed manual test
 localizes instantly to render-vs-math.
 
 **Documentation duties (per `ogp-change-control` / CLAUDE.md matrix):**
-- **ADR-035**: solar engine + shadow architecture (Qt-free core, canvas-frame
-  math, overlay non-serialization, aggregation strategy). **ADR-036**: 3D
+- **ADR-037**: solar engine + shadow architecture (Qt-free core, canvas-frame
+  math, overlay non-serialization, aggregation strategy). **ADR-038**: 3D
   engine GO/NO-GO. (ADRs live in `docs/09-architecture-decisions/README.md`;
-  034 is the last used as of 2026-07-04.)
+  036 is the last used as of 2026-07-19 / v1.24.3.)
 - **FR entries** in `docs/functional-requirements.md` (suggest FR-SUN-01…):
   height property, shadow overlay, time control, heatmap, empty states, and
   the explicit exclusions (flat-ground assumption; refraction ignored;
@@ -611,7 +617,7 @@ localizes instantly to render-vs-math.
   elevation angle, equation of time, hour angle, solar noon, full sun /
   partial shade / full shade bands.
 - **Roadmap + wiki**: mark the USes, sync `../open-garden-planner.wiki/Roadmap.md`.
-- **§11.1**: close/update the Qt3D open-question row with the ADR-036 outcome.
+- **§11.1**: close/update the Qt3D open-question row with the ADR-038 outcome.
 
 ---
 
@@ -665,8 +671,9 @@ lit 14:40–sunset (~19:20, sun W→NW).
 
 ## Provenance and maintenance
 
-All repo facts verified 2026-07-04 against the working tree at v1.23.0.
-One-line re-verification commands (run from repo root):
+All repo facts verified 2026-07-04 against the working tree at v1.23.0;
+re-verified 2026-07-19 at v1.24.3 (ADR numbering corrected to 037/038, all
+other facts held). One-line re-verification commands (run from repo root):
 
 - Solar oracle still green: `python3 .claude/skills/ogp-3d-sunshade-campaign/scripts/solar_reference.py --quiet; echo $?` → expect final `RESULT: ALL CHECKS PASSED`, exit 0.
 - Phase 14 roadmap section: `grep -n "Phase 14" docs/roadmap.md` → line ~2447.
@@ -676,4 +683,4 @@ One-line re-verification commands (run from repo root):
 - pyclipper + numpy deps: `grep -nE "pyclipper|numpy" pyproject.toml`.
 - Species height coverage: the python3 one-liner in §0 → `118 / 118` (or more records, same full coverage expected).
 - Cosmetic-shadow collision: `grep -n "KEY_SHOW_SHADOWS" src/open_garden_planner/app/settings.py` → `appearance/show_shadows` still cosmetic-only.
-- Next ADR number: `grep -c "^## ADR-" docs/09-architecture-decisions/README.md` and take max+1 (034 as of 2026-07-04).
+- Next ADR number: `grep -oE "^## ADR-[0-9]+" docs/09-architecture-decisions/README.md | sort -V | tail -1` and take max+1 (036 as of 2026-07-19; campaign reserves 037 + 038). (`grep -c` would miscount if numbering ever gains a gap.)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -187,7 +187,7 @@ Full how-to (step-by-step, `.ts` format, recompile command): see `docs/08-crossc
 
 ## Where to Pick Up After Restart
 
-1. Phases 1–12 are complete (see progress table below). Next milestone = **Phase 13 (v2.0)** — 3D Visualization & Sun/Shade.
+1. Phases 1–12 are complete, Phase 13 Packages A–C shipped and Package D1+D2.0 shipped (see progress tables below). Next milestone = **Phase 14 (v2.0)** — 3D Visualization & Sun/Shade: **planned as epic [#255](https://github.com/cofade/open-garden-planner/issues/255)** (US-E1…E9 = issues #256–#264, full US table in `docs/roadmap.md` Phase 14; load the `ogp-3d-sunshade-campaign` skill before starting any of them).
 2. Read the relevant section in `docs/roadmap.md` for the user story or follow-up issue you're tackling.
 3. Check `git status` and recent git history (`git log --oneline -20`).
 4. Create feature branch and implement.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -17,8 +17,9 @@
 | **10** | **v1.8.6 – v1.8.12** | **✅ Complete** | **Companion Planting & Crop Rotation** |
 | **11** | **v1.8.13+** | **✅ Complete** | **Bed Interior Design, Visual Polish & Advanced 2D Tools** |
 | **12** | **v1.9.0 – v1.10.x** | **✅ Complete** | **Weather & Smart Features** |
-| 13 | v2.0 | Future | 3D Visualization & Sun/Shade |
-| 14 | v2.1+ | Future | Platform & Community |
+| **13** | **v1.11 – v1.24.x** | **✅ Complete** | **CAD Precision, Smart Features & Agent Integration (Packages A–D)** |
+| 14 | v2.0 | Planned ([epic #255](https://github.com/cofade/open-garden-planner/issues/255)) | 3D Visualization & Sun/Shade |
+| 15 | v2.1+ | Future | Platform & Community |
 
 ---
 
@@ -2448,11 +2449,29 @@ Manual testing of PR #191 surfaced follow-up gaps, closed in later PRs:
 
 **Goal**: Full three-dimensional garden view with sun/shade simulation — the milestone that justifies a major version bump.
 
-- 3D visualization (Qt3D integration)
+- 3D visualization (engine decided by the US-E5 spike — Qt3D vs PyVista vs pyqtgraph.opengl vs 2.5D fallback)
 - Object height properties (walls, fences, trees, structures)
 - Sun path simulation (shade calculation by season, time-of-day animation, seasonal analysis)
 - First-person walkthrough mode
 - Plant growth over time visualization (seedling → mature)
+
+**Planned 2026-07-19 — epic [#255](https://github.com/cofade/open-garden-planner/issues/255).** Each US carries a full stand-alone implementation spec in its issue; the authoritative runbook is the `ogp-3d-sunshade-campaign` skill (load it plus `ogp-change-control` + `ogp-architecture-contract` before starting any US). Slice order is deliberately 2D-first: the sun/shade value (US-E1…E4) ships even if the 3D spike NO-GOs.
+
+| Status | US    | Description                                                        | Issue | Depends on |
+| ------ | ----- | ------------------------------------------------------------------ | ----- | ---------- |
+| ⬜     | US-E1 | Solar position engine — Qt-free `core/solar.py` (NOAA/Meeus, pinned oracle numbers) | [#256](https://github.com/cofade/open-garden-planner/issues/256) | — |
+| ⬜     | US-E2 | Object height property — additive `object_height_cm` + Qt-free resolver + undoable panel editor (no FILE_VERSION bump) | [#257](https://github.com/cofade/open-garden-planner/issues/257) | — |
+| ⬜     | US-E3 | 2D analytic shadow overlay + sun date/time control (`L = h/tan α`, pyclipper union, runtime-only overlay) | [#258](https://github.com/cofade/open-garden-planner/issues/258) | E1, E2 |
+| ⬜     | US-E4 | Hours-of-sun heatmap — threaded 15-min aggregation, horticultural bands | [#259](https://github.com/cofade/open-garden-planner/issues/259) | E3 |
+| ⬜     | US-E5 | 3D engine spike — GO/NO-GO, timebox 5 days, decisive frozen-exe gate, ADR-038 | [#260](https://github.com/cofade/open-garden-planner/issues/260) | E2 |
+| ⬜     | US-E6 | 3D view MVP — extruded footprints, orbit camera, solar light *(conditional: E5 GO)* | [#261](https://github.com/cofade/open-garden-planner/issues/261) | E5 GO |
+| ⬜     | US-E7 | First-person walkthrough *(conditional)* | [#262](https://github.com/cofade/open-garden-planner/issues/262) | E6 |
+| ⬜     | US-E8 | Growth-over-time visualization — `min→max_height_cm` interpolation (118/118 species coverage) *(conditional)* | [#263](https://github.com/cofade/open-garden-planner/issues/263) | E6 (or 2.5D fallback) |
+| ⬜     | US-E9 | *(Optional)* AI asset-generation dev tooling feeding the `fill_patterns.py` texture seam | [#264](https://github.com/cofade/open-garden-planner/issues/264) | — (off critical path) |
+
+Reserved identifiers: **ADR-037** (solar + shadow architecture), **ADR-038** (3D engine choice), **§8.20**, **FR-SUN-\***. `FILE_VERSION` stays `"1.4"` (heights/planted-date are additive metadata).
+
+> **Decision (2026-07-19):** the external `claude-skill-game-assets-enhancer` skill was evaluated for 3D asset generation and rejected — it produces 2D game sprites via a paid fal.ai API, no 3D assets; Phase 14's 3D pipeline is procedural (extruded footprints). The salvageable idea (AI-generated textures through the existing `fill_patterns.py` seam, already sanctioned by §11.1) is captured as optional US-E9. Full rationale in epic #255.
 
 ---
 


### PR DESCRIPTION
Planning-docs sync for **Phase 14 — 3D Visualization & Sun/Shade (v2.0)**, filed as epic #255 with fully-specced sub-issues #256–#264 (US-E1…E9). No `src/` changes.

## What's in this PR

1. **`docs/roadmap.md`**
   - Phase 14 section: bullet list replaced by the US-E1…E9 table (issue links, dependencies, conditionality), the 2D-first slice rationale, reserved identifiers (ADR-037/038, §8.20, FR-SUN-*), and the recorded decision to reject the external `claude-skill-game-assets-enhancer` skill (it generates 2D game sprites via a paid fal.ai API — no 3D assets; the salvageable AI-texture idea is optional US-E9 / #264).
   - Top phase-index table fixed (senior-reviewer P1): it still claimed "13 | v2.0 | Future | 3D" — Phase 13 (Packages A–D, v1.11–v1.24.x) is now marked ✅ Complete, 3D is Phase 14 (Planned, epic #255), Platform & Community is Phase 15, matching the body headings.
2. **`.claude/skills/ogp-3d-sunshade-campaign/SKILL.md`** — surgical stale-fact fixes only: campaign ADRs renumbered 035/036 → **037/038** (US-D1.6/D2.0 consumed 035/036 after the skill was written), re-verified-at-v1.24.3 status note, provenance lines updated, ADR-count one-liner hardened (`grep -oE … | sort -V | tail -1`). **Oracle script and all pinned solar numbers untouched** (verified: oracle still exits 0, ALL CHECKS PASSED).
3. **`CLAUDE.md`** — "Where to Pick Up After Restart" now points at epic #255 + the roadmap US table (was stale "Phase 13 (v2.0) — 3D").

## Review status

`senior-reviewer` pass run on the diff: 1 P1 (the stale phase-index table) — fixed in this PR; 2 P2 nits — the grep hardening applied, the em-dash mojibake concern checked (file is clean UTF-8). No P0s.

## Manual-review checklist for the owner

- [x] Read epic #255 — confirm the slice order (2D-first, E5 spike gate) and the game-assets-enhancer rejection
- [x] #257 (US-E2): confirm the proposed per-ObjectType height default table (FENCE 120, WALL 200, HOUSE 450, …)
- [x] #264 (US-E9, optional AI texture tooling): keep or drop
- [x] Roadmap renders correctly on GitHub (tables, links)

## Follow-up (not in this PR)

- Wiki sync (`../open-garden-planner.wiki/Roadmap.md`) — the wiki isn't cloned in this environment; it likely mirrors the same stale "Phase 13 = 3D" numbering and should be synced on merge per the CLAUDE.md docs matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014cuxirJgz6LYpFaf7Btc1w

---
_Generated by [Claude Code](https://claude.ai/code/session_014cuxirJgz6LYpFaf7Btc1w)_